### PR TITLE
rgw/sfs: filled bucket create json-response for system users

### DIFF
--- a/src/rgw/store/sfs/bucket.cc
+++ b/src/rgw/store/sfs/bucket.cc
@@ -23,14 +23,9 @@ namespace rgw::sal {
 
 
 SFSBucket::SFSBucket(
-  SFStore *_store, sfs::BucketRef _bucket
+  SFStore *_store, sfs::BucketRef _bucket, const RGWBucketInfo &info
 ) : store(_store), bucket(_bucket), acls() {
-
-  info.bucket = bucket->get_bucket();
-  info.owner = bucket->get_owner().user_id;
-  info.creation_time = _bucket->get_creation_time();
-  info.placement_rule.name = "default";
-  info.placement_rule.storage_class = "STANDARD"; 
+  this->info = info;
 }
 
 void SFSBucket::write_meta(const DoutPrefixProvider *dpp) {

--- a/src/rgw/store/sfs/bucket.h
+++ b/src/rgw/store/sfs/bucket.h
@@ -63,7 +63,7 @@ class SFSBucket : public Bucket {
   std::unique_ptr<Object> _get_object(sfs::ObjectRef obj);
 
  public:
-  SFSBucket(SFStore *_store, sfs::BucketRef _bucket);
+  SFSBucket(SFStore *_store, sfs::BucketRef _bucket, const RGWBucketInfo &info);
   SFSBucket& operator=(const SFSBucket&) = delete;
 
   virtual std::unique_ptr<Bucket> clone() override {

--- a/src/rgw/store/sfs/sfs_bucket.cc
+++ b/src/rgw/store/sfs/sfs_bucket.cc
@@ -43,7 +43,8 @@ int SFStore::get_bucket(const DoutPrefixProvider *dpp, User *u,
     return -ENOENT;
   }
   auto bucketref = it->second;
-  auto bucket = make_unique<SFSBucket>(this, bucketref);
+  RGWBucketInfo info;
+  auto bucket = make_unique<SFSBucket>(this, bucketref, bucketref->to_rgw_bucket_info(info));
   ldpp_dout(dpp, 10) << __func__ << ": bucket: " << bucket->get_name() << dendl;
   result->reset(bucket.release());
   return 0;
@@ -61,7 +62,8 @@ int SFStore::get_bucket(const DoutPrefixProvider *dpp, User *u,
     return -ENOENT;
   }
   auto bucketref = it->second;
-  auto b = make_unique<SFSBucket>(this, bucketref);
+  RGWBucketInfo info;
+  auto b = make_unique<SFSBucket>(this, bucketref, bucketref->to_rgw_bucket_info(info));
   ldpp_dout(dpp, 10) << __func__ << ": bucket: " << b->get_name() << dendl;
   bucket->reset(b.release());
   return 0;

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -68,6 +68,7 @@ class Bucket {
   rgw_bucket bucket;
   RGWUserInfo owner;
   ceph::real_time creation_time;
+  rgw_placement_rule placement_rule;
 
 
  public:
@@ -88,8 +89,19 @@ class Bucket {
     const RGWBucketInfo &_bucket_info,
     const RGWUserInfo &_owner
   ) : cct(_cct), store(_store), name(_bucket_info.bucket.name),
-      bucket(_bucket_info.bucket), owner(_owner), creation_time(_bucket_info.creation_time) {
+      bucket(_bucket_info.bucket), owner(_owner),
+      creation_time(_bucket_info.creation_time),
+      placement_rule(_bucket_info.placement_rule) {
     _refresh_objects();
+  }
+
+  RGWBucketInfo& to_rgw_bucket_info(RGWBucketInfo &out_info) const{
+    out_info.bucket = get_bucket();
+    out_info.owner = get_owner().user_id;
+    out_info.creation_time = get_creation_time();
+    out_info.placement_rule.name = placement_rule.name;
+    out_info.placement_rule.storage_class = placement_rule.storage_class; 
+    return out_info;
   }
 
   const std::string get_name() const {
@@ -100,11 +112,19 @@ class Bucket {
     return bucket;
   }
 
+  const rgw_bucket& get_bucket() const{
+    return bucket;
+  }
+
   RGWUserInfo& get_owner() {
     return owner;
   }
 
-  ceph::real_time get_creation_time() {
+  const RGWUserInfo& get_owner() const{
+    return owner;
+  }
+
+  ceph::real_time get_creation_time() const{
     return creation_time;
   }
 


### PR DESCRIPTION
System users are expected to receive an additional json response upon
bucket create operation.
Said response was not filled when a create bucket operation was
issued against a radosgw using sfs backend.

unit test is provided on a separate [PR](https://github.com/aquarist-labs/s3gw-tools/pull/158) on `s3gw-tools` repo 


For reference here is a _post-patch_ response produced with sfs be:

```
{
        "bucket_info" : 
        {
                "bi_shard_hash_type" : 0,
                "bucket" : 
                {
                        "bucket_id" : "foo2.1661759760247537382",
                        "explicit_placement" : 
                        {
                                "data_extra_pool" : "",
                                "data_pool" : "",
                                "index_pool" : ""
                        },
                        "marker" : "foo2.1661759760247537382",
                        "name" : "foo2",
                        "tenant" : ""
                },
                "creation_time" : "2022-08-29T07:56:00.247537Z",
                "flags" : 0,
                "has_instance_obj" : false,
                "has_website" : false,
                "index_type" : 0,
                "mdsearch_config" : [],
                "new_bucket_instance_id" : "",
                "num_shards" : 1,
                "owner" : "testid",
                "placement_rule" : "default",
                "quota" : 
                {
                        "check_on_raw" : false,
                        "enabled" : false,
                        "max_objects" : -1,
                        "max_size" : -1,
                        "max_size_kb" : 0
                },
                "requester_pays" : false,
                "reshard_status" : 0,
                "swift_ver_location" : "",
                "swift_versioning" : false,
                "zonegroup" : ""
        },
        "entry_point_object_ver" : 
        {
                "tag" : "",
                "ver" : 0
        },
        "object_ver" : 
        {
                "tag" : "_GrJjqdMWjT5r1yKjPB_Ec5a",
                "ver" : 1
        }
}
```

here a response produced with dbstore be:

```
{
        "bucket_info" : 
        {
                "bi_shard_hash_type" : 0,
                "bucket" : 
                {
                        "bucket_id" : "/workspaces/ceph/wd_dbstore/dbstore-default_ns.1",
                        "explicit_placement" : 
                        {
                                "data_extra_pool" : "",
                                "data_pool" : "",
                                "index_pool" : ""
                        },
                        "marker" : "/workspaces/ceph/wd_dbstore/dbstore-default_ns.1",
                        "name" : "foo",
                        "tenant" : ""
                },
                "creation_time" : "2022-08-29T08:03:50.579885Z",
                "flags" : 0,
                "has_instance_obj" : false,
                "has_website" : false,
                "index_type" : 0,
                "mdsearch_config" : [],
                "new_bucket_instance_id" : "",
                "num_shards" : 1,
                "owner" : "testid",
                "placement_rule" : "default",
                "quota" : 
                {
                        "check_on_raw" : false,
                        "enabled" : false,
                        "max_objects" : -1,
                        "max_size" : -1,
                        "max_size_kb" : 0
                },
                "requester_pays" : false,
                "reshard_status" : 0,
                "swift_ver_location" : "",
                "swift_versioning" : false,
                "zonegroup" : ""
        },
        "entry_point_object_ver" : 
        {
                "tag" : "",
                "ver" : 0
        },
        "object_ver" : 
        {
                "tag" : "_8r7qaX5xJIVrnjVSaFVuJpX",
                "ver" : 1
        }
}
```

and finally a response with rados:

```
{
   "entry_point_object_ver":{
      "tag":"_qzEqtETO0am7s2j5N53GXfh",
      "ver":1
   },
   "object_ver":{
      "tag":"_yG_oXGUtJVElk3kuAMl41jB",
      "ver":1
   },
   "bucket_info":{
      "bucket":{
         "name":"ddddd4444",
         "marker":"6898b142-d7e1-4ce7-a366-7049469e3a4c.174267.1",
         "bucket_id":"6898b142-d7e1-4ce7-a366-7049469e3a4c.174267.1",
         "tenant":"",
         "explicit_placement":{
            "data_pool":"",
            "data_extra_pool":"",
            "index_pool":""
         }
      },
      "creation_time":"2022-08-17T16:00:44.774976Z",
      "owner":"dashboard",
      "flags":0,
      "zonegroup":"f4a00e1c-87ec-47f5-b947-526341b0132e",
      "placement_rule":"default-placement",
      "has_instance_obj":"false",
      "quota":{
         "enabled":false,
         "check_on_raw":false,
         "max_size":-1,
         "max_size_kb":0,
         "max_objects":-1
      },
      "num_shards":11,
      "bi_shard_hash_type":0,
      "requester_pays":"false",
      "has_website":"false",
      "swift_versioning":"false",
      "swift_ver_location":"",
      "index_type":0,
      "mdsearch_config":[
         
      ],
      "reshard_status":0,
      "new_bucket_instance_id":""
   }
}
```


Fixes: https://github.com/aquarist-labs/s3gw/issues/66
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
