### PR TITLE
rgw/sfs: Initial Garbage collector thread.

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -215,6 +215,7 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
                           << " user in sfs error r=" << r << dendl;
       }
     }
+    store->initialize(cct, dpp);
     return store;
   }
 #endif // WITH_RADOSGW_SFS

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -43,6 +43,7 @@
 #include "services/svc_zone_utils.h"
 
 #include "store/sfs/notification.h"
+#include "store/sfs/sfs_gc.h"
 #include "store/sfs/writer.h"
 
 #include "rgw/store/sfs/sqlite/sqlite_users.h"
@@ -382,11 +383,16 @@ int SFStore::initialize(
   const DoutPrefixProvider* dpp
 ) {
   ldpp_dout(dpp, 10) << __func__ << dendl;
+  gc = new sfs::SFSGC();
+  gc->initialize(cct, this);
+  gc->start_processor();
   return 0;
 }
 
 void SFStore::finalize(void) {
   ldout(ctx(), 10) << __func__ << ": TODO" << dendl;
+  delete gc;
+  gc = nullptr;
   return;
 }
 

--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -41,7 +41,9 @@
   ldpp_dout(_dpp, _lvl) << "> " << this->get_cls_name() \
                         << "::" << __func__ << " "
 
-
+namespace rgw::sal::sfs {
+  class SFSGC;
+}
 namespace rgw::sal {
 
 class SFStore;
@@ -76,6 +78,7 @@ class SFStore : public Store {
   CephContext *const cctx;
   ceph::mutex buckets_map_lock = ceph::make_mutex("buckets_map_lock");
   std::map<std::string, sfs::BucketRef> buckets;
+  sfs::SFSGC *gc = nullptr;
 
  public:
   sfs::sqlite::DBConnRef db_conn;
@@ -89,6 +92,7 @@ class SFStore : public Store {
     CephContext* cct,
     const DoutPrefixProvider* dpp
   ) override;
+
   virtual void finalize(void) override;
   void maybe_init_store();
 

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 - Added a mechanism to check for incompatibility issues without changing the
   original metadata database. When any incompatibility is found it is also shown
   in the logs.
+- Added GC thread deleting permanently removed buckets, its objects and
+  versions.
 
 ## [0.7.0] - 2022-10-20
 

--- a/src/rgw/store/sfs/CMakeLists.txt
+++ b/src/rgw/store/sfs/CMakeLists.txt
@@ -34,6 +34,7 @@ set(sfs_srcs
     zone.cc
     writer.cc
     sfs_bucket.cc
+    sfs_gc.cc
     sfs_user.cc
     )
 

--- a/src/rgw/store/sfs/sfs_gc.cc
+++ b/src/rgw/store/sfs/sfs_gc.cc
@@ -1,0 +1,197 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2022 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#include "sfs_gc.h"
+
+#include "store/sfs/sqlite/sqlite_objects.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::sal::sfs {
+
+SFSGC::~SFSGC() {
+  stop_processor();
+  finalize();
+}
+
+void SFSGC::initialize(CephContext *_cct, SFStore *_store) {
+  cct = _cct;
+  store = _store;
+}
+
+void SFSGC::finalize() {
+}
+
+int SFSGC::process() {
+  // This is the method that does the garbage collection.
+
+  // set the maximum number of objects we can delete in this iteration
+  max_objects = cct->_conf->rgw_gc_max_objs;
+  lsfs_dout(this, 10) << "garbage collection: processing with max_objects = "
+                    << max_objects << dendl;
+
+  // For now, delete only the objects with deleted bucket.
+  process_deleted_buckets();
+  return 0;
+}
+
+bool SFSGC::going_down() {
+  return down_flag;
+}
+
+void SFSGC::start_processor() {
+  worker = new GCWorker(this, cct, this);
+  worker->create("rgw_gc");
+}
+
+void SFSGC::stop_processor() {
+  down_flag = true;
+  if (worker) {
+    worker->stop();
+    worker->join();
+    delete worker;
+  }
+  worker = nullptr;
+}
+
+unsigned SFSGC::get_subsys() const
+{
+  return dout_subsys;
+}
+
+std::ostream& SFSGC::gen_prefix(std::ostream& out) const
+{
+  return out << "garbage collection: ";
+}
+
+void SFSGC::process_deleted_buckets() {
+  // permanently delete removed buckets and their objects and versions
+  sqlite::SQLiteBuckets db_buckets(store->db_conn);
+  auto deleted_buckets = db_buckets.get_deleted_buckets_ids();
+  lsfs_dout(this, 10) << "deleted buckets found = "
+                     << deleted_buckets.size() << dendl;
+  for (auto const& bucket_id : deleted_buckets) {
+    if (max_objects <= 0) {
+      break;
+    }
+    delete_bucket(bucket_id);
+  }
+}
+
+void SFSGC::delete_objects(const std::string & bucket_id) {
+  sqlite::SQLiteObjects db_objs(store->db_conn);
+  auto objects = db_objs.get_objects(bucket_id);
+  for (auto const& object : objects) {
+    if (max_objects <= 0) {
+      break;
+    }
+    auto obj_instance = std::make_shared<Object>(object.name,
+                                                 object.uuid,
+                                                 true);
+    delete_object(obj_instance);
+  }
+}
+
+void SFSGC::delete_versioned_objects(const std::shared_ptr<Object> & object) {
+  sqlite::SQLiteVersionedObjects db_ver_objs(store->db_conn);
+  auto versions = db_ver_objs.get_versioned_objects(object->path.get_uuid());
+  for (auto const& version : versions) {
+    if (max_objects <= 0) {
+      break;
+    }
+    delete_versioned_object(object, version.id);
+  }
+}
+
+void SFSGC::delete_bucket(const std::string & bucket_id) {
+  // delete the objects of the bucket first
+  delete_objects(bucket_id);
+  if (max_objects > 0) {
+    sqlite::SQLiteBuckets db_buckets(store->db_conn);
+    db_buckets.remove_bucket(bucket_id);
+    lsfs_dout(this, 30) << "Deleted bucket: "
+                        << bucket_id
+                        << dendl;
+    --max_objects;
+  }
+}
+
+void SFSGC::delete_object(const std::shared_ptr<Object> & object) {
+  // delete its versions first
+  delete_versioned_objects(object);
+  if (max_objects > 0) {
+    object->delete_object(store);
+    lsfs_dout(this, 30) << "Deleted object: "
+                        << object->path.get_uuid()
+                        << dendl;
+    --max_objects;
+  }
+}
+
+void SFSGC::delete_versioned_object(const std::shared_ptr<Object> & object,
+                                    uint id) {
+  object->version_id = id;
+  object->delete_object_version(store);
+  lsfs_dout(this, 30) << "Deleted version: ("
+                      << object->path.get_uuid()
+                      << ","
+                      << id
+                      << ")"
+                      << dendl;
+  --max_objects;
+}
+
+SFSGC::GCWorker::GCWorker(const DoutPrefixProvider *_dpp,
+                          CephContext *_cct,
+                          SFSGC *_gc)
+  : dpp(_dpp), cct(_cct), gc(_gc) {
+}
+
+void *SFSGC::GCWorker::entry() {
+  do {
+    utime_t start = ceph_clock_now();
+    lsfs_dout(dpp, 2) << "start" << dendl;
+    int r = gc->process();
+    if (r < 0) {
+      lsfs_dout(dpp, 0)
+         << "ERROR: garbage collection process() returned error r="
+         << r
+         << dendl;
+    }
+    lsfs_dout(dpp, 2) << "stop" << dendl;
+
+    if (gc->going_down())
+      break;
+
+    utime_t end = ceph_clock_now();
+    end -= start;
+    int secs = cct->_conf->rgw_gc_processor_period;
+    secs -= end.sec();
+    if (secs <= 0) {
+      // in case the GC iteration took more time than the period
+      secs = cct->_conf->rgw_gc_processor_period;;
+    }
+
+    std::unique_lock locker{lock};
+    cond.wait_for(locker, std::chrono::seconds(secs));
+  } while (!gc->going_down());
+
+  return nullptr;
+}
+
+void SFSGC::GCWorker::stop() {
+  std::lock_guard l{lock};
+  cond.notify_all();
+}
+
+} //  namespace rgw::sal::sfs

--- a/src/rgw/store/sfs/sfs_gc.h
+++ b/src/rgw/store/sfs/sfs_gc.h
@@ -1,0 +1,76 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2022 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#pragma once
+
+#include "rgw_sal.h"
+#include "rgw_sal_sfs.h"
+#include "store/sfs/types.h"
+
+namespace rgw::sal::sfs {
+
+class SFSGC : public DoutPrefixProvider {
+  CephContext *cct = nullptr;
+  SFStore *store = nullptr;
+  std::atomic<bool> down_flag = { false };
+  long int max_objects;
+
+  class GCWorker : public Thread {
+    const DoutPrefixProvider *dpp = nullptr;
+    CephContext *cct = nullptr;
+    SFSGC *gc = nullptr;
+    ceph::mutex lock = ceph::make_mutex("GCWorker");
+    ceph::condition_variable cond;
+
+    std::string get_cls_name() const { return "GCWorker"; }
+
+  public:
+    GCWorker(const DoutPrefixProvider *_dpp, CephContext *_cct, SFSGC *_gc);
+    void *entry() override;
+    void stop();
+  };
+
+  GCWorker *worker = nullptr;
+public:
+  SFSGC() = default;
+  ~SFSGC();
+
+  void initialize(CephContext *_cct, SFStore *_store);
+  void finalize();
+
+  int process();
+
+  bool going_down();
+  void start_processor();
+  void stop_processor();
+
+  CephContext *get_cct() const override { return store->ctx(); }
+  unsigned get_subsys() const;
+
+  std::ostream& gen_prefix(std::ostream& out) const;
+
+  std::string get_cls_name() const { return "SFSGC"; }
+
+ private:
+  void process_deleted_buckets();
+
+  void delete_objects(const std::string & bucket_id);
+  void delete_versioned_objects(const std::shared_ptr<Object> & object);
+
+  void delete_bucket(const std::string & bucket_id);
+  void delete_object(const std::shared_ptr<Object> & object);
+  void delete_versioned_object(const std::shared_ptr<Object> & object, uint id);
+
+};
+
+} //  namespace rgw::sal::sfs

--- a/src/rgw/store/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/store/sfs/sqlite/sqlite_buckets.cc
@@ -82,4 +82,11 @@ std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets(const std::string & user_
   return get_rgw_buckets(storage.get_all<DBBucket>(where(c(&DBBucket::owner_id) = user_id)));
 }
 
+std::vector<std::string> SQLiteBuckets::get_deleted_buckets_ids() const {
+  std::shared_lock l(conn->rwlock);
+  auto storage = conn->get_storage();
+  return storage.select(&DBBucket::bucket_id,
+                        where(c(&DBBucket::deleted) = true));
+}
+
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/sqlite/sqlite_buckets.h
+++ b/src/rgw/store/sfs/sqlite/sqlite_buckets.h
@@ -39,6 +39,8 @@ class SQLiteBuckets {
 
   std::vector<DBOPBucketInfo> get_buckets() const;
   std::vector<DBOPBucketInfo> get_buckets(const std::string & user_id) const;
+
+  std::vector<std::string> get_deleted_buckets_ids() const;
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/store/sfs/types.cc
+++ b/src/rgw/store/sfs/types.cc
@@ -86,6 +86,24 @@ void Object::metadata_finish(SFStore *store) {
   db_versioned_objs.store_versioned_object(*db_versioned_object);
 }
 
+int Object::delete_object_version(SFStore *store) {
+  // remove object data
+  std::filesystem::remove(store->get_data_path() / get_storage_path());
+
+  // remove metadata
+  sqlite::SQLiteVersionedObjects db_versioned_objs(store->db_conn);
+  db_versioned_objs.remove_versioned_object(version_id);
+  return 0;
+}
+
+void Object::delete_object(SFStore *store) {
+  // remove object folder
+  std::filesystem::remove(store->get_data_path() / path.to_path());
+  // remove metadata
+  sqlite::SQLiteObjects db_objs(store->db_conn);
+  db_objs.remove_object(path.get_uuid());
+}
+
 void MultipartObject::_abort(const DoutPrefixProvider *dpp) {
   // assumes being called while holding the lock.
   ceph_assert(aborted);

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -72,6 +72,9 @@ struct Object {
                      bool new_object, bool new_version);
   void metadata_change_version_state(SFStore *store, ObjectState state);
   void metadata_finish(SFStore *store);
+
+  int delete_object_version(SFStore *store);
+  void delete_object(SFStore *store);
 };
 
 using ObjectRef = std::shared_ptr<Object>;

--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -25,3 +25,8 @@ target_link_libraries(unittest_rgw_sfs_sfs_user ${rgw_libs})
 add_executable(unittest_rgw_sfs_metadata_compatibility test_rgw_sfs_metadata_compatibility.cc)
 add_ceph_unittest(unittest_rgw_sfs_metadata_compatibility)
 target_link_libraries(unittest_rgw_sfs_metadata_compatibility ${rgw_libs})
+
+add_executable(unittest_rgw_sfs_gc test_rgw_sfs_gc.cc)
+add_ceph_unittest(unittest_rgw_sfs_gc)
+target_link_libraries(unittest_rgw_sfs_gc ${rgw_libs})
+

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -1,0 +1,316 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/ceph_context.h"
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/sqlite_buckets.h"
+#include "rgw/store/sfs/sqlite/buckets/bucket_conversions.h"
+#include "rgw/store/sfs/sqlite/sqlite_users.h"
+
+#include "rgw/store/sfs/uuid_path.h"
+#include "rgw/store/sfs/sfs_gc.h"
+
+#include "rgw/rgw_sal_sfs.h"
+
+#include <chrono>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+#include <thread>
+
+using namespace rgw::sal::sfs::sqlite;
+using namespace std::this_thread;
+using namespace std::chrono_literals;
+using std::chrono::system_clock;
+
+namespace fs = std::filesystem;
+const static std::string TEST_DIR = "rgw_sfs_tests";
+const static std::string TEST_USERNAME = "test_user";
+
+class TestSFSGC : public ::testing::Test {
+protected:
+  void SetUp() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::create_directory(TEST_DIR);
+  }
+
+  void TearDown() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(TEST_DIR);
+  }
+
+  std::string getTestDir() const {
+    auto test_dir = fs::temp_directory_path() / TEST_DIR;
+    return test_dir.string();
+  }
+
+  fs::path getDBFullPath(const std::string & base_dir) const {
+    auto db_full_name = "s3gw.db";
+    auto db_full_path = fs::path(base_dir) /  db_full_name;
+    return db_full_path;
+  }
+
+  fs::path getDBFullPath() const {
+    return getDBFullPath(getTestDir());
+  }
+
+  std::size_t getStoreNbFiles() {
+    using std::filesystem::recursive_directory_iterator;
+    using fp = bool (*)( const std::filesystem::path&);
+    return std::count_if(recursive_directory_iterator(getTestDir()), recursive_directory_iterator{}, (fp)std::filesystem::is_regular_file);
+  }
+
+  void createTestUser(DBConnRef conn) {
+    SQLiteUsers users(conn);
+    DBOPUserInfo user;
+    user.uinfo.user_id.id = TEST_USERNAME;
+    users.store_user(user);
+  }
+
+  void storeRandomObjectVersion(const std::shared_ptr<rgw::sal::sfs::Object> & object) {
+    std::filesystem::path object_path =
+        getTestDir() / object->get_storage_path();
+    std::filesystem::create_directories(object_path.parent_path());
+    auto mode = \
+        std::ofstream::binary | \
+        std::ofstream::out | \
+        std::ofstream::app;
+    std::ofstream ofs(object_path, mode);
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> dist(1, 4096);
+    auto file_size = dist(gen);
+    while(file_size) {
+        ofs << dist(gen);
+        --file_size;
+    }
+    ofs.flush();
+    ofs.close();
+  }
+
+  void createTestBucket(const std::string & bucket_id,
+                        DBConnRef conn) {
+    SQLiteBuckets db_buckets(conn);
+    DBOPBucketInfo bucket;
+    bucket.binfo.bucket.name = bucket_id + "_name";
+    bucket.binfo.bucket.bucket_id = bucket_id;
+    bucket.binfo.owner.id = TEST_USERNAME;
+    bucket.deleted = false;
+    db_buckets.store_bucket(bucket);
+  }
+
+  bool bucketExists(const std::string & bucket_id,
+                        DBConnRef conn) {
+    SQLiteBuckets db_buckets(conn);
+    auto bucket = db_buckets.get_bucket(bucket_id);
+    return bucket.has_value();
+  }
+
+  std::shared_ptr<rgw::sal::sfs::Object> createTestObject(
+                                                const std::string & bucket_id,
+                                                const std::string & name,
+                                                DBConnRef conn) {
+    auto object = std::make_shared<rgw::sal::sfs::Object>(name);
+    SQLiteObjects db_objects(conn);
+    DBOPObjectInfo db_object;
+    db_object.uuid = object->path.get_uuid();
+    db_object.name = name;
+    db_object.bucket_id = bucket_id;
+    db_objects.store_object(db_object);
+    return object;
+  }
+
+  void createTestObjectVersion(std::shared_ptr<rgw::sal::sfs::Object> & object,
+                               uint version,
+                               DBConnRef conn) {
+    object->version_id = version;
+    storeRandomObjectVersion(object);
+    SQLiteVersionedObjects db_versioned_objects(conn);
+    DBOPVersionedObjectInfo db_version;
+    db_version.id = version;
+    db_version.object_id = object->path.get_uuid();
+    db_versioned_objects.insert_versioned_object(db_version);
+  }
+
+  void deleteTestObject(std::shared_ptr<rgw::sal::sfs::Object> & object,
+                        DBConnRef conn) {
+    // delete mark the object
+    SQLiteVersionedObjects db_versioned_objects(conn);
+    auto last_version = db_versioned_objects.get_last_versioned_object(
+                                                       object->path.get_uuid());
+    ASSERT_TRUE(last_version.has_value());
+    last_version->object_state = rgw::sal::ObjectState::DELETED;
+    db_versioned_objects.insert_versioned_object(*last_version);
+  }
+
+  void deleteTestBucket(const std::string & bucket_id, DBConnRef conn) {
+    SQLiteBuckets db_buckets(conn);
+    auto bucket = db_buckets.get_bucket(bucket_id);
+    ASSERT_TRUE(bucket.has_value());
+
+    SQLiteObjects db_objects(conn);
+    auto objects = db_objects.get_objects(bucket_id);
+    for (auto & object: objects) {
+        auto objptr = std::make_shared<rgw::sal::sfs::Object>(object.name,
+                                                              object.uuid,
+                                                              false);
+        deleteTestObject(objptr, conn);
+    }
+    bucket->deleted = true;
+    db_buckets.store_bucket(*bucket);
+  }
+
+  size_t getNumberObjectsForBucket(const std::string & bucket_id, DBConnRef conn) {
+      SQLiteObjects db_objs(conn);
+      auto objects = db_objs.get_objects(bucket_id);
+      return objects.size();
+  }
+};
+
+TEST_F(TestSFSGC, TestDeletedBuckets) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_conf.set_val("rgw_gc_processor_period", "1");
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+
+  // create the test user
+  createTestUser(store->db_conn);
+
+  // create 2 buckets
+  createTestBucket("test_bucket_1", store->db_conn);
+  createTestBucket("test_bucket_2", store->db_conn);
+
+  // create a few objects in bucket_1 with a few versions
+  uint version_id = 1;
+  auto object1 = createTestObject("test_bucket_1", "obj_1", store->db_conn);
+  createTestObjectVersion(object1, version_id++, store->db_conn);
+  createTestObjectVersion(object1, version_id++, store->db_conn);
+  createTestObjectVersion(object1, version_id++, store->db_conn);
+
+  auto object2 = createTestObject("test_bucket_2", "obj_2", store->db_conn);
+  createTestObjectVersion(object2, version_id++, store->db_conn);
+  createTestObjectVersion(object2, version_id++, store->db_conn);
+
+  // we should have 5 version files plus the sqlite db
+  EXPECT_EQ(getStoreNbFiles(), 6);
+
+  auto gc = std::make_shared<rgw::sal::sfs::SFSGC>();
+  gc->initialize(ceph_context.get(), store);
+  gc->start_processor();
+  gc->stop_processor();
+
+  // nothing should be removed
+  EXPECT_EQ(getStoreNbFiles(), 6);
+  SQLiteVersionedObjects db_versioned_objs(store->db_conn);
+  auto versions = db_versioned_objs.get_versioned_object_ids();
+  EXPECT_EQ(versions.size(), 5);
+
+  // delete bucket 2
+  deleteTestBucket("test_bucket_2", store->db_conn);
+  // nothing should be removed permanently yet
+  EXPECT_EQ(getStoreNbFiles(), 6);
+  versions = db_versioned_objs.get_versioned_object_ids();
+  // we should have 1 more version (delete marker for 1 object)
+  EXPECT_EQ(versions.size(), 6);
+
+  gc->start_processor();
+  gc->stop_processor();
+
+  // only objects for bucket 1 should be available
+  EXPECT_EQ(getStoreNbFiles(), 4);
+  EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_FALSE(bucketExists("test_bucket_2", store->db_conn));
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
+  EXPECT_TRUE(bucketExists("test_bucket_1", store->db_conn));
+
+  // delete bucket 1 now
+  deleteTestBucket("test_bucket_1", store->db_conn);
+  gc->start_processor();
+  gc->stop_processor();
+
+  // only the db file should be present
+  EXPECT_EQ(getStoreNbFiles(), 1);
+  EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_FALSE(bucketExists("test_bucket_2", store->db_conn));
+  EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
+  EXPECT_FALSE(bucketExists("test_bucket_1", store->db_conn));
+}
+
+TEST_F(TestSFSGC, TestDeletedBucketsMaxObjects) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_conf.set_val("rgw_gc_processor_period", "1");
+  // gc will only remove 1 objects per iteration
+  ceph_context->_conf.set_val("rgw_gc_max_objs", "1");
+  auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+
+  NoDoutPrefix ndp(ceph_context.get(), 1);
+  RGWEnv env;
+  env.init(ceph_context.get());
+
+  // create the test user
+  createTestUser(store->db_conn);
+
+  // create 2 buckets
+  createTestBucket("test_bucket_1", store->db_conn);
+  createTestBucket("test_bucket_2", store->db_conn);
+
+  // create a few objects in bucket_1 with a few versions
+  uint version_id = 1;
+  auto object1 = createTestObject("test_bucket_1", "obj_1", store->db_conn);
+  createTestObjectVersion(object1, version_id++, store->db_conn);
+  createTestObjectVersion(object1, version_id++, store->db_conn);
+  createTestObjectVersion(object1, version_id++, store->db_conn);
+
+  auto object2 = createTestObject("test_bucket_2", "obj_2", store->db_conn);
+  createTestObjectVersion(object2, version_id++, store->db_conn);
+  createTestObjectVersion(object2, version_id++, store->db_conn);
+
+  // we should have 5 version files plus the sqlite db
+  EXPECT_EQ(getStoreNbFiles(), 6);
+
+  auto gc = std::make_shared<rgw::sal::sfs::SFSGC>();
+  gc->initialize(ceph_context.get(), store);
+
+  // delete bucket 2
+  deleteTestBucket("test_bucket_2", store->db_conn);
+
+  gc->start_processor();
+  gc->stop_processor();
+
+  // only 1 file should be removed
+  EXPECT_EQ(getStoreNbFiles(), 5);
+  // the object is still reachable in the db
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
+
+  gc->start_processor();
+  gc->stop_processor();
+
+  // one more version removed
+  EXPECT_EQ(getStoreNbFiles(), 4);
+  // the object is still reachable in the db (versions removed)
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
+
+  gc->start_processor();
+  gc->stop_processor();
+  // one more version removed
+  EXPECT_EQ(getStoreNbFiles(), 4);
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
+
+  gc->start_processor();
+  gc->stop_processor();
+  // one more version removed
+  EXPECT_EQ(getStoreNbFiles(), 4);
+  // the object is finally removed
+  EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
+}


### PR DESCRIPTION
This adds an initial GC approach just starting a thread and running
 a basic remove deleted buckets operation.

The implementation of how the thread is started and stopped are taken from rgw's code for consistency across stores and thinking on the possible merge upstream. 

It uses 2 parameters from rgw:

- `rgw_gc_processor_period` : defines the time GC waits to be triggered (in seconds)
- `rgw_gc_max_objs` : defines the maximum number of items the GC can remove per iteration.

Any possible actions done to the `sqlite` metadata is considered an item (object) when taking into account the maxium number of items to be processed in a single iteration as those actions block the metadata database.

Fixes: https://github.com/aquarist-labs/s3gw/issues/165
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
