### PR TITLE
rgw/sfs: Fix versioned object tests.

### DIFF
--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -67,6 +67,7 @@ protected:
     SQLiteBuckets buckets(conn);
     DBOPBucketInfo bucket;
     bucket.binfo.bucket.name = bucketname;
+    bucket.binfo.bucket.bucket_id = bucketname;
     bucket.binfo.owner.id = username;
     buckets.store_bucket(bucket);
   }
@@ -83,7 +84,7 @@ protected:
 
     DBOPObjectInfo object;
     object.uuid.parse(object_id.c_str());
-    object.bucket_name = bucketname;
+    object.bucket_id = bucketname;
     object.name = "test_name";
     object.size = rand();
     object.etag = "test_etag";


### PR DESCRIPTION
Fixes compilation issue introduced after merging the PR: https://github.com/aquarist-labs/ceph/pull/44

I used `bucketname` as the value for `bucket_id` because there are no clashes in the tests and because the tests are for `Versioned Object`, so out of the scope of `bucket_id`.

`bucket_id` and its relation with objects is tested in the tests for `objects`

Fixes: https://github.com/aquarist-labs/s3gw/issues/133
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
