### PR TITLE
rgw/sfs: add ability to list buckets via meta_list_*() functions

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 
 - Undelete objects.
 
+- Ability to list buckets via admin REST API
+
 ## [0.4.0] - 2022-09-01
 
 ### Added

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -437,7 +437,9 @@ TEST_F(TestSFSSQLiteUsers, StoreListUsers) {
   const NoDoutPrefix no_dpp(ceph_context.get(), 1);
   std::list<std::string> userIds;
   bool truncated;
-  store->meta_list_keys_next(&no_dpp, nullptr, std::numeric_limits<int>::max(), userIds, &truncated);
+  void * meta_handle;
+  store->meta_list_keys_init(&no_dpp, std::string("user"), std::string(), &meta_handle);
+  store->meta_list_keys_next(&no_dpp, meta_handle, std::numeric_limits<int>::max(), userIds, &truncated);
   ASSERT_FALSE(truncated);
   ASSERT_EQ(userIds.size(), 0);
 
@@ -450,7 +452,7 @@ TEST_F(TestSFSSQLiteUsers, StoreListUsers) {
   db_users->store_user(user2);
   db_users->store_user(user3);
 
-  store->meta_list_keys_next(&no_dpp, nullptr, std::numeric_limits<int>::max(),userIds, &truncated);
+  store->meta_list_keys_next(&no_dpp, meta_handle, std::numeric_limits<int>::max(),userIds, &truncated);
   ASSERT_FALSE(truncated);
   ASSERT_EQ(userIds.size(), 3);
   std::vector<std::string> users_vector{ std::make_move_iterator(userIds.begin()),
@@ -474,7 +476,9 @@ TEST_F(TestSFSSQLiteUsers, StoreAddUser) {
 
   std::list<std::string> userIds;
   bool truncated;
-  store->meta_list_keys_next(&no_dpp, nullptr, std::numeric_limits<int>::max(), userIds, &truncated);
+  void * meta_handle;
+  store->meta_list_keys_init(&no_dpp, std::string("user"), std::string(), &meta_handle);
+  store->meta_list_keys_next(&no_dpp, meta_handle, std::numeric_limits<int>::max(), userIds, &truncated);
   ASSERT_FALSE(truncated);
   ASSERT_EQ(userIds.size(), 1);
 
@@ -642,7 +646,9 @@ TEST_F(TestSFSSQLiteUsers, StoreRemoveUser) {
   const NoDoutPrefix no_dpp(ceph_context.get(), 1);
   std::list<std::string> userIds;
   bool truncated;
-  store->meta_list_keys_next(&no_dpp, nullptr, std::numeric_limits<int>::max(), userIds, &truncated);
+  void * meta_handle;
+  store->meta_list_keys_init(&no_dpp, std::string("user"), std::string(), &meta_handle);
+  store->meta_list_keys_next(&no_dpp, meta_handle, std::numeric_limits<int>::max(), userIds, &truncated);
   ASSERT_FALSE(truncated);
   ASSERT_EQ(userIds.size(), 0);
 
@@ -654,7 +660,7 @@ TEST_F(TestSFSSQLiteUsers, StoreRemoveUser) {
   db_users->store_user(user2);
   db_users->store_user(user3);
 
-  store->meta_list_keys_next(&no_dpp, nullptr, std::numeric_limits<int>::max(), userIds, &truncated);
+  store->meta_list_keys_next(&no_dpp, meta_handle, std::numeric_limits<int>::max(), userIds, &truncated);
   ASSERT_FALSE(truncated);
   ASSERT_EQ(userIds.size(), 3);
   std::vector<std::string> users_vector{ std::make_move_iterator(userIds.begin()),
@@ -669,7 +675,7 @@ TEST_F(TestSFSSQLiteUsers, StoreRemoveUser) {
 
   // ensure the user was removed
   userIds.clear();
-  store->meta_list_keys_next(&no_dpp, nullptr, std::numeric_limits<int>::max(), userIds, &truncated);
+  store->meta_list_keys_next(&no_dpp, meta_handle, std::numeric_limits<int>::max(), userIds, &truncated);
   ASSERT_FALSE(truncated);
   ASSERT_EQ(userIds.size(), 2);
   std::vector<std::string> users_after_remove_vector{ std::make_move_iterator(userIds.begin()),


### PR DESCRIPTION
This is a nasty hack to make `meta_list_keys_*()` work with both users and buckets.  What we _should_ do is create some extra class that knows how to do meta key listing of various types of object, and pass an instance of that around via the handle arguments to these functions. This would allow that as-yet-nonexistent class to keep track of max and truncated in `meta_list_keys_next()`.  Instead, the immediate nasty hack is to make handle point at a const string which indicates what type of metadata we're dealing with, then check that value and call an instance of the appropriate `rgw::sal::sfs::sqlite::SQLite*` class to get the metdata we care about.

Fixes: https://github.com/aquarist-labs/s3gw/issues/64
Signed-off-by: Tim Serong <tserong@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
