### PR TITLE
rgw/dbstore: fixing a seg-fault when deleting an object

### DIFF
--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -567,10 +567,11 @@ namespace rgw::sal {
 
   int DBObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjState **pstate, optional_yield y, bool follow_olh)
   {
-    RGWObjState* astate;
+    RGWObjState* astate = nullptr;
     DB::Object op_target(store->getDB(), get_bucket()->get_info(), get_obj());
     int ret = op_target.get_obj_state(dpp, get_bucket()->get_info(), get_obj(), follow_olh, &astate);
     if (ret < 0) {
+      delete astate;
       return ret;
     }
 
@@ -580,7 +581,10 @@ namespace rgw::sal {
     bool prefetch_data = state.prefetch_data;
 
     state = *astate;
+    delete astate;
+
     *pstate = &state;
+
 
     state.obj = obj;
     state.is_atomic = is_atomic;

--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -1226,6 +1226,7 @@ int DB::Object::get_obj_state(const DoutPrefixProvider *dpp,
   /* XXX: For now use state->shadow_obj to store ObjectID string */
   s->shadow_obj = params.op.obj.obj_id;
 
+  *state = new RGWObjState();
   **state = *s;
 
   if (follow_olh && params.op.obj.state.obj.key.instance.empty()) {


### PR DESCRIPTION
This fix addresses a `radosgw` crash when using `dbstore` backend and deleting an object.
Please, refer to the linked issue for details about the issue itself and how to reproduce/test it. 

Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
