### PR TITLE
rgw/sfs: ensure sqlite user ops hold required locks

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 - Fixed queries to users by access key when user has multiple keys.
 - Fixed a circular lock dependency, which could lead to a deadlock when aborting
   multiparts for an object while finishing a different object.
+- Fixed a few SQLite users operations that did not acquire the required locks
+  when accessing the database.
 
 ## [0.6.0] - 2022-09-29
 

--- a/src/rgw/store/sfs/sqlite/sqlite_users.h
+++ b/src/rgw/store/sfs/sqlite/sqlite_users.h
@@ -39,9 +39,18 @@ class SQLiteUsers {
   template<class... Args>
   std::vector<DBOPUserInfo> get_users_by(Args... args) const;
 
-  void store_access_keys(const DBOPUserInfo & user) const;
-  void remove_access_keys(const std::string & userid) const;
-  std::optional<std::string> get_user_id_by_access_key(const std::string & key) const;
+  void _store_access_keys(
+    rgw::sal::sfs::sqlite::Storage storage,
+    const DBOPUserInfo & user
+  ) const;
+  void _remove_access_keys(
+    rgw::sal::sfs::sqlite::Storage storage,
+    const std::string & userid
+  ) const;
+  std::optional<std::string> _get_user_id_by_access_key(
+    rgw::sal::sfs::sqlite::Storage storage,
+    const std::string & key
+  ) const;
 };
 
 }  // namespace rgw::sal::sfs::sqlite


### PR DESCRIPTION
A few user operations were not acquiring the connection lock, either at
all or at some stage of their execution. This was leading to operations
failing/asserting because the database would be locked by a concurrent
operation.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>