### PR TITLE
rgw/sfs: fix circular lock dependency

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 ### Fixed
 
 - Fixed queries to users by access key when user has multiple keys.
+- Fixed a circular lock dependency, which could lead to a deadlock when aborting
+  multiparts for an object while finishing a different object.
+
 ## [0.6.0] - 2022-09-29
 
 ### Added

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -388,7 +388,8 @@ class Bucket {
   }
 
   void finish_multipart(const std::string &upload_id, ObjectRef objref) {
-    std::lock_guard l(multipart_map_lock);
+    std::lock_guard l1(obj_map_lock);
+    std::lock_guard l2(multipart_map_lock);
 
     auto it = multiparts.find(upload_id);
     ceph_assert(it != multiparts.end());
@@ -397,7 +398,7 @@ class Bucket {
     multiparts.erase(it);
 
     objref->metadata_finish(store);
-    finish(nullptr, objref->name);
+    _finish_object(objref);
   }
 
   std::string gen_multipart_upload_id() {


### PR DESCRIPTION
Because we were obtaining `obj_map_lock` (through `Bucket::finish()`) after acquiring `multipart_map_lock`, we introduced a circular dependency with `Bucket::abort_multiparts()`.

By ensuring we acquire the locks in the intended order (`obj_map_lock` first, then `multipart_part_lock`), matching the other function, we avoid getting stuck in a deadlock situation.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>