### PR TITLE
rgw/sfs: undelete objects implementation.

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to
 - Fixed the admin API request: get-bucket-info where the client was receiving
   an empty response.
 
+- Show delete markers when listing object versions.
+
+### Added
+
+- Undelete objects.
+
 ## [0.4.0] - 2022-09-01
 
 ### Added

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -27,6 +27,7 @@
 #include "rgw/store/sfs/sqlite/dbconn.h"
 #include "rgw/store/sfs/sqlite/sqlite_buckets.h"
 #include "rgw/store/sfs/sqlite/sqlite_objects.h"
+#include "rgw/store/sfs/sqlite/sqlite_versioned_objects.h"
 
 namespace rgw::sal::sfs {
 
@@ -90,6 +91,9 @@ class Bucket {
 
  private:
   void _refresh_objects();
+  void _undelete_object(ObjectRef objref, const rgw_obj_key & key,
+                        sqlite::SQLiteVersionedObjects & sqlite_versioned_objects,
+                        sqlite::DBOPVersionedObjectInfo & last_version);
 
  public:
   Bucket(
@@ -155,7 +159,7 @@ class Bucket {
 
   void finish(const DoutPrefixProvider *dpp, const std::string &objname);
 
-  void delete_object(ObjectRef objref);
+  void delete_object(ObjectRef objref, const rgw_obj_key & key);
 
   inline std::string get_cls_name() { return "sfs::bucket"; }
 };


### PR DESCRIPTION
This allows the user to remove delete makers of objects which means basically undeleting objects.

It also shows delete markers correctly, so users are able to find what objects have been deleted.

### Example:

This shows an object with 2 versions:
```bash
$ aws --endpoint=http://127.0.0.1:7480 s3api list-object-versions --bucket test                                            
{
    "Versions": [
        {
            "ETag": "\"bf18c66f70054819415a46d7dc1bf34c\"",
            "Size": 2297,
            "StorageClass": "STANDARD",
            "Key": "test-object3",
            "VersionId": "waOECDbBj1.EmwbrkEFPNmMO79GA0DO",
            "IsLatest": false,
            "LastModified": "2022-09-14T13:35:59.566Z",
            "Owner": {
                "DisplayName": "M. Tester",
                "ID": "testid"
            }
        },
        {
            "ETag": "\"bf18c66f70054819415a46d7dc1bf34c\"",
            "Size": 2055,
            "StorageClass": "STANDARD",
            "Key": "test-object3",
            "VersionId": "A8-yMIbz2eMAH338n8y0uN59ZCf3RRO",
            "IsLatest": true,
            "LastModified": "2022-09-14T13:36:04.627Z",
            "Owner": {
                "DisplayName": "M. Tester",
                "ID": "testid"
            }
        }
    ]
}
```

After removing the object:
```bash
$ aws --endpoint=http://127.0.0.1:7480 s3api delete-object --bucket test --key test-object3
$ aws --endpoint=http://127.0.0.1:7480 s3api list-object-versions --bucket test             
{
    "Versions": [
        {
            "ETag": "\"bf18c66f70054819415a46d7dc1bf34c\"",
            "Size": 2297,
            "StorageClass": "STANDARD",
            "Key": "test-object3",
            "VersionId": "waOECDbBj1.EmwbrkEFPNmMO79GA0DO",
            "IsLatest": false,
            "LastModified": "2022-09-14T13:35:59.566Z",
            "Owner": {
                "DisplayName": "M. Tester",
                "ID": "testid"
            }
        },
        {
            "ETag": "\"bf18c66f70054819415a46d7dc1bf34c\"",
            "Size": 2055,
            "StorageClass": "STANDARD",
            "Key": "test-object3",
            "VersionId": "A8-yMIbz2eMAH338n8y0uN59ZCf3RRO",
            "IsLatest": false,
            "LastModified": "2022-09-14T13:36:04.627Z",
            "Owner": {
                "DisplayName": "M. Tester",
                "ID": "testid"
            }
        }
    ],
    "DeleteMarkers": [
        {
            "Owner": {
                "DisplayName": "M. Tester",
                "ID": "testid"
            },
            "Key": "test-object3",
            "VersionId": "jSubVuZibnIqjokGezeI7vhO8yssiMI",
            "IsLatest": true,
            "LastModified": "2022-09-14T13:36:04.627Z"
        }
    ]
}
```

Delete marker is show, the object now is not shown when listing the bucket.

```bash
$ aws --endpoint=http://127.0.0.1:7480 s3 ls s3://test
```

To undelete the object (note that we must pass the version id of the Delete Marker)
```bash
$ aws --endpoint=http://127.0.0.1:7480 s3api delete-object --bucket test --key test-object3 --version-id jSubVuZibnIqjokGezeI7vhO8yssiMI
```

Object is shown again in the bucket and it is available:
```bash
$ aws --endpoint=http://127.0.0.1:7480 s3 ls s3://test                         
2022-09-14 15:36:04       2055 test-object3
```

Fixes: https://github.com/aquarist-labs/s3gw/issues/107
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
