### PR TITLE
rgw/sfs : Remove bucket

### DIFF
--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -388,11 +388,13 @@ class SFStore : public Store {
     buckets.clear();
     sfs::sqlite::SQLiteUsers users(db_conn);
     for (auto &b : existing) {
-      auto user = users.get_user(b.binfo.owner.id);
-      sfs::BucketRef ref = std::make_shared<sfs::Bucket>(
-        ctx(), this, b.binfo, user->uinfo
-      );
-      buckets[b.binfo.bucket.name] = ref;
+      if (!b.deleted) {
+        auto user = users.get_user(b.binfo.owner.id);
+        sfs::BucketRef ref = std::make_shared<sfs::Bucket>(
+          ctx(), this, b.binfo, user->uinfo
+        );
+        buckets[b.binfo.bucket.name] = ref;
+      }
     }
   }
 

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to
 ### Added
 
 - Undelete objects.
-
 - Ability to list buckets via admin REST API
+- Delete buckets.
 
 ### Fixed
 

--- a/src/rgw/store/sfs/sfs_bucket.cc
+++ b/src/rgw/store/sfs/sfs_bucket.cc
@@ -43,6 +43,10 @@ int SFStore::get_bucket(const DoutPrefixProvider *dpp, User *u,
     return -ENOENT;
   }
   auto bucketref = it->second;
+
+  if (bucketref->get_deleted_flag()) {
+    return -ENOENT;
+  }
   auto bucket = make_unique<SFSBucket>(this, bucketref, bucketref->to_rgw_bucket_info());
   ldpp_dout(dpp, 10) << __func__ << ": bucket: " << bucket->get_name() << dendl;
   result->reset(bucket.release());
@@ -61,6 +65,9 @@ int SFStore::get_bucket(const DoutPrefixProvider *dpp, User *u,
     return -ENOENT;
   }
   auto bucketref = it->second;
+  if (bucketref->get_deleted_flag()) {
+    return -ENOENT;
+  }
   auto b = make_unique<SFSBucket>(this, bucketref, bucketref->to_rgw_bucket_info());
   ldpp_dout(dpp, 10) << __func__ << ": bucket: " << b->get_name() << dendl;
   bucket->reset(b.release());

--- a/src/rgw/store/sfs/sqlite/buckets/bucket_conversions.cc
+++ b/src/rgw/store/sfs/sqlite/buckets/bucket_conversions.cc
@@ -30,6 +30,7 @@ DBOPBucketInfo get_rgw_bucket(const DBBucket & bucket) {
   assign_optional_value(bucket.creation_time, rgw_bucket.binfo.creation_time);
   assign_optional_value(bucket.placement_name, rgw_bucket.binfo.placement_rule.name);
   assign_optional_value(bucket.placement_storage_class, rgw_bucket.binfo.placement_rule.storage_class);
+  rgw_bucket.deleted = bucket.deleted;
 
   return rgw_bucket;
 }
@@ -48,6 +49,7 @@ DBBucket get_db_bucket(const DBOPBucketInfo & bucket) {
   assign_db_value(bucket.binfo.creation_time, db_bucket.creation_time);
   assign_db_value(bucket.binfo.placement_rule.name, db_bucket.placement_name);
   assign_db_value(bucket.binfo.placement_rule.storage_class, db_bucket.placement_storage_class);
+  db_bucket.deleted = bucket.deleted;
 
   return db_bucket;
 }

--- a/src/rgw/store/sfs/sqlite/buckets/bucket_definitions.h
+++ b/src/rgw/store/sfs/sqlite/buckets/bucket_definitions.h
@@ -54,11 +54,13 @@ struct DBBucket {
   std::optional<int> bucket_version;
   std::optional<std::string> bucket_version_tag;
   std::optional<BLOB> mtime;
+  bool deleted;
 };
 
 // Struct with information needed by SAL layer
 struct DBOPBucketInfo {
   RGWBucketInfo binfo;
+  bool deleted{false};
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/sqlite/dbconn.h
+++ b/src/rgw/store/sfs/sqlite/dbconn.h
@@ -76,6 +76,7 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("creation_time", &DBBucket::creation_time),
           sqlite_orm::make_column("placement_name", &DBBucket::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBBucket::placement_storage_class),
+          sqlite_orm::make_column("deleted", &DBBucket::deleted),
           sqlite_orm::foreign_key(&DBBucket::owner_id).references(&DBUser::user_id)),
     sqlite_orm::make_table(std::string(OBJECTS_TABLE),
           sqlite_orm::make_column("object_id", &DBObject::object_id, sqlite_orm::primary_key()),

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -82,6 +82,7 @@ class Bucket {
   ceph::real_time creation_time;
   rgw_placement_rule placement_rule;
   uint32_t flags{0};
+  bool deleted{false};
 
  public:
   std::map<std::string, ObjectRef> objects;
@@ -168,6 +169,9 @@ class Bucket {
   void delete_object(ObjectRef objref, const rgw_obj_key & key);
 
   inline std::string get_cls_name() { return "sfs::bucket"; }
+
+  void set_deleted_flag(bool deleted_flag) { deleted = deleted_flag; }
+  bool get_deleted_flag() const { return deleted; }
 };
 
 using BucketRef = std::shared_ptr<Bucket>;

--- a/src/rgw/store/sfs/user.cc
+++ b/src/rgw/store/sfs/user.cc
@@ -133,8 +133,12 @@ int SFSUser::list_buckets(const DoutPrefixProvider *dpp,
 
   std::list<sfs::BucketRef> lst = store->bucket_list();
   for (const auto &bucketref : lst) {
-    auto bucket = std::unique_ptr<Bucket>(new SFSBucket{store, bucketref, bucketref->to_rgw_bucket_info()});
-    buckets.add(std::move(bucket));
+    if (!bucketref->get_deleted_flag()) {
+      buckets.add(
+        std::unique_ptr<Bucket>(
+          new SFSBucket{store, bucketref, bucketref->to_rgw_bucket_info()}
+        ));
+    }
   }
   
   ldpp_dout(dpp, 10) << __func__ << ": buckets=" << buckets.get_buckets()

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <gtest/gtest.h>
 #include <memory>
+#include <random>
 
 using namespace rgw::sal::sfs::sqlite;
 
@@ -73,6 +74,13 @@ void compareBucketRGWInfo(const RGWBucketInfo & origin, const RGWBucketInfo & de
 
 void compareBuckets(const DBOPBucketInfo & origin, const DBOPBucketInfo & dest) {
   compareBucketRGWInfo(origin.binfo, dest.binfo);
+  ASSERT_EQ(origin.deleted, dest.deleted);
+}
+
+bool randomBool() {
+  std::random_device generator;
+  std::uniform_int_distribution<int> distribution(0,1);
+  return static_cast<bool>(distribution(generator));
 }
 
 DBOPBucketInfo createTestBucket(const std::string & suffix) {
@@ -91,6 +99,7 @@ DBOPBucketInfo createTestBucket(const std::string & suffix) {
   bucket.binfo.quota.max_objects = 512;
   bucket.binfo.quota.enabled = true;
   bucket.binfo.quota.check_on_raw = true;
+  bucket.deleted = randomBool();
   return bucket;
 }
 


### PR DESCRIPTION
Implement bucket delete by adding a delete flag to the bucket which flags the bucket and makes it not available.

SAL layer already deals with removing all the objects inside the bucket before removing it.

Fixes: https://github.com/aquarist-labs/s3gw/issues/34
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
