### PR TITLE
Status Page Frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ if(NOT CMAKE_BUILD_TYPE AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
       STRING "Default BUILD_TYPE is Debug, other options are: RelWithDebInfo, Release, and MinSizeRel." FORCE)
 endif()
 
+add_compile_definitions(FMT_DEPRECATED_OSTREAM=1)
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LINUX ON)
   FIND_PACKAGE(Threads)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -354,7 +354,9 @@ set(rgw_schedulers_srcs
 set(radosgw_srcs
   rgw_loadgen_process.cc
   rgw_asio_client.cc
-  rgw_asio_frontend.cc)
+  rgw_asio_frontend.cc
+  rgw_status_frontend.cc
+  rgw_status_page.cc)
 
 add_library(rgw_schedulers STATIC ${rgw_schedulers_srcs})
 target_link_libraries(rgw_schedulers

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -683,6 +683,10 @@ int radosgw_Main(int argc, const char **argv)
 
       RGWStatusFrontend* stat = new RGWStatusFrontend(env, config, cct->get());
       stat->register_status_page(std::make_unique<PerfCounterStatusPage>(cct->get_perfcounters_collection()));
+      if (store->get_name() == "sfs") {
+	auto sfs = dynamic_cast<rgw::sal::SFStore*>(store);
+	stat->register_status_page(sfs->make_status_page());
+      }
       fe = stat;
     }
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 #include <boost/intrusive/list.hpp>
+#include <memory>
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "global/signal_handler.h"
@@ -33,6 +34,7 @@
 #include "rgw_rest_realm.h"
 #include "rgw_rest_sts.h"
 #include "rgw_rest_ratelimit.h"
+#include "rgw_sal_sfs.h"
 #include "rgw_swift_auth.h"
 #include "rgw_log.h"
 #include "rgw_tools.h"
@@ -51,6 +53,7 @@
 #include "rgw_kafka.h"
 #endif
 #include "rgw_asio_frontend.h"
+#include "rgw_status_frontend.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 #ifdef WITH_RADOSGW_LUA_PACKAGES
 #include "rgw_lua.h"
@@ -669,6 +672,18 @@ int radosgw_Main(int argc, const char **argv)
       RGWProcessEnv env{ store, &rest, olog, port, uri_prefix, 
                          auth_registry, &ratelimiting, lua_background.get()};
       fe = new RGWAsioFrontend(env, config, sched_ctx);
+    }
+    else if (framework == "status") {
+      int port;
+      config->get_val("port", 80, &port);
+      std::string uri_prefix;
+      config->get_val("prefix", "", &uri_prefix);
+      RGWProcessEnv env{ store, &rest, olog, port, uri_prefix,
+                         auth_registry, &ratelimiting, lua_background.get()};
+
+      RGWStatusFrontend* stat = new RGWStatusFrontend(env, config, cct->get());
+      stat->register_status_page(std::make_unique<PerfCounterStatusPage>(cct->get_perfcounters_collection()));
+      fe = stat;
     }
 
     service_map_meta["frontend_type#" + stringify(fe_count)] = framework;

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -23,6 +23,7 @@
 
 #include "cls/rgw/cls_rgw_client.h"
 #include "common/Clock.h"
+#include "common/ceph_mutex.h"
 #include "common/errno.h"
 #include "rgw_acl_s3.h"
 #include "rgw_aio.h"
@@ -42,6 +43,7 @@
 #include "services/svc_zone.h"
 #include "services/svc_zone_utils.h"
 
+#include "sqlite/dbconn.h"
 #include "store/sfs/notification.h"
 #include "store/sfs/writer.h"
 
@@ -371,6 +373,65 @@ int SFStore::log_op(const DoutPrefixProvider *dpp, string &oid,
                             bufferlist &bl) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return 0;
