### PR TITLE
rgw/sfs: Fixed bucket creation time always set at now() for SFS backend

### DIFF
--- a/.github/workflows/test-radosgw.yml
+++ b/.github/workflows/test-radosgw.yml
@@ -22,12 +22,12 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
 
     steps:
-      - name: Checkout s3gw-core
+      - name: Checkout s3gw-tools
         uses: actions/checkout@v3
         with:
-          repository: 'aquarist-labs/s3gw-core'
+          repository: 'aquarist-labs/s3gw-tools'
           ref: 'main'
-          path: 's3gw-core'
+          path: 's3gw-tools'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -53,7 +53,7 @@ jobs:
           push: true
           tags: |
             localhost:5000/s3gw:latest
-          file: s3gw-core/build/Dockerfile.build-container
+          file: s3gw-tools/build/Dockerfile.build-container
           context: ceph/build
 
       - name: Install S3cmd
@@ -77,5 +77,5 @@ jobs:
           # to boot up.
 
           echo "Running Tests:\n"
-          s3gw-core/tests/s3gw-smoke-test.sh localhost:7480
+          s3gw-tools/tests/s3gw-smoke-test.sh localhost:7480
           # TODO: Run tests here

--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -345,7 +345,7 @@ class SFStore : public Store {
     meta_buckets->store_bucket(info);
 
     sfs::BucketRef b = std::make_shared<sfs::Bucket>(
-      ctx(), this, bucket, owner
+      ctx(), this, info.binfo, owner
     );
     buckets[bucket.name] = b;
     return b;
@@ -364,7 +364,7 @@ class SFStore : public Store {
     for (auto &b : existing) {
       auto user = users.get_user(b.binfo.owner.id);
       sfs::BucketRef ref = std::make_shared<sfs::Bucket>(
-        ctx(), this, b.binfo.bucket, user->uinfo
+        ctx(), this, b.binfo, user->uinfo
       );
       buckets[b.binfo.bucket.name] = ref;
     }

--- a/src/rgw/store/sfs/bucket.cc
+++ b/src/rgw/store/sfs/bucket.cc
@@ -28,7 +28,7 @@ SFSBucket::SFSBucket(
 
   info.bucket = bucket->get_bucket();
   info.owner = bucket->get_owner().user_id;
-  info.creation_time = ceph::real_clock::now();
+  info.creation_time = _bucket->get_creation_time();
   info.placement_rule.name = "default";
   info.placement_rule.storage_class = "STANDARD"; 
 }

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -85,11 +85,10 @@ class Bucket {
   Bucket(
     CephContext *_cct,
     SFStore *_store,
-    const rgw_bucket &_bucket,
+    const RGWBucketInfo &_bucket_info,
     const RGWUserInfo &_owner
-  ) : cct(_cct), store(_store), name(_bucket.name),
-      bucket(_bucket), owner(_owner) {
-    creation_time = ceph::real_clock::now();
+  ) : cct(_cct), store(_store), name(_bucket_info.bucket.name),
+      bucket(_bucket_info.bucket), owner(_owner), creation_time(_bucket_info.creation_time) {
     _refresh_objects();
   }
 


### PR DESCRIPTION
Creation time for buckets was correctly set on sqlite table but
when retrieving it, the data was not propagated during the object
copy chain.

Tested using s3cmd.

Fixes: https://github.com/aquarist-labs/s3gw/issues/63
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
