### PR TITLE
rgw/dbstore: fix for GET operation.

### DIFF
--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -738,6 +738,7 @@ int DB::Bucket::List::list_objects(const DoutPrefixProvider *dpp, int64_t max,
   db_params.op.obj.min_marker = params.marker.name;
   db_params.op.obj.max_marker = params.end_marker.name;
   db_params.op.list_max_count = max + 1; /* +1 for next_marker */
+  db_params.op.obj.prefix = params.prefix;
 
   ret = store->ProcessOp(dpp, "ListBucketObjects", &db_params);
 

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -86,6 +86,7 @@ struct DBOpObjectInfo {
   bufferlist head_data;
   std::string min_marker;
   std::string max_marker;
+  std::string prefix;
   std::list<rgw_bucket_dir_entry> list_entries;
   /* XXX: Maybe use std::vector instead of std::list */
 };
@@ -277,6 +278,7 @@ struct DBOpObjectPrepareInfo {
   static constexpr const char* is_multipart = ":is_multipart";
   static constexpr const char* mp_parts = ":mp_parts";
   static constexpr const char* head_data = ":head_data";
+  static constexpr const char* prefix = ":prefix";
   static constexpr const char* min_marker = ":min_marker";
   static constexpr const char* max_marker = ":max_marker";
   /* Below used to update mp_parts obj name
@@ -1083,7 +1085,7 @@ class ListBucketObjectsOp: virtual public DBOp {
       ObjID, TailInstance, HeadPlacementRuleName, HeadPlacementRuleStorageClass, \
       TailPlacementRuleName, TailPlacementStorageClass, \
       ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, HeadData from '{}' \
-      where BucketName = {} and ObjName > {} ORDER BY ObjName ASC LIMIT {}";
+      where BucketName = {} and ObjName like {} and ObjName > {} ORDER BY ObjName ASC LIMIT {}";
   public:
     virtual ~ListBucketObjectsOp() {}
 
@@ -1092,6 +1094,7 @@ class ListBucketObjectsOp: virtual public DBOp {
       return fmt::format(Query,
           params.object_table,
           params.op.bucket.bucket_name,
+          params.op.obj.prefix,
           params.op.obj.min_marker,
           params.op.list_max_count);
     }

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -2322,6 +2322,13 @@ int SQLListBucketObjects::Bind(const DoutPrefixProvider *dpp, struct DBOpParams 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.prefix, sdb);
+  {
+    std::ostringstream os;
+    os << params->op.obj.prefix << ((params->op.obj.prefix != "") ? "/%" : "%");
+    SQL_BIND_TEXT(dpp, stmt, index, os.str().c_str(), sdb);
+  }
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.min_marker, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.min_marker.c_str(), sdb);
 


### PR DESCRIPTION
Have a look to the linked [ceph issue](https://tracker.ceph.com/issues/55288) and [s3gw issue](https://github.com/aquarist-labs/s3gw-core/issues/5) for details.

Please, be aware that this patch partially solves the issue.
GET computed set is now more correct because it does not include parent directory objects, but it will still wrongly
include objects in children directories.
Solving this entirely will probably involve design choices in dbstore.
This patch, by the way, resolves the major issue of `rm --recursive` deleting the entire content of the bucket.

Fixes: aquarist-labs/s3gw#5
Fixes: https://tracker.ceph.com/issues/55288
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
