### PR TITLE
rgw/sfs: Get user by access_key when user has multiple keys

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed queries to users by access key when user has multiple keys.
 ## [0.6.0] - 2022-09-29
 
 ### Added

--- a/src/rgw/store/sfs/sqlite/dbconn.h
+++ b/src/rgw/store/sfs/sqlite/dbconn.h
@@ -31,6 +31,7 @@ constexpr std::string_view USERS_TABLE = "users";
 constexpr std::string_view BUCKETS_TABLE = "buckets";
 constexpr std::string_view OBJECTS_TABLE = "objects";
 constexpr std::string_view VERSIONED_OBJECTS_TABLE = "versioned_objects";
+constexpr std::string_view ACCESS_KEYS = "access_keys";
 
 
 inline auto _make_storage(const std::string &path) {
@@ -41,8 +42,6 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("ns", &DBUser::ns),
           sqlite_orm::make_column("display_name", &DBUser::display_name),
           sqlite_orm::make_column("user_email", &DBUser::user_email),
-          sqlite_orm::make_column("access_keys_id", &DBUser::access_keys_id),
-          sqlite_orm::make_column("access_keys_secret", &DBUser::access_keys_secret),
           sqlite_orm::make_column("access_keys", &DBUser::access_keys),
           sqlite_orm::make_column("swift_keys", &DBUser::swift_keys),
           sqlite_orm::make_column("sub_users", &DBUser::sub_users),
@@ -101,7 +100,12 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("object_state", &DBVersionedObject::object_state),
           sqlite_orm::make_column("version_id", &DBVersionedObject::version_id),
           sqlite_orm::make_column("etag", &DBVersionedObject::etag),
-          sqlite_orm::foreign_key(&DBVersionedObject::object_id).references(&DBObject::object_id))
+          sqlite_orm::foreign_key(&DBVersionedObject::object_id).references(&DBObject::object_id)),
+    sqlite_orm::make_table(std::string(ACCESS_KEYS),
+          sqlite_orm::make_column("id", &DBAccessKey::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("access_key", &DBAccessKey::access_key),
+          sqlite_orm::make_column("user_id", &DBAccessKey::user_id),
+          sqlite_orm::foreign_key(&DBAccessKey::user_id).references(&DBUser::user_id))
   );  
 }
 