+}
+
+// }}}
+
+// Status Page  {{{
+SFSStatusPage::SFSStatusPage(SFStore *store) : sfs(store) {
+}
+
+SFSStatusPage::~SFSStatusPage() {
+}
+
+http::status SFSStatusPage::render(std::ostream &os) {
+  os << "<h1>SFS</h1>\n"
+     << "<h2>Locks</h2>\n"
+     << "<ul>\n";
+
+  os << "<li>buckets_map: "
+     << " locked=" << ceph_mutex_is_locked(sfs->buckets_map_lock) << "</li>\n";
+  os << "</ul>\n";
+
+
+  auto db = sfs->db_conn->get_storage();
+  sqlite3* sqlite_db = sfs->db_conn->sqlite_db;
+
+  os << "<h2>SQLite</h2>\n"
+     << "<ul>\n"
+     << "<li> filename: " << db.filename() << "</li>\n"
+     << "<li> libversion: " << db.libversion() << "</li>\n"
+     << "<li> total_changes: " << db.total_changes() << "</li>\n";
+
+  int current;
+  int highwater;
+  // db stats
+  sqlite3_db_status(sqlite_db, SQLITE_DBSTATUS_CACHE_USED, &current, &highwater, false);
+  os << "<li> cache_used: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_db_status(sqlite_db, SQLITE_DBSTATUS_CACHE_HIT, &current, &highwater, false);
+  os << "<li> cache_hit: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_db_status(sqlite_db, SQLITE_DBSTATUS_CACHE_MISS, &current, &highwater, false);
+  os << "<li> cache_miss: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_db_status(sqlite_db, SQLITE_DBSTATUS_CACHE_USED_SHARED, &current, &highwater, false);
+  os << "<li> cache_used_shared: " << current << " (high: " << highwater << ")</li>\n";
+
+  // sqlite stats
+  sqlite3_status(SQLITE_STATUS_MEMORY_USED, &current, &highwater, false);
+  os << "<li> mem_used: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_status(SQLITE_STATUS_PAGECACHE_USED, &current, &highwater, false);
+  os << "<li> pagecache_used: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_status(SQLITE_STATUS_PAGECACHE_SIZE, &current, &highwater, false);
+  os << "<li> pagecache_size: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_status(SQLITE_STATUS_PAGECACHE_OVERFLOW, &current, &highwater, false);
+  os << "<li> pagecache_overflow: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_status(SQLITE_STATUS_MALLOC_SIZE, &current, &highwater, false);
+  os << "<li> malloc_size: " << current << " (high: " << highwater << ")</li>\n";
+  sqlite3_status(SQLITE_STATUS_MALLOC_COUNT, &current, &highwater, false);
+  os << "<li> malloc_count: " << current << " (high: " << highwater << ")</li>\n";
+
+  os << "</ul>";
+
+  return boost::beast::http::status::ok;
 }
 
 // }}}

--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -26,6 +26,7 @@
 #include "rgw_role.h"
 #include "rgw_sal.h"
 
+#include "rgw_status_page.h"
 #include "store/sfs/types.h"
 #include "store/sfs/user.h"
 #include "store/sfs/bucket.h"
@@ -67,6 +68,25 @@ class UnsupportedLuaScriptManager : public LuaScriptManager {
   }
 };
 
+class SFSStatusPage : public StatusPage {
+ private:
+  SFStore *sfs;
+
+ public:
+  SFSStatusPage(SFStore *store);
+  ~SFSStatusPage() override;
+  std::string name() const override {
+    return "SFS";
+  };
+  std::string prefix() const override {
+    return "/sfs";
+  };
+  std::string content_type() const override {
+    return "text/html";
+  };
+  http::status render(std::ostream &os) override;
+};
+
 class SFStore : public Store {
  private:
   RGWSyncModuleInstanceRef sync_module;
@@ -91,6 +111,10 @@ class SFStore : public Store {
   ) override;
   virtual void finalize(void) override;
   void maybe_init_store();
+
+  std::unique_ptr<StatusPage> make_status_page() {
+    return std::make_unique<SFSStatusPage>(this);
+  }
 
   virtual const std::string get_name() const override { return "sfs"; }
 
@@ -427,6 +451,10 @@ class SFStore : public Store {
   }
 
   std::string get_cls_name() const { return "sfstore"; }
+
+
+
+  friend class SFSStatusPage;
 };
 
 }  // namespace rgw::sal

