### PR TITLE
rgw/sfs: Lists only the buckets owned by the user.

### DIFF
--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -17,3 +17,7 @@ target_link_libraries(unittest_rgw_sfs_sqlite_versioned_objects ${rgw_libs})
 add_executable(unittest_rgw_sfs_sfs_bucket test_rgw_sfs_sfs_bucket.cc)
 add_ceph_unittest(unittest_rgw_sfs_sfs_bucket)
 target_link_libraries(unittest_rgw_sfs_sfs_bucket ${rgw_libs})
+
+add_executable(unittest_rgw_sfs_sfs_user test_rgw_sfs_sfs_user.cc)
+add_ceph_unittest(unittest_rgw_sfs_sfs_user)
+target_link_libraries(unittest_rgw_sfs_sfs_user ${rgw_libs})

--- a/src/test/rgw/sfs/rgw_sfs_utils.h
+++ b/src/test/rgw/sfs/rgw_sfs_utils.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "rgw/rgw_sal_sfs.h"
+
+#include <gtest/gtest.h>
+
+template <typename T>
+bool compare(const T & origin, const T & dest) {
+  return origin == dest;
+}
+
+bool compare(const RGWAccessKey & origin, const RGWAccessKey & dest) {
+  if (origin.id != dest.id) return false;
+  if (origin.key != dest.key) return false;
+  if (origin.subuser != dest.subuser) return false;
+  return true;
+}
+
+bool compare(const RGWSubUser & origin, const RGWSubUser & dest) {
+  if (origin.name != dest.name) return false;
+  if (origin.perm_mask != dest.perm_mask) return false;
+  return true;
+}
+
+template <typename T>
+bool compareMaps(const T & origin, const T & dest) {
+  if (origin.size() != dest.size()) return false;
+  for (auto const& [key, val] : origin)
+  {
+    if (dest.find(key) == dest.end()) return false;
+    auto & dest_val = dest.at(key);
+    if (!compare(val, dest_val)) return false;
+  }
+  return true;
+}
+
+std::string getCapsString(const RGWUserCaps & caps) {
+  auto formatter = std::make_unique<ceph::JSONFormatter>(new ceph::JSONFormatter(true));
+  encode_json("caps", caps, formatter.get());
+  std::ostringstream oss;
+  formatter->flush(oss);
+  return oss.str();
+}
+
+void compareUsersRGWInfo(const RGWUserInfo & origin, const RGWUserInfo & dest) {
+  ASSERT_EQ(origin.user_id.id, dest.user_id.id);
+  ASSERT_EQ(origin.user_id.tenant, dest.user_id.tenant);
+  ASSERT_EQ(origin.user_id.ns, dest.user_id.ns);
+  ASSERT_EQ(origin.display_name, dest.display_name);
+  ASSERT_EQ(origin.user_email, dest.user_email);
+  ASSERT_TRUE(compareMaps(origin.access_keys, dest.access_keys));
+  ASSERT_TRUE(compareMaps(origin.swift_keys, dest.swift_keys));
+  ASSERT_TRUE(compareMaps(origin.subusers, dest.subusers));
+  ASSERT_EQ(origin.suspended, dest.suspended);
+  ASSERT_EQ(origin.max_buckets, dest.max_buckets);
+  ASSERT_EQ(origin.op_mask, dest.op_mask);
+  ASSERT_EQ(getCapsString(origin.caps), getCapsString(dest.caps));
+  ASSERT_EQ(origin.system, dest.system);
+  ASSERT_EQ(origin.default_placement.name, dest.default_placement.name);
+  ASSERT_EQ(origin.default_placement.storage_class, dest.default_placement.storage_class);
+  ASSERT_EQ(origin.placement_tags, dest.placement_tags);
+  ASSERT_EQ(origin.quota.bucket_quota.max_size, dest.quota.bucket_quota.max_size);
+  ASSERT_EQ(origin.quota.bucket_quota.max_objects, dest.quota.bucket_quota.max_objects);
+  ASSERT_EQ(origin.quota.bucket_quota.enabled, dest.quota.bucket_quota.enabled);
+  ASSERT_EQ(origin.quota.bucket_quota.check_on_raw, dest.quota.bucket_quota.check_on_raw);
+  ASSERT_TRUE(compareMaps(origin.temp_url_keys, dest.temp_url_keys));
+  ASSERT_EQ(origin.quota.user_quota.max_size, dest.quota.user_quota.max_size);
+  ASSERT_EQ(origin.quota.user_quota.max_objects, dest.quota.user_quota.max_objects);
+  ASSERT_EQ(origin.quota.user_quota.enabled, dest.quota.user_quota.enabled);
+  ASSERT_EQ(origin.quota.user_quota.check_on_raw, dest.quota.user_quota.check_on_raw);
+  ASSERT_EQ(origin.type, dest.type);
+  ASSERT_EQ(origin.mfa_ids, dest.mfa_ids);
+  ASSERT_EQ(origin.assumed_role_arn, dest.assumed_role_arn);
+}
+
+void compareUserAttrs(const rgw::sal::Attrs & origin, const rgw::sal::Attrs & dest) {
+  ASSERT_TRUE(compareMaps(origin, dest));
+}
+
+void compareUserVersion(const obj_version & origin, const obj_version & dest) {
+  ASSERT_EQ(origin.ver, dest.ver);
+  ASSERT_EQ(origin.tag, dest.tag);
+}

