### PR TITLE
rgw/dbstore: Add basic user list to dbstore

### DIFF
--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1857,7 +1857,8 @@ namespace rgw::sal {
 
   int DBStore::meta_list_keys_next(const DoutPrefixProvider *dpp, void* handle, int max, list<string>& keys, bool* truncated)
   {
-    return 0;
+    *truncated = false;
+    return getDB()->list_users(dpp, keys);
   }
 
   void DBStore::meta_list_keys_complete(void* handle)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -421,6 +421,11 @@ void RGWUserAdminOpState::set_user_info(RGWUserInfo& user_info)
   user->get_info() = user_info;
 }
 
+void RGWUserAdminOpState::set_user_version_tracker(RGWObjVersionTracker& objv_tracker)
+{
+  user->get_version_tracker() = objv_tracker;
+}
+
 const rgw_user& RGWUserAdminOpState::get_user_id()
 {
   return user->get_id();
@@ -1515,6 +1520,7 @@ int RGWUser::init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, 
     op_state.set_user_info(user->get_info());
     op_state.set_populated();
     op_state.objv = user->get_version_tracker();
+    op_state.set_user_version_tracker(user->get_version_tracker());
 
     old_info = user->get_info();
     set_populated();
@@ -1568,6 +1574,8 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 
   ret = user->store_user(dpp, y, false, pold_info);
   op_state.objv = user->get_version_tracker();
+  op_state.set_user_version_tracker(user->get_version_tracker());
+
   if (ret < 0) {
     set_err_msg(err_msg, "unable to store user info");
     return ret;
@@ -1717,6 +1725,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   RGWUserInfo& user_info = op_state.get_user_info();
   user_info.user_id = new_user->get_id();
   op_state.objv = user->get_version_tracker();
+  op_state.set_user_version_tracker(user->get_version_tracker());
 
   rename_swift_keys(new_user->get_id(), user_info.swift_keys);
 

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -300,6 +300,8 @@ struct RGWUserAdminOpState {
 
   void set_user_info(RGWUserInfo& user_info);
 
+ void set_user_version_tracker(RGWObjVersionTracker& objv_tracker);
+
   void set_max_buckets(int32_t mb) {
     max_buckets = mb;
     max_buckets_specified = true;

--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -108,6 +108,8 @@ DBOp *DB::getDBOp(const DoutPrefixProvider *dpp, std::string_view Op,
     return dbops.GetBucket;
   if (!Op.compare("ListUserBuckets"))
     return dbops.ListUserBuckets;
+  if (!Op.compare("ListUsers"))
+    return dbops.ListUsers;
   if (!Op.compare("InsertLCEntry"))
     return dbops.InsertLCEntry;
   if (!Op.compare("RemoveLCEntry"))
@@ -300,7 +302,7 @@ int DB::get_user(const DoutPrefixProvider *dpp,
     goto out;
 
   /* Verify if its a valid user */
-  if (params.op.user.uinfo.access_keys.empty()) {
+  if (params.op.user.uinfo.access_keys.empty() || params.op.user.uinfo.user_id.id.empty()) {
     ldpp_dout(dpp, 0)<<"In GetUser - No user with query(" <<query_str.c_str()<<"), user_id(" << uinfo.user_id <<") found" << dendl;
     return -ENOENT;
   }
@@ -626,6 +628,23 @@ int DB::list_buckets(const DoutPrefixProvider *dpp, const std::string& query_str
   }
 
 out:
+  return ret;
+}
+
+int DB::list_users(const DoutPrefixProvider *dpp, std::list<std::string> & users) {
+  int ret = 0;
+
+  DBOpParams params = {};
+  InitializeParams(dpp, &params);
+
+  ret = ProcessOp(dpp, "ListUsers", &params);
+
+  if (ret) {
+    ldpp_dout(dpp, 0)<<"In ListUsers failed err:(" <<ret<<") " << dendl;
+    return ret;
+  }
+  users = params.op.user_ids;
+  
   return ret;
 }
 

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -128,6 +128,7 @@ struct DBOpInfo {
   DBOpLCHeadInfo lc_head;
   DBOpLCEntryInfo lc_entry;
   uint64_t list_max_count;
+  std::list<std::string> user_ids;
 };
 
 struct DBOpParams {
@@ -347,6 +348,7 @@ struct DBOps {
   class RemoveBucketOp *RemoveBucket;
   class GetBucketOp *GetBucket;
   class ListUserBucketsOp *ListUserBuckets;
+  class ListUsersOp *ListUsers;
   class InsertLCEntryOp *InsertLCEntry;
   class RemoveLCEntryOp *RemoveLCEntry;
   class GetLCEntryOp *GetLCEntry;
@@ -978,6 +980,18 @@ class ListUserBucketsOp: virtual public DBOp {
     }
 };
 
+class ListUsersOp: virtual public DBOp {
+  private:
+    static constexpr std::string_view Query = "SELECT UserID FROM '{}'";
+
+  public:
+    virtual ~ListUsersOp() {};
+
+    static std::string Schema(DBOpPrepareParams &params) {
+        return fmt::format(Query, params.user_table);
+    }
+};
+
 class PutObjectOp: virtual public DBOp {
   private:
     static constexpr std::string_view Query =
@@ -1569,6 +1583,7 @@ class DB {
         bool need_stats,
         RGWUserBuckets *buckets,
         bool *is_truncated);
+    int list_users(const DoutPrefixProvider *dpp, std::list<std::string> & users);
     int update_bucket(const DoutPrefixProvider *dpp, const std::string& query_str,
         RGWBucketInfo& info, bool exclusive,
         const rgw_user* powner_id, std::map<std::string, bufferlist>* pattrs,

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -231,6 +231,23 @@ class SQLListUserBuckets : public SQLiteDB, public ListUserBucketsOp {
     int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
 };
 
+class SQLListUsers : public SQLiteDB, public ListUsersOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLListUsers(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {
+    }
+    ~SQLListUsers() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
 class SQLPutObject : public SQLiteDB, public PutObjectOp {
   private:
     sqlite3 **sdb = NULL;


### PR DESCRIPTION
Adds a basic user listing to dbstore, so we can get the list of users using the REST API.

It also includes a fix so the REST API works. The fix has been picked up from upstream instead of committing mine. 

Fixes: https://github.com/aquarist-labs/s3gw-core/issues/42

Signed-off-by: 0xavi0 <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
