### PR TITLE
rgw/sfs: Add basic user management via rest api.

### DIFF
--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -46,6 +46,8 @@
 #include "store/sfs/notification.h"
 #include "store/sfs/writer.h"
 
+#include "rgw/store/sfs/sqlite/sqlite_users.h"
+
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
@@ -144,8 +146,7 @@ int SFStore::forward_request_to_master(const DoutPrefixProvider *dpp,
                                                bufferlist &in_data,
                                                JSONParser *jp, req_info &info,
                                                optional_yield y) {
-  ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
-  return -ENOTSUP;
+  return 0;
 }
 
 int SFStore::forward_iam_request_to_master(
@@ -254,7 +255,10 @@ int SFStore::meta_list_keys_init(const DoutPrefixProvider *dpp,
 int SFStore::meta_list_keys_next(const DoutPrefixProvider *dpp,
                                          void *handle, int max,
                                          list<string> &keys, bool *truncated) {
-  ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
+  *truncated = false;
+  rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(dpp->get_cct());
+  auto ids = sqlite_users.getUserIDs();
+  std::copy(ids.begin(), ids.end(), std::back_inserter(keys));
   return 0;
 }
 

--- a/src/rgw/store/sfs/bucket.cc
+++ b/src/rgw/store/sfs/bucket.cc
@@ -33,7 +33,8 @@ SFSBucket::SFSBucket(
 
 void SFSBucket::init(
   const DoutPrefixProvider *dpp,
-  const rgw_bucket &b
+  const rgw_bucket &b,
+  const RGWUserInfo & owner
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": init bucket: "
                      << get_name() << "[" << path << "]" << dendl;
@@ -44,6 +45,7 @@ void SFSBucket::init(
   std::filesystem::create_directory(obj_path);
 
   info.bucket = b;
+  info.owner = owner.user_id;
   info.creation_time = ceph::real_clock::now();
   info.placement_rule.name = "default";
   info.placement_rule.storage_class = "STANDARD";

--- a/src/rgw/store/sfs/bucket.h
+++ b/src/rgw/store/sfs/bucket.h
@@ -73,7 +73,8 @@ class SFSBucket : public Bucket {
 
   void init(
     const DoutPrefixProvider *dpp,
-    const rgw_bucket &b
+    const rgw_bucket &b,
+    const RGWUserInfo & owner
   );
 
   std::filesystem::path bucket_path() const;

--- a/src/rgw/store/sfs/sfs_user.cc
+++ b/src/rgw/store/sfs/sfs_user.cc
@@ -30,8 +30,7 @@ int SFStore::get_user_by_access_key(const DoutPrefixProvider *dpp,
   int err = 0;
   rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(dpp->get_cct());
   auto db_user = sqlite_users.getUserByAccessKey(key);
-  if (db_user) {  
-    db_user->uinfo.user_id.id = "";   // TODO Remove this when ACL is implemented
+  if (db_user) {
     user->reset(new SFSUser(db_user->uinfo, this));
   } else {
     ldpp_dout(dpp, 10) << __func__ << ": User not found" << dendl;
@@ -44,16 +43,15 @@ int SFStore::get_user_by_email(const DoutPrefixProvider *dpp,
                                        const std::string &email,
                                        optional_yield y,
                                        std::unique_ptr<User> *user) {
-  int err = 0;                    
+  int err = 0;
   rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(dpp->get_cct());
   auto db_user = sqlite_users.getUserByEmail(email);
   if (db_user) {
-    db_user->uinfo.user_id.id = "";   // TODO Remove this when ACL is implemented
     user->reset(new SFSUser(db_user->uinfo, this));
   } else {
     ldpp_dout(dpp, 10) << __func__ << ": User not found" << dendl;
-    err = -ENOENT;                                   
-  }                              
+    err = -ENOENT;
+  }
   return err;
 }
 

--- a/src/rgw/store/sfs/sqlite/sqlite_users.cc
+++ b/src/rgw/store/sfs/sqlite/sqlite_users.cc
@@ -56,8 +56,7 @@ std::optional<DBOPUserInfo> SQLiteUsers::getUserByAccessKey(const std::string & 
 
 std::vector<std::string> SQLiteUsers::getUserIDs() const {
   auto storage = getStorage();
-  auto selectStatement = storage.prepare(select(&DBUser::UserID));
-  return storage.execute(selectStatement);
+  return storage.select(&DBUser::UserID);
 }
 
 void SQLiteUsers::storeUser(const DBOPUserInfo & user) const {


### PR DESCRIPTION
This adds basic user management via rest api to `SFStore`.

Adds also a very basic versioning, increasing the version everytime the
user info is stored and checks for version when loading the user.

Added a few unittests for testing higher lever user management.

A smoke test will be added in a future PR but meanwhile you can test the user management rest api with something like this:
```python
import requests, json                                                                                         
from awsauth import S3Auth                                                                                    
                                                                                                              
ACCESS_KEY='test'                                                                             
SECRET_KEY='test'
URL='http://127.0.0.1:7480'                                                                                   
                                                                                                              
auth = S3Auth(ACCESS_KEY, SECRET_KEY, URL)                                                                    

# List users                                                                                                              
response = requests.get('http://127.0.0.1:7480/admin/user?list', auth=auth)                                   
print(response)
print(response.json())

# Add user2 with display name = TEST NAME
response = requests.put('http://127.0.0.1:7480/admin/user?uid=user2&display-name=TEST+NAME', auth=auth)      
print(response)
print(response.json())

# List Users again
response = requests.get('http://127.0.0.1:7480/admin/user?list', auth=auth)                                   
print(response)
print(response.json())

# Remove user2                                                                                
response = requests.delete('http://127.0.0.1:7480/admin/user?uid=user2', auth=auth)                          
print(response)

# List users again
response = requests.get('http://127.0.0.1:7480/admin/user?list', auth=auth)                                   
print(response)
print(response.json())

# Show info of default user (testid)                                                                                
response = requests.get('http://127.0.0.1:7480/admin/user?uid=testid', auth=auth)                            
print(response)
print(response.json())
```

**NOTE: You can get the `awsauth` file from `src/pybind/mgr/dashboard/awsauth.py`**

### IMPORTANT
Because deletion of buckets is not implemented yet and `sfs` returns all the buckets always (doesn't take into account the owner), the Remove user API call will only work if there are no buckets.


### Building the unit tests
In order to build the unit tests you need to pass `-DWITH_TESTS=ON` to `cmake` and then build with:
```bash
ninja -j N bin/unittest_rgw_sfs_sqlite_users
```
To run the tests, simply execute the binary

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