--- a/src/test/rgw/sfs/test_rgw_sfs_sfs_user.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sfs_user.cc
@@ -1,0 +1,376 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/ceph_context.h"
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/sqlite_buckets.h"
+#include "rgw/store/sfs/sqlite/buckets/bucket_conversions.h"
+#include "rgw/store/sfs/sqlite/sqlite_users.h"
+
+#include "rgw/rgw_sal_sfs.h"
+
+#include "rgw_sfs_utils.h"
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+
+/*
+  HINT
+  s3gw.db will create here: /tmp/rgw_sfs_tests
+*/
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace fs = std::filesystem;
+const static std::string TEST_DIR = "rgw_sfs_tests";
+
+RGWAccessControlPolicy get_aclp_default(){
+  RGWAccessControlPolicy aclp;
+  rgw_user aclu("usr_id");
+  aclp.get_acl().create_default(aclu, "usr_id");
+  aclp.get_owner().set_name("usr_id");
+  aclp.get_owner().set_id(aclu);
+  bufferlist acl_bl;
+  aclp.encode(acl_bl);
+  return aclp;
+}
+
+RGWAccessControlPolicy get_aclp_1(){
+  RGWAccessControlPolicy aclp;
+  rgw_user aclu("usr_id");
+  RGWAccessControlList &acl = aclp.get_acl();
+  ACLGrant aclg;
+  rgw_user gusr("usr_id_2");
+  aclg.set_canon(gusr, "usr_id_2", (RGW_PERM_READ_OBJS | RGW_PERM_WRITE_OBJS));
+  acl.add_grant(&aclg);
+  aclp.get_owner().set_name("usr_id");
+  aclp.get_owner().set_id(aclu);
+  bufferlist acl_bl;
+  aclp.encode(acl_bl);
+  return aclp;
+}
+
+RGWBucketInfo get_binfo(){
+  RGWBucketInfo arg_info;
+  return arg_info;
+}
+
+
+class TestSFSUser : public ::testing::Test {
+protected:
+  void SetUp() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::create_directory(TEST_DIR);
+  }
+
+  void TearDown() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(TEST_DIR);
+  }
+
+  std::string getTestDir() const {
+    auto test_dir = fs::temp_directory_path() / TEST_DIR;
+    return test_dir.string();
+  }
+
+  fs::path getDBFullPath(const std::string & base_dir) const {
+    auto db_full_name = "s3gw.db";
+    auto db_full_path = fs::path(base_dir) /  db_full_name;
+    return db_full_path;
+  }
+
+  fs::path getDBFullPath() const {
+    return getDBFullPath(getTestDir());
+  }
+
+  void createUser(const std::string & username, DBConnRef conn) {
+    SQLiteUsers users(conn);
+    DBOPUserInfo user;
+    user.uinfo.user_id.id = username;
+    users.store_user(user);
+  }
+
+  void createBucket(const std::string & name,
+                    const std::string & user_id,
+                    rgw::sal::SFStore * store,
+                    const std::shared_ptr<CephContext> & ceph_context) {
+    rgw_bucket arg_bucket("t_" + name, name, "id_" + name);
+    rgw_placement_rule arg_pl_rule("default", "STANDARD");
+    std::string arg_swift_ver_location;
+    RGWQuotaInfo arg_quota_info;
+    RGWAccessControlPolicy arg_aclp = get_aclp_default();
+    rgw::sal::Attrs arg_attrs;
+    {
+      bufferlist acl_bl;
+      arg_aclp.encode(acl_bl);
+      arg_attrs[RGW_ATTR_ACL] = acl_bl;
+    }
+
+    RGWBucketInfo arg_info = get_binfo();
+    obj_version arg_objv;
+    bool existed = false;
+    RGWEnv env;
+    req_info arg_req_info(ceph_context.get(), &env);
+
+    std::unique_ptr<rgw::sal::Bucket> bucket_from_create;
+    NoDoutPrefix ndp(ceph_context.get(), 1);
+
+    rgw_user arg_user("", user_id, "");
+    auto user = store->get_user(arg_user);
+    ASSERT_TRUE(user != nullptr);
+    EXPECT_EQ(user->create_bucket(&ndp,                   //dpp
+                              arg_bucket,                 //b
+                              "zg1",                      //zonegroup_id
+                              arg_pl_rule,                //placement_rule
+                              arg_swift_ver_location,     //swift_ver_location
+                              &arg_quota_info,            //pquota_info
+                              arg_aclp,                   //policy
+                              arg_attrs,                  //attrs
+                              arg_info,                   //info
+                              arg_objv,                   //ep_objv
+                              false,                      //exclusive
+                              false,                      //obj_lock_enabled
+                              &existed,                   //existed
+                              arg_req_info,               //req_info
+                              &bucket_from_create,        //bucket
+                              null_yield                  //optional_yield
+                              ),
+          0);
+
+  }
+
+  bool bucketExists(const std::string & bucket_name,
+                    rgw::sal::BucketList & bucket_list) {
+    auto it = bucket_list.get_buckets().find(bucket_name);
+    return it != bucket_list.get_buckets().end();
+  }
+};
+
+void compareUsers(const std::unique_ptr<rgw::sal::SFSUser> & rgw_user,
+                  const DBOPUserInfo & db_user) {
+  compareUsersRGWInfo(rgw_user->get_info(), db_user.uinfo);
+  compareUserAttrs(rgw_user->get_attrs(), db_user.user_attrs);
+  compareUserVersion(rgw_user->get_version_tracker().read_version,
+                     db_user.user_version);
+}
+
+TEST_F(TestSFSUser, ListBuckets) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = store->get_user(arg_user);
+
+
+  // should have 0 buckets now
+  rgw::sal::BucketList bucket_list;
+  EXPECT_EQ(user->list_buckets(&ndp,
+                               "", // marker is ignored atm
+                               "", // end_maker is ignored atm
+                               0,  // max is ignored atm
+                               false, // need_stats is ignored atm
+                               bucket_list,
+                               null_yield),
+            0);
+  EXPECT_EQ(bucket_list.count(), 0);
+
+  // create buckets
+  createBucket("bucket_test_1", "usr_id", store, ceph_context);
+  createBucket("bucket_test_2", "usr_id", store, ceph_context);
+  createBucket("bucket_test_3", "usr_id", store, ceph_context);
+
+  // should have 3 buckets now
+  EXPECT_EQ(user->list_buckets(&ndp,
+                               "", // marker is ignored atm
+                               "", // end_maker is ignored atm
+                               0,  // max is ignored atm
+                               false, // need_stats is ignored atm
+                               bucket_list,
+                               null_yield),
+            0);
+  EXPECT_EQ(bucket_list.count(), 3);
+
+  EXPECT_TRUE(bucketExists("bucket_test_1", bucket_list));
+  EXPECT_TRUE(bucketExists("bucket_test_2", bucket_list));
+  EXPECT_TRUE(bucketExists("bucket_test_3", bucket_list));
+
+  // create a new user
+  createUser("usr_id2", store->db_conn);
+
+  rgw_user arg_user2("", "usr_id2", "");
+  auto user2 = store->get_user(arg_user2);
+  ASSERT_NE(user2, nullptr);
+
+  // user2 has no buckets yet
+  bucket_list.clear();
+  EXPECT_EQ(user2->list_buckets(&ndp,
+                               "", // marker is ignored atm
+                               "", // end_maker is ignored atm
+                               0,  // max is ignored atm
+                               false, // need_stats is ignored atm
+                               bucket_list,
+                               null_yield),
+            0);
+  EXPECT_EQ(bucket_list.count(), 0);
+
+  // create buckets for user2
+  createBucket("bucket_test_2_1", "usr_id2", store, ceph_context);
+  createBucket("bucket_test_2_2", "usr_id2", store, ceph_context);
+
+  // should have 2 buckets now
+  EXPECT_EQ(user2->list_buckets(&ndp,
+                               "", // marker is ignored atm
+                               "", // end_maker is ignored atm
+                               0,  // max is ignored atm
+                               false, // need_stats is ignored atm
+                               bucket_list,
+                               null_yield),
+            0);
+  EXPECT_EQ(bucket_list.count(), 2);
+  EXPECT_TRUE(bucketExists("bucket_test_2_1", bucket_list));
+  EXPECT_TRUE(bucketExists("bucket_test_2_2", bucket_list));
+
+
+  // first user has the same list
+  bucket_list.clear();
+  EXPECT_EQ(user->list_buckets(&ndp,
+                               "", // marker is ignored atm
+                               "", // end_maker is ignored atm
+                               0,  // max is ignored atm
+                               false, // need_stats is ignored atm
+                               bucket_list,
+                               null_yield),
+            0);
+  EXPECT_EQ(bucket_list.count(), 3);
+
+  EXPECT_TRUE(bucketExists("bucket_test_1", bucket_list));
+  EXPECT_TRUE(bucketExists("bucket_test_2", bucket_list));
+  EXPECT_TRUE(bucketExists("bucket_test_3", bucket_list));
+}
+
+TEST_F(TestSFSUser, LoadUser) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  createUser("usr_id", store->db_conn);
+
+  // get info from sqlite
+  rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(store->db_conn);
+  auto db_user = sqlite_users.get_user("usr_id");
+  ASSERT_TRUE(db_user.has_value());
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = std::make_unique<rgw::sal::SFSUser>(arg_user, store);
+
+  // it's empty now
+  ASSERT_EQ(user->get_info().access_keys.size(), 0);
+
+  // load data
+  EXPECT_EQ(user->load_user(&ndp, null_yield), 0);
+
+  compareUsers(user, *db_user);
+}
+
+TEST_F(TestSFSUser, LoadUserDoesNotExist) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id_does_not_exist", "");
+  auto user = std::make_unique<rgw::sal::SFSUser>(arg_user, store);
+  EXPECT_EQ(user->load_user(&ndp, null_yield), -ENOENT);
+}
+
+TEST_F(TestSFSUser, StoreUser) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  createUser("usr_id", store->db_conn);
+
+  // get info from sqlite
+  rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(store->db_conn);
+  auto db_user = sqlite_users.get_user("usr_id");
+  ASSERT_TRUE(db_user.has_value());
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = std::make_unique<rgw::sal::SFSUser>(arg_user, store);
+
+  // load data of user
+  EXPECT_EQ(user->load_user(&ndp, null_yield), 0);
+
+  RGWUserInfo old_info_before_changes = user->get_info();
+  std::map<std::string, RGWAccessKey> access_keys;
+  access_keys["key1"] = RGWAccessKey("key1", "secret1");
+  access_keys["key2"] = RGWAccessKey("key2", "secret2");
+
+  user->get_info().access_keys = access_keys;
+
+  RGWUserInfo old_info;
+  EXPECT_EQ(user->store_user(&ndp, null_yield, false, &old_info), 0);
+
+  // reload info
+  EXPECT_EQ(user->load_user(&ndp, null_yield), 0);
+
+  // version should be increased by 1
+  EXPECT_EQ(user->get_version_tracker().read_version.ver,
+            db_user->user_version.ver + 1);
+
+  ASSERT_TRUE(compareMaps(user->get_info().access_keys, access_keys));
+
+  // old info obtained in store should match what sqlite had before
+  compareUsersRGWInfo(old_info, old_info_before_changes);
+}
+
+TEST_F(TestSFSUser, StoreUserVersionMismatch) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = std::make_unique<rgw::sal::SFSUser>(arg_user, store);
+  EXPECT_EQ(user->load_user(&ndp, null_yield), 0);
+
+  // change the version so it does not match when storing
+  user->get_version_tracker().read_version.ver = 1999;
+
+  RGWUserInfo old_info;
+  EXPECT_EQ(user->store_user(&ndp, null_yield, false, &old_info), -ECANCELED);
+}
+
+TEST_F(TestSFSUser, RemoveUser) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  createUser("usr_id", store->db_conn);
+
+  rgw_user arg_user("", "usr_id", "");
+  auto user = std::make_unique<rgw::sal::SFSUser>(arg_user, store);
+  EXPECT_EQ(user->load_user(&ndp, null_yield), 0);
+  EXPECT_EQ(user->remove_user(&ndp, null_yield), 0);
+  // try to remove again
+  EXPECT_EQ(user->remove_user(&ndp, null_yield), -ECANCELED);
+
+  // user is removed from metadata
+  rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(store->db_conn);
+  auto db_user = sqlite_users.get_user("usr_id");
+  ASSERT_FALSE(db_user.has_value());
+}

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -7,6 +7,7 @@
 #include "rgw/store/sfs/sqlite/users/users_conversions.h"
 
 #include "rgw/rgw_sal_sfs.h"