--- a/src/rgw/rgw_status_frontend.cc
+++ b/src/rgw/rgw_status_frontend.cc
@@ -1,0 +1,205 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=2 sw=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2022 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#include "rgw_status_frontend.h"
+
+#include <boost/asio/ip/address.hpp>
+#include <cstdlib>
+
+#include "common/debug.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_collection.h"
+#include "rgw_asio_frontend.h"
+#include "rgw_sal_sfs.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+StatusHttpConnection::StatusHttpConnection(
+    tcp::socket socket,
+    const std::vector<std::unique_ptr<StatusPage>>& status_pages)
+    : socket_(std::move(socket)), status_pages(status_pages) {
+}
+
+void StatusHttpConnection::start() {
+  read_request();
+  check_deadline();
+}
+
+void StatusHttpConnection::read_request() {
+  auto self = shared_from_this();
+
+  http::async_read(socket_, buffer_, request_,
+                   [self](beast::error_code ec, std::size_t bytes_transferred) {
+                     boost::ignore_unused(bytes_transferred);
+                     if (!ec) self->process_request();
+                   });
+}
+
+void StatusHttpConnection::process_request() {
+  response_.version(request_.version());
+  response_.keep_alive(false);
+
+  switch (request_.method()) {
+    case http::verb::get:
+      response_.result(http::status::ok);
+      response_.set(http::field::server, "RGW Status");
+      create_response();
+      break;
+
+    default:
+      response_.result(http::status::bad_request);
+      response_.set(http::field::content_type, "text/plain");
+      beast::ostream(response_.body())
+          << "Invalid request-method '" << std::string(request_.method_string())
+          << "'";
+      break;
+  }
+  write_response();
+}
+
+void StatusHttpConnection::check_deadline() {
+  auto self = shared_from_this();
+
+  deadline_.async_wait([self](beast::error_code ec) {
+    if (!ec) {
+      self->socket_.close(ec);
+    }
+  });
+}
+
+void StatusHttpConnection::write_response() {
+  auto self = shared_from_this();
+
+  response_.content_length(response_.body().size());
+
+  http::async_write(socket_, response_,
+                    [self](beast::error_code ec, std::size_t) {
+                      self->socket_.shutdown(tcp::socket::shutdown_send, ec);
+                      self->deadline_.cancel();
+                    });
+}
+
+static void render_html_header(std::ostream& os) {
+  os << "<html>\n"
+     << "<head><title>RGW Status</title></head>\n"
+     << "<body>\n";
+}
+
+static void render_html_footer(std::ostream& os) {
+  os << "</body>\n"
+     << "</html>\n";
+}
+
+void StatusHttpConnection::create_response() {
+  auto os = beast::ostream(response_.body());
+
+  if (request_.target() == "/") {
+    response_.set(http::field::content_type, "text/html");
+    render_html_header(os);
+    os << "<h1>RGW Status Page Index</h1>\n"
+       << "<ul>\n";
+    for (const auto& status_page : status_pages) {
+      os << "<li><a href=\"" << status_page->prefix() << "\">"
+         << status_page->name() << "</a></li>\n";
+    }
+    os << "</ul>";
+    render_html_footer(os);
+  } else {
+    for (const auto& status_page : status_pages) {
+      if (status_page->prefix() == request_.target()) {
+        response_.set(http::field::content_type, status_page->content_type());
+        if (status_page->content_type() == "text/html") {
+          render_html_header(os);
+        }
+        response_.result(status_page->render(os));
+        if (status_page->content_type() == "text/html") {
+          render_html_footer(os);
+        }
+        return;
+      }
+    }
+    response_.result(http::status::not_found);
+    response_.set(http::field::content_type, "text/plain");
+    os << "File not found\r\n";
+  }
+}
+
+RGWStatusFrontend::RGWStatusFrontend(const RGWProcessEnv& env,
+                                     RGWFrontendConfig* conf, CephContext* cct)
+    : env(env),
+      conf(conf),
+      cct(cct),
+      ioc(1),
+      acceptor(ioc, {net::ip::make_address("127.0.0.1"), 9999}),
+      socket(ioc),
+      server_thread(this) {
+}
+RGWStatusFrontend::~RGWStatusFrontend() {
+}
+
+void http_server(tcp::acceptor& acceptor, tcp::socket& socket,
+                 const std::vector<std::unique_ptr<StatusPage>>& status_pages) {
+  acceptor.async_accept(socket, [&](beast::error_code ec) {
+    if (!ec)
+      std::make_shared<StatusHttpConnection>(std::move(socket), status_pages)
+          ->start();
+    http_server(acceptor, socket, status_pages);
+  });
+}
+
+int RGWStatusFrontend::init() {
+  try {
+    http_server(acceptor, socket, get_status_pages());
+  } catch (std::exception const& e) {
+    ldout(cct, 0) << "Error: " << e.what() << dendl;
+    return -1;
+  }
+  return 0;
+}
+
+void *RGWStatusFrontend::StatusServerThread::entry() {
+  frontend->ioc.run();
+  return nullptr;
+}
+
+int RGWStatusFrontend::run() {
+  server_thread.create("status-server");
+  return 0;
+}
+
+void RGWStatusFrontend::stop() {
+  ioc.stop();
+}
+
+void RGWStatusFrontend::join() {
+  server_thread.join(nullptr);
+}
+
+void RGWStatusFrontend::pause_for_new_config() {
+}
+
+void RGWStatusFrontend::unpause_with_new_config(
+    rgw::sal::Store* store, rgw_auth_registry_ptr_t auth_registry) {
+}
+
+void RGWStatusFrontend::register_status_page(
+    std::unique_ptr<StatusPage> status_page) {
+  status_pages.emplace_back(std::move(status_page));
+}
+
+const std::vector<std::unique_ptr<StatusPage>>&
+RGWStatusFrontend::get_status_pages() const {
+  return status_pages;
+}

