### PR TITLE
rgw/sfs: reorganized cmake build for sfs backend

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -178,25 +178,8 @@ if(WITH_RADOSGW_DBSTORE)
   list(APPEND librgw_common_srcs rgw_sal_dbstore.cc)
 endif()
 if(WITH_RADOSGW_SFS)
-  list(APPEND librgw_common_srcs
-    rgw_sal_sfs.cc
-    store/sfs/bucket.cc
-    store/sfs/multipart.cc
-    store/sfs/object.cc
-    store/sfs/user.cc
-    store/sfs/types.cc
-    store/sfs/zone.cc
-    store/sfs/writer.cc
-    store/sfs/sfs_bucket.cc
-    store/sfs/sfs_user.cc
-    store/sfs/sqlite/sqlite_users.cc
-    store/sfs/sqlite/sqlite_buckets.cc
-    store/sfs/sqlite/sqlite_objects.cc
-    store/sfs/sqlite/sqlite_versioned_objects.cc
-    store/sfs/sqlite/users/users_conversions.cc
-    store/sfs/sqlite/buckets/bucket_conversions.cc
-    store/sfs/sqlite/objects/object_conversions.cc
-    store/sfs/sqlite/versioned_object/versioned_object_conversions.cc)
+  add_subdirectory(store/sfs)
+  list(APPEND librgw_common_srcs rgw_sal_sfs.cc)
 endif()
 if(WITH_RADOSGW_MOTR)
   list(APPEND librgw_common_srcs rgw_sal_motr.cc)
@@ -282,6 +265,10 @@ endif()
 
 if(WITH_RADOSGW_DBSTORE)
   target_link_libraries(rgw_common PRIVATE global dbstore)
+endif()
+
+if(WITH_RADOSGW_SFS)
+  target_link_libraries(rgw_common PRIVATE global sfs)
 endif()
 
 if(WITH_RADOSGW_MOTR)

--- a/src/rgw/store/sfs/CMakeLists.txt
+++ b/src/rgw/store/sfs/CMakeLists.txt
@@ -1,0 +1,48 @@
+#need to update cmake version here
+cmake_minimum_required(VERSION 3.14.0)
+project(sfs)
+
+option(USE_SFS "Enable SFS" ON)
+
+find_package(SQLite3 REQUIRED)
+
+#These flags should not be necessary because radosgw is linked with sqlite
+#library via system package imported by cmake with find_package().
+#We keep these because dbstore backend is doing that in its CMakeLists.txt
+#and we decided to conform with it.
+set(SQLITE_COMPILE_FLAGS "-DSQLITE_THREADSAFE=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SQLITE_COMPILE_FLAGS}")
+
+set(CMAKE_INCLUDE_DIR ${CMAKE_INCLUDE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/sqlite")
+include_directories(${CMAKE_INCLUDE_DIR})
+
+set(sfs_srcs
+    sqlite/sqlite_users.cc
+    sqlite/sqlite_buckets.cc
+    sqlite/sqlite_objects.cc
+    sqlite/sqlite_versioned_objects.cc
+    sqlite/users/users_conversions.cc
+    sqlite/buckets/bucket_conversions.cc
+    sqlite/objects/object_conversions.cc
+    sqlite/versioned_object/versioned_object_conversions.cc
+    bucket.cc
+    multipart.cc
+    object.cc
+    user.cc
+    types.cc
+    zone.cc
+    writer.cc
+    sfs_bucket.cc
+    sfs_user.cc
+    )
+
+add_library(sfs STATIC ${sfs_srcs})
+target_include_directories(sfs PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include")
+target_include_directories(sfs PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
+set(link_targets spawn)
+if(WITH_JAEGER)
+  list(APPEND link_targets jaeger_base)
+endif()
+
+set(CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} ${link_targets} rgw_common sqlite3 pthread)
+target_link_libraries(sfs PUBLIC ${CMAKE_LINK_LIBRARIES})


### PR DESCRIPTION
ceph/src/rgw/CMakeLists.txt does not build sfs backend directly anymore. 
It now contains only the directive to compile rgw_sal_dbstore.cc similarly with other SAL BEs.
Specific sfs build has been demanded to ceph/src/rgw/store/sfs/CMakeLists.txt

Fixes: https://github.com/aquarist-labs/s3gw/issues/95
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
