### PR TITLE
rgw/sfs: Add object versioning.

### DIFF
--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -103,7 +103,7 @@ class SFStore : public Store {
    * Obtain an internal representation of an object by its key. This does not
    * directly specify the bucket, so there's no direct mapping to an actual
    * object (existing or not).
-   * 
+   *
    * The SAL layer will often call this function during its operation, setting
    * the bucket accordingly at some point.
    */

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -10,6 +10,25 @@ and this project adheres to
 ## [Unreleased]
 
 ### Added
+- rgw/sfs: object versioning.
+
+
+### Notes
+- rgw/sfs Versioning.
+  #### What works
+  - Enable / disable bucket versioning.
+  - When versioning is enabled and a new object is pushed it creates a new version,
+    keeping the previous one.
+  - Objects versions list
+  - Download specific version (older versions than the last one)
+  - Object delete (delete mark is added in a new version)
+
+  #### What's missing / does not work
+  - Remove delete marks (undelete objects)
+  - Store checksum in sqlite metadata for a version
+
+## [0.3.0] - 2022-08-05
+### Added
 - rgw/sfs: new on-disk format, based on filesystem hash tree for data
   and sqlite for metadata.
 - rgw/sfs: maintain one single sqlite database connection.
@@ -32,7 +51,6 @@ and this project adheres to
 ### Removed
 - rgw/sfs: remove unused data and metadata functions, artifacts from our
   previous file-based implementation.
-
 
 ## [0.2.0] - 2022-07-28
 

--- a/src/rgw/store/sfs/bucket.h
+++ b/src/rgw/store/sfs/bucket.h
@@ -62,6 +62,12 @@ class SFSBucket : public Bucket {
 
   std::unique_ptr<Object> _get_object(sfs::ObjectRef obj);
 
+  int list_versions(const DoutPrefixProvider *dpp,
+                      ListParams &params,
+                      int,
+                      ListResults &results,
+                      optional_yield y);
+
  public:
   SFSBucket(SFStore *_store, sfs::BucketRef _bucket, const RGWBucketInfo &info);
   SFSBucket& operator=(const SFSBucket&) = delete;

--- a/src/rgw/store/sfs/object.h
+++ b/src/rgw/store/sfs/object.h
@@ -88,9 +88,12 @@ class SFSObject : public Object {
     SFStore *_st,
     const rgw_obj_key &_k,
     Bucket *_b,
-    sfs::BucketRef _bucket
+    sfs::BucketRef _bucket,
+    bool load_metadata = true
   ) : Object(_k, _b), store(_st), bucketref(_bucket) {
-    refresh_meta();
+    if (load_metadata) {
+      refresh_meta();
+    }
   }
 
   virtual std::unique_ptr<Object> clone() override {

--- a/src/rgw/store/sfs/sqlite/buckets/bucket_conversions.cc
+++ b/src/rgw/store/sfs/sqlite/buckets/bucket_conversions.cc
@@ -24,6 +24,7 @@ DBOPBucketInfo get_rgw_bucket(const DBBucket & bucket) {
   assign_optional_value(bucket.marker, rgw_bucket.binfo.bucket.marker);
   assign_optional_value(bucket.bucket_id, rgw_bucket.binfo.bucket.bucket_id);
   rgw_bucket.binfo.owner.id = bucket.owner_id;
+  assign_optional_value(bucket.flags, rgw_bucket.binfo.flags);
   assign_optional_value(bucket.creation_time, rgw_bucket.binfo.creation_time);
   assign_optional_value(bucket.placement_name, rgw_bucket.binfo.placement_rule.name);
   assign_optional_value(bucket.placement_storage_class, rgw_bucket.binfo.placement_rule.storage_class);
@@ -39,6 +40,7 @@ DBBucket get_db_bucket(const DBOPBucketInfo & bucket) {
   assign_db_value(bucket.binfo.bucket.marker, db_bucket.marker);
   assign_db_value(bucket.binfo.bucket.bucket_id, db_bucket.bucket_id);
   db_bucket.owner_id = bucket.binfo.owner.id;
+  assign_db_value(bucket.binfo.flags, db_bucket.flags);
   assign_db_value(bucket.binfo.creation_time, db_bucket.creation_time);
   assign_db_value(bucket.binfo.placement_rule.name, db_bucket.placement_name);
   assign_db_value(bucket.binfo.placement_rule.storage_class, db_bucket.placement_storage_class);

--- a/src/rgw/store/sfs/sqlite/buckets/bucket_definitions.h
+++ b/src/rgw/store/sfs/sqlite/buckets/bucket_definitions.h
@@ -37,6 +37,7 @@ struct DBBucket {
   std::optional<std::string> placement_name;
   std::optional<std::string> placement_storage_class;
   std::string owner_id;
+  std::optional<uint32_t> flags;
   std::optional<std::string> zone_group;
   std::optional<bool> has_instance_obj;
   std::optional<BLOB> quota;

--- a/src/rgw/store/sfs/sqlite/dbconn.h
+++ b/src/rgw/store/sfs/sqlite/dbconn.h
@@ -70,6 +70,7 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("marker", &DBBucket::marker),
           sqlite_orm::make_column("bucket_id", &DBBucket::bucket_id),
           sqlite_orm::make_column("owner_id", &DBBucket::owner_id),
+          sqlite_orm::make_column("flags", &DBBucket::flags),
           sqlite_orm::make_column("creation_time", &DBBucket::creation_time),
           sqlite_orm::make_column("placement_name", &DBBucket::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBBucket::placement_storage_class),
@@ -94,6 +95,7 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("size", &DBVersionedObject::size),
           sqlite_orm::make_column("creation_time", &DBVersionedObject::creation_time),
           sqlite_orm::make_column("object_state", &DBVersionedObject::object_state),
+          sqlite_orm::make_column("version_id", &DBVersionedObject::version_id),
           sqlite_orm::foreign_key(&DBVersionedObject::object_id).references(&DBObject::object_id))
   );  
 }

--- a/src/rgw/store/sfs/sqlite/objects/object_conversions.cc
+++ b/src/rgw/store/sfs/sqlite/objects/object_conversions.cc
@@ -21,8 +21,8 @@ DBOPObjectInfo get_rgw_object(const DBObject & object) {
   rgw_object.uuid.parse(object.object_id.c_str());
   rgw_object.bucket_name = object.bucket_name;
   rgw_object.name = object.name;
-  rgw_object.size = object.size;
-  rgw_object.etag = object.etag;
+  assign_optional_value(object.size, rgw_object.size);
+  assign_optional_value(object.etag, rgw_object.etag);
   assign_optional_value(object.mtime, rgw_object.mtime);
   assign_optional_value(object.set_mtime, rgw_object.set_mtime);
   assign_optional_value(object.delete_at_time, rgw_object.delete_at);
@@ -36,8 +36,8 @@ DBObject get_db_object(const DBOPObjectInfo & object) {
   db_object.object_id = object.uuid.to_string();
   db_object.bucket_name = object.bucket_name;
   db_object.name = object.name;
-  db_object.size = object.size;
-  db_object.etag = object.etag;
+  assign_db_value(object.size, db_object.size);
+  assign_db_value(object.etag, db_object.etag);
   assign_db_value(object.mtime, db_object.mtime);
   assign_db_value(object.set_mtime, db_object.set_mtime);
   assign_db_value(object.delete_at, db_object.delete_at_time);

--- a/src/rgw/store/sfs/sqlite/objects/object_definitions.h
+++ b/src/rgw/store/sfs/sqlite/objects/object_definitions.h
@@ -25,8 +25,8 @@ struct DBObject {
   std::string object_id;
   std::string bucket_name;
   std::string name;
-  size_t size;
-  std::string etag;
+  std::optional<size_t> size;
+  std::optional<std::string> etag;
   std::optional<BLOB> mtime;
   std::optional<BLOB> set_mtime;
   std::optional<BLOB> delete_at_time;

--- a/src/rgw/store/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/store/sfs/sqlite/sqlite_versioned_objects.cc
@@ -17,6 +17,16 @@ using namespace sqlite_orm;
 
 namespace rgw::sal::sfs::sqlite {
 
+std::vector<DBOPVersionedObjectInfo> get_rgw_versioned_objects(
+  const std::vector<DBVersionedObject> & db_versioned_objects ) {
+  std::vector<DBOPVersionedObjectInfo> ret_objs;
+  for (const auto & db_obj : db_versioned_objects) {
+    auto rgw_obj = get_rgw_versioned_object(db_obj);
+    ret_objs.push_back(rgw_obj);
+  }
+  return ret_objs;
+}
+
 SQLiteVersionedObjects::SQLiteVersionedObjects(DBConnRef _conn)
   : conn(_conn) { }
 
@@ -31,11 +41,30 @@ std::optional<DBOPVersionedObjectInfo> SQLiteVersionedObjects::get_versioned_obj
   return ret_value;
 }
 
+std::optional<DBOPVersionedObjectInfo> SQLiteVersionedObjects::get_versioned_object(const std::string & version_id) const {
+  std::shared_lock l(conn->rwlock);
+  auto storage = conn->get_storage();
+  auto versioned_objects = storage.get_all<DBVersionedObject>(where(c(&DBVersionedObject::version_id) = version_id));
+  ceph_assert(versioned_objects.size() <= 1);
+  std::optional<DBOPVersionedObjectInfo> ret_value;
+  if (versioned_objects.size()) {
+    ret_value = get_rgw_versioned_object(versioned_objects[0]);
+  }
+  return ret_value;
+}
+
+uint SQLiteVersionedObjects::insert_versioned_object(const DBOPVersionedObjectInfo & object) const {
+  std::unique_lock l(conn->rwlock);
+  auto storage = conn->get_storage();
+  auto db_object = get_db_versioned_object(object);
+  return storage.insert(db_object);
+}
+
 void SQLiteVersionedObjects::store_versioned_object(const DBOPVersionedObjectInfo & object) const {
   std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto db_object = get_db_versioned_object(object);
-  storage.insert(db_object);
+  storage.update(db_object);
 }
 
 void SQLiteVersionedObjects::remove_versioned_object(uint id) const {
@@ -55,6 +84,14 @@ std::vector<uint> SQLiteVersionedObjects::get_versioned_object_ids(const uuid_d 
   auto storage = conn->get_storage();
   auto uuid = object_id.to_string();
   return storage.select(&DBVersionedObject::id, where(c(&DBVersionedObject::object_id) = uuid));
+}
+
+std::vector<DBOPVersionedObjectInfo> SQLiteVersionedObjects::get_versioned_objects(const uuid_d & object_id) const {
+  std::shared_lock l(conn->rwlock);
+  auto storage = conn->get_storage();
+  auto uuid = object_id.to_string();
+  auto versioned_objects = storage.get_all<DBVersionedObject>(where(c(&DBVersionedObject::object_id) = uuid));
+  return get_rgw_versioned_objects(versioned_objects);
 }
 
 std::optional<DBOPVersionedObjectInfo>

--- a/src/rgw/store/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/store/sfs/sqlite/sqlite_versioned_objects.h
@@ -29,12 +29,15 @@ class SQLiteVersionedObjects {
   SQLiteVersionedObjects& operator=(const SQLiteVersionedObjects&) = delete;
 
   std::optional<DBOPVersionedObjectInfo> get_versioned_object(uint id) const;
+  std::optional<DBOPVersionedObjectInfo> get_versioned_object(const std::string & version_id) const;
 
+  uint insert_versioned_object(const DBOPVersionedObjectInfo & object) const;
   void store_versioned_object(const DBOPVersionedObjectInfo & object) const;
   void remove_versioned_object(uint id) const;
 
   std::vector<uint> get_versioned_object_ids() const;
   std::vector<uint> get_versioned_object_ids(const uuid_d & object_id) const;
+  std::vector<DBOPVersionedObjectInfo> get_versioned_objects(const uuid_d & object_id) const;
 
   std::optional<DBOPVersionedObjectInfo> get_last_versioned_object(const uuid_d & object_id) const;
 };

--- a/src/rgw/store/sfs/sqlite/versioned_object/versioned_object_conversions.cc
+++ b/src/rgw/store/sfs/sqlite/versioned_object/versioned_object_conversions.cc
@@ -36,6 +36,7 @@ DBOPVersionedObjectInfo get_rgw_versioned_object(const DBVersionedObject & objec
   rgw_object.size = object.size;
   decode_blob(object.creation_time, rgw_object.creation_time);
   rgw_object.object_state = get_object_state(object.object_state);
+  rgw_object.version_id = object.version_id;
   return rgw_object;
 }
 
@@ -48,6 +49,7 @@ DBVersionedObject get_db_versioned_object(const DBOPVersionedObjectInfo & object
   db_object.size = object.size;
   encode_blob(object.creation_time, db_object.creation_time);
   db_object.object_state = get_uint_object_state(object.object_state);
+  db_object.version_id = object.version_id;
   return db_object;
 }
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/sqlite/versioned_object/versioned_object_definitions.h
+++ b/src/rgw/store/sfs/sqlite/versioned_object/versioned_object_definitions.h
@@ -30,6 +30,7 @@ struct DBVersionedObject {
   size_t size;
   BLOB creation_time;
   uint object_state;
+  std::string version_id;
 };
 
 struct DBOPVersionedObjectInfo {
@@ -40,6 +41,7 @@ struct DBOPVersionedObjectInfo {
   size_t size;
   ceph::real_time creation_time;
   ObjectState object_state;
+  std::string version_id;
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -46,16 +46,27 @@ struct Object {
   };
 
   std::string name;
+  std::string instance;
+  uint version_id{0};
   UUIDPath path;
   Meta meta;
   bool deleted;
 
-  Object(const std::string &_name) 
+  Object(const std::string &_name)
   : name(_name), path(UUIDPath::create()), deleted(false) { }
 
   Object(const std::string &_name, const uuid_d &_uuid, bool _deleted)
   : name(_name), path(_uuid), deleted(_deleted) { }
 
+  Object(const rgw_obj_key &key)
+  : name(key.name), instance(key.instance), path(UUIDPath::create()), deleted(false) { }
+
+  std::filesystem::path get_storage_path() const;
+
+  void metadata_init(SFStore *store, const std::string & bucket_name,
+                     bool new_object, bool new_version);
+  void metadata_change_version_state(SFStore *store, ObjectState state);
+  void metadata_finish(SFStore *store);
 };
 
 using ObjectRef = std::shared_ptr<Object>;
@@ -69,13 +80,11 @@ class Bucket {
   RGWUserInfo owner;
   ceph::real_time creation_time;
   rgw_placement_rule placement_rule;
-
+  uint32_t flags{0};
 
  public:
   std::map<std::string, ObjectRef> objects;
   ceph::mutex obj_map_lock = ceph::make_mutex("obj_map_lock");
-  std::map<std::string, ObjectRef> creating;
-  std::set<ObjectRef> deleted;
 
   Bucket(const Bucket&) = default;
 
@@ -91,7 +100,8 @@ class Bucket {
   ) : cct(_cct), store(_store), name(_bucket_info.bucket.name),
       bucket(_bucket_info.bucket), owner(_owner),
       creation_time(_bucket_info.creation_time),
-      placement_rule(_bucket_info.placement_rule) {
+      placement_rule(_bucket_info.placement_rule),
+      flags(_bucket_info.flags) {
     _refresh_objects();
   }
 
@@ -101,6 +111,7 @@ class Bucket {
     out_info.creation_time = get_creation_time();
     out_info.placement_rule.name = placement_rule.name;
     out_info.placement_rule.storage_class = placement_rule.storage_class; 
+    out_info.flags = get_flags();
     return out_info;
   }
 
@@ -128,31 +139,11 @@ class Bucket {
     return creation_time;
   }
 
-  ObjectRef get_or_create(const std::string &name) {
-    std::lock_guard l(obj_map_lock);
-
-    {
-      auto it = objects.find(name);
-      if (it != objects.end()) {
-        return it->second;
-      }
-    }
-
-    // is object already being created?
-    //   this will potentially clash between two competing tasks.
-    //   deal with that later.
-    {
-      auto it = creating.find(name);
-      if (it != creating.end()) {
-        return it->second;
-      }
-    }
-
-    // create new object
-    ObjectRef obj = std::make_shared<Object>(name);
-    creating[name] = obj;
-    return obj;
+  uint32_t get_flags() const {
+    return flags;
   }
+
+  ObjectRef get_or_create(const rgw_obj_key &key);
 
   ObjectRef get(const std::string &name) {
     auto it = objects.find(name);
@@ -164,26 +155,7 @@ class Bucket {
 
   void finish(const DoutPrefixProvider *dpp, const std::string &objname);
 
-  void delete_object(ObjectRef objref) {
-    std::lock_guard l(obj_map_lock);
-
-    objref->deleted = true;
-
-    auto it = objects.find(objref->name);
-    if (it == objects.end()) {
-      // nothing to do.
-      return;
-    }
-
-    ObjectRef found = it->second;
-    if (!found->path.match(objref->path)) {
-      // different objects, nothing to do.
-      return;
-    }
-
-    deleted.insert(objref);
-    objects.erase(it);
-  }
+  void delete_object(ObjectRef objref);
 
   inline std::string get_cls_name() { return "sfs::bucket"; }
 };

--- a/src/rgw/store/sfs/writer.h
+++ b/src/rgw/store/sfs/writer.h
@@ -34,6 +34,7 @@ class SFSAtomicWriter : public Writer {
   uint64_t olh_epoch;
   const std::string &unique_tag;
   uint64_t bytes_written;
+  uint versioned_object_id;
 
  public:
   SFSAtomicWriter(

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -63,6 +63,7 @@ void compareBucketRGWInfo(const RGWBucketInfo & origin, const RGWBucketInfo & de
   ASSERT_EQ(origin.placement_rule.name, dest.placement_rule.name);
   ASSERT_EQ(origin.placement_rule.storage_class, dest.placement_rule.storage_class);
   ASSERT_EQ(origin.owner.id, dest.owner.id);
+  ASSERT_EQ(origin.flags, dest.flags);
 }
 
 void compareBuckets(const DBOPBucketInfo & origin, const DBOPBucketInfo & dest) {
@@ -79,6 +80,7 @@ DBOPBucketInfo createTestBucket(const std::string & suffix) {
   bucket.binfo.placement_rule.name = "default";
   bucket.binfo.placement_rule.storage_class = "STANDARD";
   bucket.binfo.owner.id = "usertest";
+  bucket.binfo.flags = static_cast<uint32_t>(rand());
   return bucket;
 }
 


### PR DESCRIPTION
Adds object versioning using the sqlite versioned objects table.

This version keeps the last available (updated) version in memory for
faster access and queries sqlite metadata for specific versions.

Also implements enabling bucket versioning.

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

Fixes: https://github.com/aquarist-labs/s3gw/issues/9




## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