--- a/src/rgw/rgw_status_frontend.h
+++ b/src/rgw/rgw_status_frontend.h
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=2 sw=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2022 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#ifndef RGW_STATUS_FRONTEND_H
+#define RGW_STATUS_FRONTEND_H
+
+#include <boost/asio.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/http/status.hpp>
+#include <boost/beast/version.hpp>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rgw_frontend.h"
+#include "rgw_status_page.h"
+
+namespace beast = boost::beast;    // from <boost/beast.hpp>
+namespace http = beast::http;      // from <boost/beast/http.hpp>
+namespace net = boost::asio;       // from <boost/asio.hpp>
+using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
+
+class StatusPage;
+
+class StatusHttpConnection
+    : public std::enable_shared_from_this<StatusHttpConnection> {
+ public:
+  StatusHttpConnection(
+      tcp::socket socket,
+      const std::vector<std::unique_ptr<StatusPage>>& status_pages);
+  void start();
+
+ private:
+  tcp::socket socket_;
+  beast::flat_buffer buffer_{8192};
+  http::request<http::dynamic_body> request_;
+  http::response<http::dynamic_body> response_;
+  net::steady_timer deadline_{socket_.get_executor(), std::chrono::seconds(60)};
+  const std::vector<std::unique_ptr<StatusPage>>& status_pages;
+
+  void read_request();
+  void process_request();
+  void write_response();
+  void create_response();
+  void check_deadline();
+};
+
+class RGWStatusFrontend : public RGWFrontend {
+ private:
+  const RGWProcessEnv& env;
+  RGWFrontendConfig* conf;
+  CephContext* cct;
+
+  net::io_context ioc;
+  tcp::acceptor acceptor;
+  tcp::socket socket;
+
+  std::vector<std::unique_ptr<StatusPage>> status_pages;
+
+  class StatusServerThread : public Thread {
+   private:
+    RGWStatusFrontend* frontend;
+    void *entry() override;
+   public:
+    StatusServerThread(RGWStatusFrontend* frontend) : frontend(frontend) {};
+  } server_thread;
+
+  public : RGWStatusFrontend(const RGWProcessEnv& env, RGWFrontendConfig* conf,
+                             CephContext* cct);
+  ~RGWStatusFrontend() override;
+
+  int init() override;
+  int run() override;
+  void stop() override;
+  void join() override;
+
+  void register_status_page(std::unique_ptr<StatusPage> status_page);
+  const std::vector<std::unique_ptr<StatusPage>>& get_status_pages() const;
+
+  void pause_for_new_config() override;
+  void unpause_with_new_config(rgw::sal::Store* store,
+                               rgw_auth_registry_ptr_t auth_registry) override;
+
+  friend class StatusServerThread;
+};
+
+#endif  // RGW_STATUS_FRONTEND_H

