### PR TITLE
rgw/sfs: basic object copy capabilities

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to
 - rgw/sfs: maintain one single sqlite database connection.
 - rgw/sfs: protect sqlite access with 'std::shared_lock'; allows multiple
   parallel reads, but only one write at a time.
+- rgw/sfs: allow copying objects; the current implementation breaks S3
+  semantics by returning EEXIST if the destination object exists.
+
+### Known Issues
+
+- object copy fails if the destination object exists; this will be addressed at
+  a later stage.
 
 
 ## [0.2.0] - 2022-07-28

--- a/src/rgw/store/sfs/object.h
+++ b/src/rgw/store/sfs/object.h
@@ -103,18 +103,34 @@ class SFSObject : public Object {
                              Completions *aio, bool keep_index_consistent,
                              optional_yield y) override;
   virtual int copy_object(
-      User *user, req_info *info, const rgw_zone_id &source_zone,
-      rgw::sal::Object *dest_object, rgw::sal::Bucket *dest_bucket,
-      rgw::sal::Bucket *src_bucket, const rgw_placement_rule &dest_placement,
-      ceph::real_time *src_mtime, ceph::real_time *mtime,
-      const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
-      bool high_precision_time, const char *if_match, const char *if_nomatch,
-      AttrsMod attrs_mod, bool copy_if_newer, Attrs &attrs,
-      RGWObjCategory category, uint64_t olh_epoch,
-      boost::optional<ceph::real_time> delete_at, std::string *version_id,
-      std::string *tag, std::string *etag, void (*progress_cb)(off_t, void *),
-      void *progress_data, const DoutPrefixProvider *dpp,
-      optional_yield y) override;
+    User *user,
+    req_info *info,
+    const rgw_zone_id &source_zone,
+    rgw::sal::Object *dest_object,
+    rgw::sal::Bucket *dest_bucket,
+    rgw::sal::Bucket *src_bucket,
+    const rgw_placement_rule &dest_placement,
+    ceph::real_time *src_mtime,
+    ceph::real_time *mtime,
+    const ceph::real_time *mod_ptr,
+    const ceph::real_time *unmod_ptr,
+    bool high_precision_time,
+    const char *if_match,
+    const char *if_nomatch,
+    AttrsMod attrs_mod,
+    bool copy_if_newer,
+    Attrs &attrs,
+    RGWObjCategory category,
+    uint64_t olh_epoch,
+    boost::optional<ceph::real_time> delete_at,
+    std::string *version_id,
+    std::string *tag,
+    std::string *etag,
+    void (*progress_cb)(off_t, void *),
+    void *progress_data,
+    const DoutPrefixProvider *dpp,
+    optional_yield y
+  ) override;
 
   virtual RGWAccessControlPolicy &get_acl(void) override { return acls; }
   virtual int set_acl(const RGWAccessControlPolicy &acl) override {


### PR DESCRIPTION
This implementation breaks S3 semantics because we do not allow a copy
to an existing object.

Fixes: aquarist-labs/s3gw#35

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>