### PR TITLE
rgw/sfs: ACL implementation

### DIFF
--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -367,11 +367,13 @@ class SFStore : public Store {
     info.requester_pays = false;
     info.quota = db_binfo.binfo.quota;
     
+    db_binfo.battrs = attrs;
+
     auto meta_buckets = sfs::get_meta_buckets(db_conn);
     meta_buckets->store_bucket(db_binfo);
 
     sfs::BucketRef b = std::make_shared<sfs::Bucket>(
-      ctx(), this, db_binfo.binfo, owner
+      ctx(), this, db_binfo.binfo, owner, db_binfo.battrs
     );
     buckets[bucket.name] = b;
     return b;
@@ -391,7 +393,7 @@ class SFStore : public Store {
       if (!b.deleted) {
         auto user = users.get_user(b.binfo.owner.id);
         sfs::BucketRef ref = std::make_shared<sfs::Bucket>(
-          ctx(), this, b.binfo, user->uinfo
+          ctx(), this, b.binfo, user->uinfo, b.battrs
         );
         buckets[b.binfo.bucket.name] = ref;
       }
@@ -421,7 +423,6 @@ class SFStore : public Store {
 
   std::string get_cls_name() const { return "sfstore"; }
 };
-
 
 }  // namespace rgw::sal
 

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - Undelete objects.
 - Ability to list buckets via admin REST API
 - Delete buckets.
+- Support for bucket ACL.
 
 ### Fixed
 

--- a/src/rgw/store/sfs/bucket.h
+++ b/src/rgw/store/sfs/bucket.h
@@ -69,7 +69,7 @@ class SFSBucket : public Bucket {
                       optional_yield y);
 
  public:
-  SFSBucket(SFStore *_store, sfs::BucketRef _bucket, const RGWBucketInfo &info);
+  SFSBucket(SFStore *_store, sfs::BucketRef _bucket);
   SFSBucket& operator=(const SFSBucket&) = delete;
 
   virtual std::unique_ptr<Bucket> clone() override {
@@ -107,10 +107,7 @@ class SFSBucket : public Bucket {
   virtual RGWAccessControlPolicy &get_acl(void) override { return acls; }
 
   virtual int set_acl(const DoutPrefixProvider *dpp,
-                      RGWAccessControlPolicy &acl, optional_yield y) override {
-    acls = acl;
-    return 0;
-  }
+                      RGWAccessControlPolicy &acl, optional_yield y) override;
   /**
    * Load this bucket from disk.
    */
@@ -220,6 +217,15 @@ class SFSBucket : public Bucket {
     const std::string &meta
   );
   inline std::string get_cls_name() { return "bucket"; }
+
+  SFStore& get_store(){
+    return *store;
+  }
+
+  const SFStore& get_store() const{
+    return *store;
+  }
+
 };
 
 } // ns rgw::sal