--- a/src/rgw/rgw_status_page.cc
+++ b/src/rgw/rgw_status_page.cc
@@ -1,0 +1,164 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=2 sw=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2022 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw_status_page.h"
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <chrono>
+
+#include "common/Formatter.h"
+#include "common/perf_counters.h"
+
+using namespace fmt::literals;
+
+PerfCounterStatusPage::PerfCounterStatusPage(
+    const PerfCountersCollection* perf_counters)
+    : perf_counters(perf_counters) {
+}
+
+PerfCounterStatusPage::~PerfCounterStatusPage() {
+}
+
+constexpr const char* metric_type(perfcounter_type_d type) {
+  if (type & PERFCOUNTER_COUNTER) {
+    return "counter";
+  } else {
+    return "gauge";
+  }
+}
+
+constexpr bool is_histogram(perfcounter_type_d type) {
+  return (type & PERFCOUNTER_HISTOGRAM) != 0;
+}
+
+constexpr bool is_longrunavg(perfcounter_type_d type) {
+  return (type & PERFCOUNTER_LONGRUNAVG) != 0;
+}
+
+constexpr const char* metric_type_human(perfcounter_type_d type) {
+  if (is_histogram(type)) {
+    return "histogram";
+  } else if (is_longrunavg(type)) {
+    return "running avg";
+  } else {
+    return metric_type(type);
+  }
+}
+
+constexpr const char* metric_value_type_human(perfcounter_type_d type) {
+  if (type & PERFCOUNTER_TIME) {
+    return "time";
+  } else {
+    return "int";
+  }
+}
+
+static std::string format_bytes(uint64_t bytes) {
+  if (bytes < 1024) {
+    return fmt::format("{} B", bytes);
+  } else {
+    double mantissa = bytes;
+    int i = 0;
+    for (; mantissa >= 1024 && i < 5; mantissa /= 1024, ++i) {}
+    return fmt::format("{:.3Lf} {}B ({:d})", mantissa, "_KMGT"[i], bytes);
+  }
+}
+
+static std::string format_int_value(uint64_t val, unit_t unit) {
+  if (unit == unit_t::UNIT_BYTES) {
+    return format_bytes(val);
+  } else {
+    return fmt::format("{:L}", val);
+  }
+}
+
+http::status PerfCounterStatusPage::render(std::ostream& os) {
+  os << R"(
+<h1>Perf Counters</h1>
+<table>
+<thead>
+  <tr>
+    <th>Path</th>
+    <th>Description</th>
+    <th>Type</th>
+    <th>Value Type</th>
+    <th>Prio</th>
+    <th>Value</th>
+  </tr>
+</thead>
+<tbody>
+)";
+
+  perf_counters->with_counters(
+      [&](const PerfCountersCollectionImpl::CounterMap& by_path) {
+        for (const auto& kv : by_path) {
+          auto& path = kv.first;
+          auto& data = *(kv.second.data);
+          auto& perf_counters = *(kv.second.perf_counters);
+          if (std::string::npos != path.find("mempool.")) {
+            continue;
+          }
+
+          auto format_value = [&]() {
+            if (is_histogram(data.type)) {
+              auto f = Formatter::create("table");
+              bufferlist bl;
+              perf_counters.dump_formatted_histograms(f, false);
+              f->flush(bl);
+              return bl.to_str();
+            } else if (is_longrunavg(data.type)) {
+              // TODO properly format PERFCOUNTER_TIME
+              return fmt::format("(sum, avgcount)={}", data.read_avg());
+            } else {
+              if (data.type & PERFCOUNTER_U64) {
+                return format_int_value(data.u64, data.unit);
+              } else if (data.type & PERFCOUNTER_TIME) {
+                std::chrono::seconds secs{data.u64};
+                return fmt::format("{:L}", secs);
+              } else {
+                return std::string("???");
+              }
+            }
+          };
+
+          fmt::print(os, R"(
+<tr>
+  <td>{path}</td>
+  <td>{descr}</td>
+  <td>{type}</td>
+  <td>{value_type}</td>
+  <td>{prio}</td>
+  <td>{value}</td>
+</tr>
+)",
+                     "path"_a = path,
+                     "descr"_a = data.description ? data.description : "",
+                     "type"_a = metric_type_human(data.type),
+                     "value_type"_a = metric_value_type_human(data.type),
+                     "prio"_a = perf_counters.get_adjusted_priority(data.prio),
+                     "value"_a = format_value());
+        }
+      });
+
+  os << R"(
+</tbody>
+</table>
+)";
+
+  return http::status::ok;
+}