--- a/src/rgw/store/sfs/sqlite/sqlite_users.cc
+++ b/src/rgw/store/sfs/sqlite/sqlite_users.cc
@@ -44,10 +44,14 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_email(const std::string & e
 }
 
 std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(const std::string & key) const {
-  auto users = get_users_by(where(c(&DBUser::access_keys_id) = key));
+  auto user_id = get_user_id_by_access_key(key);
   std::optional<DBOPUserInfo> ret_value;
-  if (users.size()) {
-    ret_value = users[0];
+  if (user_id.has_value()) {
+    auto storage = conn->get_storage();
+    auto user = storage.get_pointer<DBUser>(user_id);
+    if (user) {
+      ret_value = get_rgw_user(*user);
+    }
   }
   return ret_value;
 }
@@ -63,11 +67,13 @@ void SQLiteUsers::store_user(const DBOPUserInfo & user) const {
   auto storage = conn->get_storage();
   auto db_user = get_db_user(user);
   storage.replace(db_user);
+  store_access_keys(user);
 }
 
 void SQLiteUsers::remove_user(const std::string & userid) const {
   std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
+  remove_access_keys(userid);
   storage.remove<DBUser>(userid);
 }
 
@@ -81,6 +87,36 @@ std::vector<DBOPUserInfo> SQLiteUsers::get_users_by(Args... args) const {
     users_return.push_back(get_rgw_user(user));
   }
   return users_return;
+}
+
+void SQLiteUsers::store_access_keys(const DBOPUserInfo & user) const {
+  auto storage = conn->get_storage();
+  // remove existing keys for the user (in case any of them had changed)
+  remove_access_keys(user.uinfo.user_id.id);
+  for (auto const& key: user.uinfo.access_keys) {
+    DBAccessKey db_key;
+    db_key.access_key = key.first;
+    db_key.user_id = user.uinfo.user_id.id;
+    storage.insert(db_key);
+  }
+}
+
+void SQLiteUsers::remove_access_keys(const std::string & userid) const {
+  auto storage = conn->get_storage();
+  storage.remove_all<DBAccessKey>(where(c(&DBAccessKey::user_id) = userid));
+}
+
+std::optional<std::string> SQLiteUsers::get_user_id_by_access_key(
+                                              const std::string & key) const {
+  auto storage = conn->get_storage();
+  auto keys = storage.get_all<DBAccessKey>(where(c(&DBAccessKey::access_key) = key));
+  std::optional<std::string> ret_value;
+  if (keys.size() > 0) {
+    // in case we have 2 keys that are equal in different users we return
+    // the first one.
+    ret_value = keys[0].user_id;
+  }
+  return ret_value;
 }
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/sqlite/sqlite_users.h
+++ b/src/rgw/store/sfs/sqlite/sqlite_users.h
@@ -38,6 +38,10 @@ class SQLiteUsers {
  private:
   template<class... Args>
   std::vector<DBOPUserInfo> get_users_by(Args... args) const;
+
+  void store_access_keys(const DBOPUserInfo & user) const;
+  void remove_access_keys(const std::string & userid) const;
+  std::optional<std::string> get_user_id_by_access_key(const std::string & key) const;
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/sqlite/users/users_conversions.cc
+++ b/src/rgw/store/sfs/sqlite/users/users_conversions.cc
@@ -55,12 +55,6 @@ DBUser get_db_user(const DBOPUserInfo & user) {
   assign_db_value(user.uinfo.user_id.ns, db_user.ns);
   assign_db_value(user.uinfo.display_name, db_user.display_name);
   assign_db_value(user.uinfo.user_email, db_user.user_email);
-  if (!user.uinfo.access_keys.empty()) {
-    auto it = user.uinfo.access_keys.begin();
-    const auto& k = it->second;
-    assign_db_value(k.id, db_user.access_keys_id);
-    assign_db_value(k.key, db_user.access_keys_secret);
-  }
   assign_db_value(user.uinfo.access_keys, db_user.access_keys);
   assign_db_value(user.uinfo.swift_keys, db_user.swift_keys);
   assign_db_value(user.uinfo.subusers, db_user.sub_users);

--- a/src/rgw/store/sfs/sqlite/users/users_definitions.h
+++ b/src/rgw/store/sfs/sqlite/users/users_definitions.h
@@ -31,8 +31,6 @@ struct DBUser {
   std::optional<std::string> ns;
   std::optional<std::string> display_name;
   std::optional<std::string> user_email;
-  std::optional<std::string> access_keys_id;
-  std::optional<std::string> access_keys_secret;
   std::optional<BLOB> access_keys;
   std::optional<BLOB> swift_keys;
   std::optional<BLOB> sub_users;
@@ -54,6 +52,16 @@ struct DBUser {
   std::optional<BLOB> user_attrs;
   std::optional<int> user_version;
   std::optional<std::string> user_version_tag;
+};
+
+// access keys are stored in a different table because a user could have more
+// than one key and we need to be able to query by all of them.
+// Keys are stored as a blob in the user, so this table is only used for the
+// purpose of getting the user id based on the access key.
+struct DBAccessKey {
+  int id;
+  std::string access_key;
+  std::string user_id;
 };
 
 // Struct with information needed by SAL layer

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -136,8 +136,8 @@ DBOPUserInfo createTestUser(const std::string & suffix) {
   user.uinfo.user_id.ns = "NS" + suffix;
   user.uinfo.display_name = "DisplayName1" + suffix;
   user.uinfo.user_email = "user" + suffix + "@test.com";
-  user.uinfo.access_keys["key1"] = RGWAccessKey("key1_" + suffix, "secret1");
-  user.uinfo.access_keys["key2"] = RGWAccessKey("key2_" + suffix, "secret2");
+  user.uinfo.access_keys["key1_" + suffix] = RGWAccessKey("key1_" + suffix, "secret1");
+  user.uinfo.access_keys["key2_" + suffix] = RGWAccessKey("key2_" + suffix, "secret2");
   user.uinfo.swift_keys["swift_key_1"] = RGWAccessKey("swift_key1_" + suffix, "swift_secret1");
   RGWSubUser subuser;
   subuser.name = "subuser1";
@@ -682,4 +682,32 @@ TEST_F(TestSFSSQLiteUsers, StoreRemoveUser) {
                                   std::make_move_iterator(userIds.end()) };
   ASSERT_EQ(users_after_remove_vector[0], "test1");
   ASSERT_EQ(users_after_remove_vector[1], "test3");
+}
+
+TEST_F(TestSFSSQLiteUsers, GetByAccessKeyMultipleKeys) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+
+  auto db_users = std::make_shared<SQLiteUsers>(conn);
+  auto user = createTestUser("1");
+  // add extra key
+  user.uinfo.access_keys["key3"] = RGWAccessKey("key3", "secret3");
+
+  db_users->store_user(user);
+  EXPECT_TRUE(fs::exists(getDBFullPath()));
+
+  auto ret_user = db_users->get_user_by_access_key("key1_1");
+  ASSERT_TRUE(ret_user.has_value());
+  compareUsers(user, *ret_user);
+
+  ret_user = db_users->get_user_by_access_key("key2_1");
+  ASSERT_TRUE(ret_user.has_value());
+  compareUsers(user, *ret_user);
+
+  ret_user = db_users->get_user_by_access_key("key3");
+  ASSERT_TRUE(ret_user.has_value());
+  compareUsers(user, *ret_user);
 }


### PR DESCRIPTION
Added a new table in sqlite's metadata to store the access keys related to a user.
That way, when querying by access key we query first that table to obtain the user id.

Could not implement in the user table itself because access keys are stored in a blob and we'd need to first decode the blob in order to query by access key.

Removed the helper columns in users table for access keys as it was only supporting the first key and it's no longer used.

Fixes: https://github.com/aquarist-labs/s3gw/issues/83
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