--- a/src/rgw/store/sfs/sfs_bucket.cc
+++ b/src/rgw/store/sfs/sfs_bucket.cc
@@ -47,7 +47,7 @@ int SFStore::get_bucket(const DoutPrefixProvider *dpp, User *u,
   if (bucketref->get_deleted_flag()) {
     return -ENOENT;
   }
-  auto bucket = make_unique<SFSBucket>(this, bucketref, bucketref->to_rgw_bucket_info());
+  auto bucket = make_unique<SFSBucket>(this, bucketref);
   ldpp_dout(dpp, 10) << __func__ << ": bucket: " << bucket->get_name() << dendl;
   result->reset(bucket.release());
   return 0;
@@ -68,7 +68,7 @@ int SFStore::get_bucket(const DoutPrefixProvider *dpp, User *u,
   if (bucketref->get_deleted_flag()) {
     return -ENOENT;
   }
-  auto b = make_unique<SFSBucket>(this, bucketref, bucketref->to_rgw_bucket_info());
+  auto b = make_unique<SFSBucket>(this, bucketref);
   ldpp_dout(dpp, 10) << __func__ << ": bucket: " << b->get_name() << dendl;
   bucket->reset(b.release());
   return 0;

--- a/src/rgw/store/sfs/sqlite/buckets/bucket_conversions.cc
+++ b/src/rgw/store/sfs/sqlite/buckets/bucket_conversions.cc
@@ -30,6 +30,7 @@ DBOPBucketInfo get_rgw_bucket(const DBBucket & bucket) {
   assign_optional_value(bucket.creation_time, rgw_bucket.binfo.creation_time);
   assign_optional_value(bucket.placement_name, rgw_bucket.binfo.placement_rule.name);
   assign_optional_value(bucket.placement_storage_class, rgw_bucket.binfo.placement_rule.storage_class);
+  assign_optional_value(bucket.bucket_attrs, rgw_bucket.battrs);
   rgw_bucket.deleted = bucket.deleted;
 
   return rgw_bucket;
@@ -49,6 +50,7 @@ DBBucket get_db_bucket(const DBOPBucketInfo & bucket) {
   assign_db_value(bucket.binfo.creation_time, db_bucket.creation_time);
   assign_db_value(bucket.binfo.placement_rule.name, db_bucket.placement_name);
   assign_db_value(bucket.binfo.placement_rule.storage_class, db_bucket.placement_storage_class);
+  assign_db_value(bucket.battrs, db_bucket.bucket_attrs);
   db_bucket.deleted = bucket.deleted;
 
   return db_bucket;

--- a/src/rgw/store/sfs/sqlite/buckets/bucket_definitions.h
+++ b/src/rgw/store/sfs/sqlite/buckets/bucket_definitions.h
@@ -60,7 +60,16 @@ struct DBBucket {
 // Struct with information needed by SAL layer
 struct DBOPBucketInfo {
   RGWBucketInfo binfo;
+  Attrs battrs;
   bool deleted{false};
+
+  DBOPBucketInfo() = default;
+
+  DBOPBucketInfo(const RGWBucketInfo &info, const Attrs &attrs) : 
+    binfo(info),
+    battrs(attrs) { }
+
+  DBOPBucketInfo(const DBOPBucketInfo &other) = default;
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/sqlite/dbconn.h
+++ b/src/rgw/store/sfs/sqlite/dbconn.h
@@ -77,6 +77,7 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("placement_name", &DBBucket::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBBucket::placement_storage_class),
           sqlite_orm::make_column("deleted", &DBBucket::deleted),
+          sqlite_orm::make_column("bucket_attrs", &DBBucket::bucket_attrs),
           sqlite_orm::foreign_key(&DBBucket::owner_id).references(&DBUser::user_id)),
     sqlite_orm::make_table(std::string(OBJECTS_TABLE),
           sqlite_orm::make_column("object_id", &DBObject::object_id, sqlite_orm::primary_key()),

--- a/src/rgw/store/sfs/types.cc
+++ b/src/rgw/store/sfs/types.cc
@@ -99,7 +99,7 @@ ObjectRef Bucket::get_or_create(const rgw_obj_key &key) {
     obj = std::make_shared<Object>(key);
     objects[key.name] = obj;
   }
-  obj->metadata_init(store, name, new_object, create_new_version);
+  obj->metadata_init(store, info.bucket.name, new_object, create_new_version);
 
   return obj;
 }
@@ -113,7 +113,7 @@ void Bucket::finish(const DoutPrefixProvider *dpp, const std::string &objname) {
   ObjectRef ref = objects[objname];
   sqlite::DBOPObjectInfo oinfo;
   oinfo.uuid = ref->path.get_uuid();
-  oinfo.bucket_name = name;
+  oinfo.bucket_name = info.bucket.name;
   oinfo.name = objname;
   oinfo.size = ref->meta.size;
   oinfo.etag = ref->meta.etag;
@@ -181,7 +181,7 @@ void Bucket::_undelete_object(ObjectRef objref, const rgw_obj_key & key,
 
 void Bucket::_refresh_objects() {
   sqlite::SQLiteObjects objs(store->db_conn);
-  auto existing = objs.get_objects(name);
+  auto existing = objs.get_objects(info.bucket.name);
   for (const auto &obj : existing) {
     sqlite::SQLiteVersionedObjects objs_versions(store->db_conn);
     auto last_version = objs_versions.get_last_versioned_object(obj.uuid);

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -76,14 +76,11 @@ class Bucket {
 
   CephContext *cct;
   SFStore *store;
-  const std::string name;
-  rgw_bucket bucket;
   RGWUserInfo owner;
-  ceph::real_time creation_time;
-  rgw_placement_rule placement_rule;
-  uint32_t flags{0};
+  RGWBucketInfo info;
+  rgw::sal::Attrs attrs;
   bool deleted{false};
-
+  
  public:
   std::map<std::string, ObjectRef> objects;
   ceph::mutex obj_map_lock = ceph::make_mutex("obj_map_lock");
@@ -101,41 +98,41 @@ class Bucket {
     CephContext *_cct,
     SFStore *_store,
     const RGWBucketInfo &_bucket_info,
-    const RGWUserInfo &_owner
-  ) : cct(_cct), store(_store), name(_bucket_info.bucket.name),
-      bucket(_bucket_info.bucket), owner(_owner),
-      creation_time(_bucket_info.creation_time),
-      placement_rule(_bucket_info.placement_rule),
-      flags(_bucket_info.flags) {
+    const RGWUserInfo &_owner,
+    const rgw::sal::Attrs &_attrs
+  ) : cct(_cct), store(_store),
+      owner(_owner),
+      info(_bucket_info),
+      attrs(_attrs) {
     _refresh_objects();
   }
 
-  RGWBucketInfo& to_rgw_bucket_info(RGWBucketInfo &out_info) const{
-    out_info.bucket = get_bucket();
-    out_info.owner = get_owner().user_id;
-    out_info.creation_time = get_creation_time();
-    out_info.placement_rule.name = placement_rule.name;
-    out_info.placement_rule.storage_class = placement_rule.storage_class; 
-    out_info.flags = get_flags();
-    return out_info;
+  const RGWBucketInfo& get_info() const{
+    return info;
   }
 
-  RGWBucketInfo to_rgw_bucket_info() const{
-    RGWBucketInfo rval;
-    to_rgw_bucket_info(rval);
-    return rval;
+  RGWBucketInfo& get_info(){
+    return info;
+  }
+
+  const rgw::sal::Attrs& get_attrs() const{
+    return attrs;
+  }
+
+  rgw::sal::Attrs& get_attrs(){
+    return attrs;
   }
 
   const std::string get_name() const {
-    return name;
+    return info.bucket.name;
   }
 
   rgw_bucket& get_bucket() {
-    return bucket;
+    return info.bucket;
   }
 
   const rgw_bucket& get_bucket() const{
-    return bucket;
+    return info.bucket;
   }
 
   RGWUserInfo& get_owner() {
@@ -147,11 +144,11 @@ class Bucket {
   }
 
   ceph::real_time get_creation_time() const{
-    return creation_time;
+    return info.creation_time;
   }
 
   uint32_t get_flags() const {
-    return flags;
+    return info.flags;
   }
 
   ObjectRef get_or_create(const rgw_obj_key &key);

--- a/src/rgw/store/sfs/user.cc
+++ b/src/rgw/store/sfs/user.cc
@@ -136,7 +136,7 @@ int SFSUser::list_buckets(const DoutPrefixProvider *dpp,
     if (!bucketref->get_deleted_flag()) {
       buckets.add(
         std::unique_ptr<Bucket>(
-          new SFSBucket{store, bucketref, bucketref->to_rgw_bucket_info()}
+          new SFSBucket{store, bucketref}
         ));
     }
   }
@@ -185,10 +185,7 @@ int SFSUser::create_bucket(
     return -EINVAL;
   }
 
-  auto new_bucket = new SFSBucket{store, bucketref, info};
-  new_bucket->set_attrs(attrs);
-
-  bucket_out->reset(new_bucket);
+  bucket_out->reset(new SFSBucket{store, bucketref});
 
   return 0;
 }

--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -13,3 +13,7 @@ target_link_libraries(unittest_rgw_sfs_sqlite_objects ${rgw_libs})
 add_executable(unittest_rgw_sfs_sqlite_versioned_objects test_rgw_sfs_sqlite_versioned_objects.cc)
 add_ceph_unittest(unittest_rgw_sfs_sqlite_versioned_objects)
 target_link_libraries(unittest_rgw_sfs_sqlite_versioned_objects ${rgw_libs})
+
+add_executable(unittest_rgw_sfs_sfs_bucket test_rgw_sfs_sfs_bucket.cc)
+add_ceph_unittest(unittest_rgw_sfs_sfs_bucket)
+target_link_libraries(unittest_rgw_sfs_sfs_bucket ${rgw_libs})

--- a/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
@@ -1,0 +1,409 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/ceph_context.h"
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/sqlite_buckets.h"
+#include "rgw/store/sfs/sqlite/buckets/bucket_conversions.h"
+#include "rgw/store/sfs/sqlite/sqlite_users.h"
+
+#include "rgw/rgw_sal_sfs.h"
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+
+/*
+  HINT
+  s3gw.db will create here: /tmp/rgw_sfs_tests
+*/
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace fs = std::filesystem;
+const static std::string TEST_DIR = "rgw_sfs_tests";
+
+class TestSFSBucket : public ::testing::Test {
+protected:
+  void SetUp() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::create_directory(TEST_DIR);
+  }
+
+  void TearDown() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(TEST_DIR);
+  }
+
+  std::string getTestDir() const {
+    auto test_dir = fs::temp_directory_path() / TEST_DIR;
+    return test_dir.string();
+  }
+
+  fs::path getDBFullPath(const std::string & base_dir) const {
+    auto db_full_name = "s3gw.db";
+    auto db_full_path = fs::path(base_dir) /  db_full_name;
+    return db_full_path;
+  }
+
+  fs::path getDBFullPath() const {
+    return getDBFullPath(getTestDir());
+  }
+
+  void createUser(const std::string & username, DBConnRef conn) {
+    SQLiteUsers users(conn);
+    DBOPUserInfo user;
+    user.uinfo.user_id.id = username;
+    users.store_user(user);
+  }
+};
+
+RGWAccessControlPolicy get_aclp_default(){
+  RGWAccessControlPolicy aclp;
+  rgw_user aclu("usr_id");
+  aclp.get_acl().create_default(aclu, "usr_id");
+  aclp.get_owner().set_name("usr_id");
+  aclp.get_owner().set_id(aclu);
+  bufferlist acl_bl;
+  aclp.encode(acl_bl);
+  return aclp;
+}
+
+RGWAccessControlPolicy get_aclp_1(){
+  RGWAccessControlPolicy aclp;
+  rgw_user aclu("usr_id");
+  RGWAccessControlList &acl = aclp.get_acl();
+  ACLGrant aclg;
+  rgw_user gusr("usr_id_2");
+  aclg.set_canon(gusr, "usr_id_2", (RGW_PERM_READ_OBJS | RGW_PERM_WRITE_OBJS));
+  acl.add_grant(&aclg);
+  aclp.get_owner().set_name("usr_id");
+  aclp.get_owner().set_id(aclu);
+  bufferlist acl_bl;
+  aclp.encode(acl_bl);
+  return aclp;
+}
+
+RGWBucketInfo get_binfo(){
+  RGWBucketInfo arg_info;
+  return arg_info;
+}
+
+TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = store->get_user(arg_user);
+
+  rgw_bucket arg_bucket("t_id", "b_name", "");
+  rgw_placement_rule arg_pl_rule("default", "STANDARD");
+  std::string arg_swift_ver_location;
+  RGWQuotaInfo arg_quota_info;
+  RGWAccessControlPolicy arg_aclp = get_aclp_default();
+  rgw::sal::Attrs arg_attrs; 
+  {
+    bufferlist acl_bl;
+    arg_aclp.encode(acl_bl);
+    arg_attrs[RGW_ATTR_ACL] = acl_bl;
+  }
+  
+  RGWBucketInfo arg_info = get_binfo();
+  obj_version arg_objv;
+  bool existed = false;
+  req_info arg_req_info(ceph_context.get(), &env);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_create;
+
+  EXPECT_EQ(user->create_bucket(&ndp,                       //dpp
+                                arg_bucket,                 //b
+                                "zg1",                      //zonegroup_id
+                                arg_pl_rule,                //placement_rule
+                                arg_swift_ver_location,     //swift_ver_location
+                                &arg_quota_info,            //pquota_info
+                                arg_aclp,                   //policy
+                                arg_attrs,                  //attrs
+                                arg_info,                   //info
+                                arg_objv,                   //ep_objv
+                                false,                      //exclusive
+                                false,                      //obj_lock_enabled
+                                &existed,                   //existed
+                                arg_req_info,               //req_info
+                                &bucket_from_create,        //bucket
+                                null_yield                  //optional_yield
+                                ), 
+            0);
+
+  EXPECT_EQ(existed, false);
+  EXPECT_EQ(bucket_from_create->get_tenant(), "t_id");
+  EXPECT_EQ(bucket_from_create->get_name(), "b_name");
+  EXPECT_EQ(bucket_from_create->get_placement_rule().name, "default");
+  EXPECT_EQ(bucket_from_create->get_placement_rule().storage_class, "STANDARD");
+  EXPECT_NE(bucket_from_create->get_attrs().find(RGW_ATTR_ACL), bucket_from_create->get_attrs().end());
+  
+  auto acl_bl_it = bucket_from_create->get_attrs().find(RGW_ATTR_ACL);
+  {
+    RGWAccessControlPolicy aclp;
+    auto ci_lval = acl_bl_it->second.cbegin();
+    aclp.decode(ci_lval);
+    EXPECT_EQ(aclp, arg_aclp);
+  }
+
+  EXPECT_EQ(bucket_from_create->get_acl(), arg_aclp);
+  
+  //@warning this triggers segfault
+  //EXPECT_EQ(bucket_from_create->get_owner()->get_id().id, "usr_id");
+
+}
+
+TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromStore) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = store->get_user(arg_user);
+
+  rgw_bucket arg_bucket("t_id", "b_name", "");
+  rgw_placement_rule arg_pl_rule("default", "STANDARD");
+  std::string arg_swift_ver_location;
+  RGWQuotaInfo arg_quota_info;
+  RGWAccessControlPolicy arg_aclp = get_aclp_default();
+  rgw::sal::Attrs arg_attrs; 
+  {
+    bufferlist acl_bl;
+    arg_aclp.encode(acl_bl);
+    arg_attrs[RGW_ATTR_ACL] = acl_bl;
+  }
+  
+  RGWBucketInfo arg_info = get_binfo();
+  obj_version arg_objv;
+  bool existed = false;
+  req_info arg_req_info(ceph_context.get(), &env);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_create;
+
+  EXPECT_EQ(user->create_bucket(&ndp,                       //dpp
+                                arg_bucket,                 //b
+                                "zg1",                      //zonegroup_id
+                                arg_pl_rule,                //placement_rule
+                                arg_swift_ver_location,     //swift_ver_location
+                                &arg_quota_info,            //pquota_info
+                                arg_aclp,                   //policy
+                                arg_attrs,                  //attrs
+                                arg_info,                   //info
+                                arg_objv,                   //ep_objv
+                                false,                      //exclusive
+                                false,                      //obj_lock_enabled
+                                &existed,                   //existed
+                                arg_req_info,               //req_info
+                                &bucket_from_create,        //bucket
+                                null_yield                  //optional_yield
+                                ), 
+            0);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_store;
+
+  EXPECT_EQ(store->get_bucket(&ndp,
+                              user.get(), 
+                              arg_info.bucket,
+                              &bucket_from_store,
+                              null_yield), 
+            0);
+
+  EXPECT_EQ(*bucket_from_store, *bucket_from_create);
+  EXPECT_NE(bucket_from_store->get_attrs().find(RGW_ATTR_ACL), bucket_from_store->get_attrs().end());
+  
+  auto acl_bl_it = bucket_from_store->get_attrs().find(RGW_ATTR_ACL);
+  {
+    RGWAccessControlPolicy aclp;
+    auto ci_lval = acl_bl_it->second.cbegin();
+    aclp.decode(ci_lval);
+    EXPECT_EQ(aclp, arg_aclp);
+  }
+
+  EXPECT_EQ(bucket_from_store->get_acl(), bucket_from_create->get_acl());
+}
+
+TEST_F(TestSFSBucket, BucketSetAcl) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = store->get_user(arg_user);
+
+  rgw_bucket arg_bucket("t_id", "b_name", "");
+  rgw_placement_rule arg_pl_rule("default", "STANDARD");
+  std::string arg_swift_ver_location;
+  RGWQuotaInfo arg_quota_info;
+  RGWAccessControlPolicy arg_aclp = get_aclp_default();
+  rgw::sal::Attrs arg_attrs; 
+  {
+    bufferlist acl_bl;
+    arg_aclp.encode(acl_bl);
+    arg_attrs[RGW_ATTR_ACL] = acl_bl;
+  }
+  
+  RGWBucketInfo arg_info = get_binfo();
+  obj_version arg_objv;
+  bool existed = false;
+  req_info arg_req_info(ceph_context.get(), &env);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_create;
+
+  EXPECT_EQ(user->create_bucket(&ndp,                       //dpp
+                                arg_bucket,                 //b
+                                "zg1",                      //zonegroup_id
+                                arg_pl_rule,                //placement_rule
+                                arg_swift_ver_location,     //swift_ver_location
+                                &arg_quota_info,            //pquota_info
+                                arg_aclp,                   //policy
+                                arg_attrs,                  //attrs
+                                arg_info,                   //info
+                                arg_objv,                   //ep_objv
+                                false,                      //exclusive
+                                false,                      //obj_lock_enabled
+                                &existed,                   //existed
+                                arg_req_info,               //req_info
+                                &bucket_from_create,        //bucket
+                                null_yield                  //optional_yield
+                                ), 
+            0);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_store;
+
+  EXPECT_EQ(store->get_bucket(&ndp,
+                              user.get(), 
+                              arg_info.bucket,
+                              &bucket_from_store,
+                              null_yield), 
+            0);
+
+  RGWAccessControlPolicy arg_aclp_1 = get_aclp_1();
+
+  EXPECT_EQ(bucket_from_store->set_acl(&ndp,
+                                       arg_aclp_1,
+                                       null_yield),
+            0);
+
+  EXPECT_NE(bucket_from_store->get_acl(), bucket_from_create->get_acl());
+  EXPECT_EQ(bucket_from_store->get_acl(), get_aclp_1());
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_store_1;
+
+  EXPECT_EQ(store->get_bucket(&ndp,
+                            user.get(), 
+                            arg_info.bucket,
+                            &bucket_from_store_1,
+                            null_yield), 
+          0);
+
+  EXPECT_EQ(bucket_from_store->get_acl(), bucket_from_store_1->get_acl());
+}
+
+TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = store->get_user(arg_user);
+
+  rgw_bucket arg_bucket("t_id", "b_name", "");
+  rgw_placement_rule arg_pl_rule("default", "STANDARD");
+  std::string arg_swift_ver_location;
+  RGWQuotaInfo arg_quota_info;
+  RGWAccessControlPolicy arg_aclp = get_aclp_default();
+  rgw::sal::Attrs arg_attrs; 
+  {
+    bufferlist acl_bl;
+    arg_aclp.encode(acl_bl);
+    arg_attrs[RGW_ATTR_ACL] = acl_bl;
+  }
+  
+  RGWBucketInfo arg_info = get_binfo();
+  obj_version arg_objv;
+  bool existed = false;
+  req_info arg_req_info(ceph_context.get(), &env);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_create;
+
+  EXPECT_EQ(user->create_bucket(&ndp,                       //dpp
+                                arg_bucket,                 //b
+                                "zg1",                      //zonegroup_id
+                                arg_pl_rule,                //placement_rule
+                                arg_swift_ver_location,     //swift_ver_location
+                                &arg_quota_info,            //pquota_info
+                                arg_aclp,                   //policy
+                                arg_attrs,                  //attrs
+                                arg_info,                   //info
+                                arg_objv,                   //ep_objv
+                                false,                      //exclusive
+                                false,                      //obj_lock_enabled
+                                &existed,                   //existed
+                                arg_req_info,               //req_info
+                                &bucket_from_create,        //bucket
+                                null_yield                  //optional_yield
+                                ), 
+            0);
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_store;
+
+  EXPECT_EQ(store->get_bucket(&ndp,
+                              user.get(), 
+                              arg_info.bucket,
+                              &bucket_from_store,
+                              null_yield), 
+            0);
+
+  rgw::sal::Attrs new_attrs;
+  RGWAccessControlPolicy arg_aclp_1 = get_aclp_1();
+  {
+    bufferlist acl_bl;
+    arg_aclp_1.encode(acl_bl);
+    new_attrs[RGW_ATTR_ACL] = acl_bl;
+  }
+
+  EXPECT_EQ(bucket_from_store->merge_and_store_attrs(&ndp,
+                                                     new_attrs,
+                                                     null_yield),
+            0);
+
+  EXPECT_EQ(bucket_from_store->get_attrs(), new_attrs);
+  EXPECT_NE(bucket_from_store->get_acl(), bucket_from_create->get_acl());
+  EXPECT_EQ(bucket_from_store->get_acl(), get_aclp_1());
+
+  std::unique_ptr<rgw::sal::Bucket> bucket_from_store_1;
+
+  EXPECT_EQ(store->get_bucket(&ndp,
+                            user.get(), 
+                            arg_info.bucket,
+                            &bucket_from_store_1,
+                            null_yield), 
+          0);
+
+  EXPECT_EQ(bucket_from_store_1->get_attrs(), new_attrs);
+  EXPECT_EQ(bucket_from_store->get_acl(), bucket_from_store_1->get_acl());
+}


### PR DESCRIPTION
rgw/sfs: ACL implementation
    
Implemented persistence for sfs bucket's ACL.
ACL is represented as an attribute with key: RGW_ATTR_ACL in attrs.
This means that an implementation for the field attrs must be provided
for sfs's buckets.

Details:

 - Added battrs field to DBOPBucketInfo
 - Implemented a google test ensuring proper encode/decode of battrs.
   Same test also ensures fetching/storing from/to sqlite table.
 - Implemented SFSBucket::set_acl()
 - Implemented SFSBucket::merge_and_store_attrs()
 ~~- Introduced ScopedStoreBucketRefresher type implementing a RAII type for
   refreshing buckets after completing a sqlite operation over a bucket.~~
 - Some refactoring for rgw::sal::sfs::Bucket
    - Introduced more generic instance variables:
       - RGWBucketInfo info
       - rgw::sal::Attrs attrs
    - Removed instance variables: name, bucket, creation_time, placement_rule, flags.
    - Removed to_rgw_bucket_info() methods.
- Added test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc for testing SFSBucket class
    - Added test: UserCreateBucketCheckGotFromCreate
    - Added test: UserCreateBucketCheckGotFromStore
    - Added test: BucketSetAcl
    - Added test: BucketMergeAndStoreAttrs

Fixes: https://github.com/aquarist-labs/s3gw/issues/5
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