--- a/src/rgw/rgw_status_page.h
+++ b/src/rgw/rgw_status_page.h
@@ -1,0 +1,58 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=2 sw=2 expandtab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2022 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#ifndef RGW_STATUS_PAGE_H
+#define RGW_STATUS_PAGE_H
+
+#include <boost/beast/http.hpp>
+#include <boost/beast/http/status.hpp>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "common/perf_counters_collection.h"
+
+namespace http = boost::beast::http;
+
+class StatusPage {
+ public:
+  virtual ~StatusPage() = default;
+  virtual std::string name() const = 0;
+  virtual std::string prefix() const = 0;
+  virtual std::string content_type() const = 0;
+  virtual http::status render(std::ostream& os) = 0;
+};
+
+class PerfCounterStatusPage : public StatusPage {
+ private:
+  const PerfCountersCollection* perf_counters;
+
+ public:
+  PerfCounterStatusPage(const PerfCountersCollection* perf_counters);
+  virtual ~PerfCounterStatusPage() override;
+  std::string name() const override {
+    return "Perf Counters";
+  };
+  std::string prefix() const override {
+    return "/perf";
+  };
+  std::string content_type() const override {
+    return "text/html";
+  };
+  http::status render(std::ostream& os) override;
+};
+
+#endif  // RGW_STATUS_PAGE_H
+

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2022-10-20
 
 ### Fixed
 

--- a/src/rgw/store/sfs/sqlite/dbconn.h
+++ b/src/rgw/store/sfs/sqlite/dbconn.h
@@ -117,9 +117,13 @@ class DBConn {
 
  public:
   ceph::shared_mutex rwlock = ceph::make_shared_mutex("dbconn::rwlock");
+  sqlite3 *sqlite_db;
 
-  DBConn(CephContext *cct) 
+  DBConn(CephContext *cct)
   : storage(_make_storage(getDBPath(cct))) {
+    storage.on_open = [this](sqlite3 *db) {
+      sqlite_db = db;
+    };
     storage.open_forever();
     storage.busy_timeout(5000);
     storage.sync_schema();


### PR DESCRIPTION
Add new 'status' RGW frontend serving status pages on 127.0.0.1:9999.
Uses a Beast-based HTTP server. Serves a rudimentary perf counter page HTML export and an even more rudimentary SFS status page featuring SQLite stats.

Activate by setting 'rgw frontends'
(e.g `rgw frontends = beast port=7480, status`)