+#include "rgw_sfs_utils.h"
 
 #include <filesystem>
 #include <gtest/gtest.h>
@@ -44,84 +45,6 @@ protected:
     return getDBFullPath(getTestDir());
   }
 };
-
-template <typename T>
-bool compare(const T & origin, const T & dest) {
-  return origin == dest;
-}
-
-bool compare(const RGWAccessKey & origin, const RGWAccessKey & dest) {
-  if (origin.id != dest.id) return false;
-  if (origin.key != dest.key) return false;
-  if (origin.subuser != dest.subuser) return false;
-  return true;
-}
-
-bool compare(const RGWSubUser & origin, const RGWSubUser & dest) {
-  if (origin.name != dest.name) return false;
-  if (origin.perm_mask != dest.perm_mask) return false;
-  return true;
-}
-
-template <typename T>
-bool compareMaps(const T & origin, const T & dest) {
-  if (origin.size() != dest.size()) return false;
-  for (auto const& [key, val] : origin)
-  {
-    if (dest.find(key) == dest.end()) return false;
-    auto & dest_val = dest.at(key);
-    if (!compare(val, dest_val)) return false;
-  }
-  return true;
-}
-
-std::string getCapsString(const RGWUserCaps & caps) {
-  auto formatter = std::make_unique<ceph::JSONFormatter>(new ceph::JSONFormatter(true));
-  encode_json("caps", caps, formatter.get());
-  std::ostringstream oss;
-  formatter->flush(oss);
-  return oss.str();
-}
-
-void compareUsersRGWInfo(const RGWUserInfo & origin, const RGWUserInfo & dest) {
-  ASSERT_EQ(origin.user_id.id, dest.user_id.id);
-  ASSERT_EQ(origin.user_id.tenant, dest.user_id.tenant);
-  ASSERT_EQ(origin.user_id.ns, dest.user_id.ns);
-  ASSERT_EQ(origin.display_name, dest.display_name);
-  ASSERT_EQ(origin.user_email, dest.user_email);
-  ASSERT_TRUE(compareMaps(origin.access_keys, dest.access_keys));
-  ASSERT_TRUE(compareMaps(origin.swift_keys, dest.swift_keys));
-  ASSERT_TRUE(compareMaps(origin.subusers, dest.subusers));
-  ASSERT_EQ(origin.suspended, dest.suspended);
-  ASSERT_EQ(origin.max_buckets, dest.max_buckets);
-  ASSERT_EQ(origin.op_mask, dest.op_mask);
-  ASSERT_EQ(getCapsString(origin.caps), getCapsString(dest.caps));
-  ASSERT_EQ(origin.system, dest.system);
-  ASSERT_EQ(origin.default_placement.name, dest.default_placement.name);
-  ASSERT_EQ(origin.default_placement.storage_class, dest.default_placement.storage_class);
-  ASSERT_EQ(origin.placement_tags, dest.placement_tags);
-  ASSERT_EQ(origin.quota.bucket_quota.max_size, dest.quota.bucket_quota.max_size);
-  ASSERT_EQ(origin.quota.bucket_quota.max_objects, dest.quota.bucket_quota.max_objects);
-  ASSERT_EQ(origin.quota.bucket_quota.enabled, dest.quota.bucket_quota.enabled);
-  ASSERT_EQ(origin.quota.bucket_quota.check_on_raw, dest.quota.bucket_quota.check_on_raw);
-  ASSERT_TRUE(compareMaps(origin.temp_url_keys, dest.temp_url_keys));
-  ASSERT_EQ(origin.quota.user_quota.max_size, dest.quota.user_quota.max_size);
-  ASSERT_EQ(origin.quota.user_quota.max_objects, dest.quota.user_quota.max_objects);
-  ASSERT_EQ(origin.quota.user_quota.enabled, dest.quota.user_quota.enabled);
-  ASSERT_EQ(origin.quota.user_quota.check_on_raw, dest.quota.user_quota.check_on_raw);
-  ASSERT_EQ(origin.type, dest.type);
-  ASSERT_EQ(origin.mfa_ids, dest.mfa_ids);
-  ASSERT_EQ(origin.assumed_role_arn, dest.assumed_role_arn);
-}
-
-void compareUserAttrs(const rgw::sal::Attrs & origin, const rgw::sal::Attrs & dest) {
-  ASSERT_TRUE(compareMaps(origin, dest));
-}
-
-void compareUserVersion(const obj_version & origin, const obj_version & dest) {
-  ASSERT_EQ(origin.ver, dest.ver);
-  ASSERT_EQ(origin.tag, dest.tag);
-}
 
 void compareUsers(const DBOPUserInfo & origin, const DBOPUserInfo & dest) {
   compareUsersRGWInfo(origin.uinfo, dest.uinfo);


### PR DESCRIPTION
Returns only the buckets owned by the SFSUser being called.

It also includes SFSUser tests.

This fix also affects the REST API user tests, as it fixes an issue in which the test fails if the store has any bucket.

Fixes: https://github.com/aquarist-labs/s3gw/issues/33
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
