### PR TITLE
rgw/sfs: Detect metadata compatibility issues.

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -150,8 +150,14 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
     const auto& data_path =
       g_conf().get_val<std::string>("rgw_sfs_data_path");
     ldpp_dout(dpp, 0) << "sfs init!" << dendl;
-    rgw::sal::SFStore *store =
-      new rgw::sal::SFStore(cct, data_path);
+    rgw::sal::SFStore *store = nullptr;
+    try {
+      store = new rgw::sal::SFStore(cct, data_path);
+    } catch (std::exception & e) {
+      ldpp_dout(dpp, 0) << e.what()
+                        << dendl;
+      return nullptr;
+    }
     const char *id = get_env_char(
       "RGW_DEFAULT_USER_ID",
       "testid");

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to
 
 - In order to make stat_bucket call available, SFSBucket::update_container_stat now returns 0.
 
+### Added
+
+- Added a mechanism to check for incompatibility issues without changing the
+  original metadata database. When any incompatibility is found it is also shown
+  in the logs.
+
 ## [0.7.0] - 2022-10-20
 
 ### Fixed

--- a/src/rgw/store/sfs/CMakeLists.txt
+++ b/src/rgw/store/sfs/CMakeLists.txt
@@ -25,6 +25,7 @@ set(sfs_srcs
     sqlite/buckets/bucket_conversions.cc
     sqlite/objects/object_conversions.cc
     sqlite/versioned_object/versioned_object_conversions.cc
+    sqlite/dbconn.cc
     bucket.cc
     multipart.cc
     object.cc

--- a/src/rgw/store/sfs/sqlite/dbconn.cc
+++ b/src/rgw/store/sfs/sqlite/dbconn.cc
@@ -1,0 +1,66 @@
+#include "dbconn.h"
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+namespace orm = sqlite_orm;
+
+namespace rgw::sal::sfs::sqlite  {
+
+std::string get_temporary_db_path(CephContext *ctt) {
+    auto rgw_sfs_path = ctt->_conf.get_val<std::string>("rgw_sfs_data_path");
+    auto tmp_db_name = std::string(SCHEMA_DB_NAME) + "_tmp";
+    auto db_path =
+      std::filesystem::path(rgw_sfs_path) / std::string(tmp_db_name);
+    return db_path.string();
+}
+
+void DBConn::check_metadata_is_compatible(CephContext *ctt) {
+    // create a copy of the actual metadata
+    fs::copy(getDBPath(ctt), get_temporary_db_path(ctt));
+
+    // try to sync the storage based on the temporary db
+    // in case something goes wrong show possible errors and return
+    auto test_storage = _make_storage(get_temporary_db_path(ctt));
+    test_storage.open_forever();
+    test_storage.busy_timeout(5000);
+    bool sync_error = false;
+    std::string result_message;
+    try {
+        auto sync_res = test_storage.sync_schema();
+        std::vector<std::string> non_compatible_tables;
+        for (auto const& [table_name, sync_result] : sync_res) {
+            if (sync_result == orm::sync_schema_result::dropped_and_recreated) {
+                // this result is aggresive as it drops the table and
+                // recreates it.
+                // Data loss is expected and we should warn the user and
+                // stop the final sync in the real database.
+                result_message += "Table: [" + table_name +
+                                  "] is no longer compatible. ";
+                non_compatible_tables.push_back(table_name);
+            }
+        }
+        if (non_compatible_tables.size() > 0) {
+            sync_error = true;
+            result_message = "Tables: [ ";
+            for (auto const& table: non_compatible_tables) {
+                result_message += table + " ";
+            }
+            result_message += "] are no longer compatible.";
+        }
+    } catch (std::exception & e) {
+        // check for any other errors (foreign keys constrains, etc...)
+        result_message = "Metadata database might be corrupted or is no longer compatible";
+        sync_error = true;
+    }
+    // remove the temporary db
+    fs::remove(get_temporary_db_path(ctt));
+
+    // if there was a sync issue, throw an exception
+    if (sync_error) {
+        throw sqlite_sync_exception("ERROR ACCESSING SFS METADATA. " +
+                                    result_message);
+    }
+}
+
+}  // namespace rgw::sal::sfs::sqlite

--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -21,3 +21,7 @@ target_link_libraries(unittest_rgw_sfs_sfs_bucket ${rgw_libs})
 add_executable(unittest_rgw_sfs_sfs_user test_rgw_sfs_sfs_user.cc)
 add_ceph_unittest(unittest_rgw_sfs_sfs_user)
 target_link_libraries(unittest_rgw_sfs_sfs_user ${rgw_libs})
+
+add_executable(unittest_rgw_sfs_metadata_compatibility test_rgw_sfs_metadata_compatibility.cc)
+add_ceph_unittest(unittest_rgw_sfs_metadata_compatibility)
+target_link_libraries(unittest_rgw_sfs_metadata_compatibility ${rgw_libs})

--- a/src/test/rgw/sfs/compatibility_test_cases/columns_added.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/columns_added.h
@@ -1,0 +1,309 @@
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/conversion_utils.h"
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace rgw::test::metadata::columns_added {
+
+struct DBTestUser {
+  std::string user_id;
+  std::optional<std::string> tenant;
+  std::optional<std::string> ns;
+  std::optional<std::string> display_name;
+  std::optional<std::string> user_email;
+  std::optional<BLOB> access_keys;
+  std::optional<BLOB> swift_keys;
+  std::optional<BLOB> sub_users;
+  std::optional<unsigned char> suspended;
+  std::optional<int> max_buckets;
+  std::optional<int> op_mask;
+  std::optional<BLOB> user_caps;
+  std::optional<int> admin;
+  std::optional<int> system;
+  std::optional<std::string> placement_name;
+  std::optional<std::string> placement_storage_class;
+  std::optional<BLOB> placement_tags;
+  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> temp_url_keys;
+  std::optional<BLOB> user_quota;
+  std::optional<int> type;
+  std::optional<BLOB> mfa_ids;
+  std::optional<std::string> assumed_role_arn;
+  std::optional<BLOB> user_attrs;
+  std::optional<int> user_version;
+  std::optional<std::string> user_version_tag;
+};
+
+struct DBTestAccessKey {
+  int id;
+  std::string access_key;
+  std::string user_id;
+};
+
+struct DBTestBucket {
+  std::string bucket_name;
+  std::string bucket_id;
+  std::optional<std::string> tenant;
+  std::optional<std::string> marker;
+  std::optional<int> size;
+  std::optional<int> size_rounded;
+  std::optional<BLOB> creation_time;
+  std::optional<int> count;
+  std::optional<std::string> placement_name;
+  std::optional<std::string> placement_storage_class;
+  std::string owner_id;
+  std::optional<uint32_t> flags;
+  std::optional<std::string> zone_group;
+  std::optional<bool> has_instance_obj;
+  std::optional<BLOB> quota;
+  std::optional<bool> requester_pays;
+  std::optional<bool> has_website;
+  std::optional<BLOB> website_conf;
+  std::optional<bool> swift_versioning;
+  std::optional<std::string> swift_ver_location;
+  std::optional<BLOB> mdsearch_config;
+  std::optional<std::string> new_bucket_instance_id;
+  std::optional<BLOB> object_lock;
+  std::optional<BLOB> sync_policy_info_groups;
+  std::optional<BLOB> bucket_attrs;
+  std::optional<int> bucket_version;
+  std::optional<std::string> bucket_version_tag;
+  std::optional<BLOB> mtime;
+  // this column will be added
+  // bool deleted;
+};
+
+struct DBTestObject {
+  std::string object_id;
+  std::string bucket_id;
+  std::string name;
+  std::optional<size_t> size;
+  std::optional<std::string> etag;
+  std::optional<BLOB> mtime;
+  std::optional<BLOB> set_mtime;
+  std::optional<BLOB> delete_at_time;
+  std::optional<BLOB> attrs;
+  std::optional<BLOB> acls;
+};
+
+struct DBTestVersionedObject {
+  uint id;
+  std::string object_id;
+  std::string checksum;
+  BLOB deletion_time;
+  size_t size;
+  BLOB creation_time;
+  uint object_state;
+  std::string version_id;
+  std::string etag;
+};
+
+inline auto _make_test_storage(const std::string &path) {
+  return sqlite_orm::make_storage(path,
+    sqlite_orm::make_table(std::string(USERS_TABLE),
+          sqlite_orm::make_column("user_id", &DBTestUser::user_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("tenant", &DBTestUser::tenant),
+          sqlite_orm::make_column("ns", &DBTestUser::ns),
+          sqlite_orm::make_column("display_name", &DBTestUser::display_name),
+          sqlite_orm::make_column("user_email", &DBTestUser::user_email),
+          sqlite_orm::make_column("access_keys", &DBTestUser::access_keys),
+          sqlite_orm::make_column("swift_keys", &DBTestUser::swift_keys),
+          sqlite_orm::make_column("sub_users", &DBTestUser::sub_users),
+          sqlite_orm::make_column("suspended", &DBTestUser::suspended),
+          sqlite_orm::make_column("max_buckets", &DBTestUser::max_buckets),
+          sqlite_orm::make_column("op_mask", &DBTestUser::op_mask),
+          sqlite_orm::make_column("user_caps", &DBTestUser::user_caps),
+          sqlite_orm::make_column("admin", &DBTestUser::admin),
+          sqlite_orm::make_column("system", &DBTestUser::system),
+          sqlite_orm::make_column("placement_name", &DBTestUser::placement_name),
+          sqlite_orm::make_column("placement_storage_class", &DBTestUser::placement_storage_class),
+          sqlite_orm::make_column("placement_tags", &DBTestUser::placement_tags),
+          sqlite_orm::make_column("bucke_quota", &DBTestUser::bucke_quota),
+          sqlite_orm::make_column("temp_url_keys", &DBTestUser::temp_url_keys),
+          sqlite_orm::make_column("user_quota", &DBTestUser::user_quota),
+          sqlite_orm::make_column("type", &DBTestUser::type),
+          sqlite_orm::make_column("mfa_ids", &DBTestUser::mfa_ids),
+          sqlite_orm::make_column("assumed_role_arn", &DBTestUser::assumed_role_arn),
+          sqlite_orm::make_column("user_attrs", &DBTestUser::user_attrs),
+          sqlite_orm::make_column("user_version", &DBTestUser::user_version),
+          sqlite_orm::make_column("user_version_tag", &DBTestUser::user_version_tag)),
+    sqlite_orm::make_table(std::string(BUCKETS_TABLE),
+          sqlite_orm::make_column("bucket_id", &DBTestBucket::bucket_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("bucket_name", &DBTestBucket::bucket_name),
+          sqlite_orm::make_column("tenant", &DBTestBucket::tenant),
+          sqlite_orm::make_column("marker", &DBTestBucket::marker),
+          sqlite_orm::make_column("owner_id", &DBTestBucket::owner_id),
+          sqlite_orm::make_column("flags", &DBTestBucket::flags),
+          sqlite_orm::make_column("zone_group", &DBTestBucket::zone_group),
+          sqlite_orm::make_column("quota", &DBTestBucket::quota),
+          sqlite_orm::make_column("creation_time", &DBTestBucket::creation_time),
+          sqlite_orm::make_column("placement_name", &DBTestBucket::placement_name),
+          sqlite_orm::make_column("placement_storage_class", &DBTestBucket::placement_storage_class),
+          // this column will be added
+          // sqlite_orm::make_column("deleted", &DBTestBucket::deleted),
+          sqlite_orm::make_column("bucket_attrs", &DBTestBucket::bucket_attrs),
+          sqlite_orm::foreign_key(&DBTestBucket::owner_id).references(&DBTestUser::user_id)),
+    sqlite_orm::make_table(std::string(OBJECTS_TABLE),
+          sqlite_orm::make_column("object_id", &DBTestObject::object_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("bucket_id", &DBTestObject::bucket_id),
+          sqlite_orm::make_column("name", &DBTestObject::name),
+          sqlite_orm::make_column("size", &DBTestObject::size),
+          sqlite_orm::make_column("etag", &DBTestObject::etag),
+          sqlite_orm::make_column("mtime", &DBTestObject::mtime),
+          sqlite_orm::make_column("set_mtime", &DBTestObject::set_mtime),
+          sqlite_orm::make_column("delete_at_time", &DBTestObject::delete_at_time),
+          sqlite_orm::make_column("attrs", &DBTestObject::attrs),
+          sqlite_orm::make_column("acls", &DBTestObject::acls),
+          sqlite_orm::foreign_key(&DBTestObject::bucket_id).references(&DBTestBucket::bucket_id)),
+    sqlite_orm::make_table(std::string(VERSIONED_OBJECTS_TABLE),
+          sqlite_orm::make_column("id", &DBTestVersionedObject::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("object_id", &DBTestVersionedObject::object_id),
+          sqlite_orm::make_column("checksum", &DBTestVersionedObject::checksum),
+          sqlite_orm::make_column("deletion_time", &DBTestVersionedObject::deletion_time),
+          sqlite_orm::make_column("size", &DBTestVersionedObject::size),
+          sqlite_orm::make_column("creation_time", &DBTestVersionedObject::creation_time),
+          sqlite_orm::make_column("object_state", &DBTestVersionedObject::object_state),
+          sqlite_orm::make_column("version_id", &DBTestVersionedObject::version_id),
+          sqlite_orm::make_column("etag", &DBTestVersionedObject::etag),
+          sqlite_orm::foreign_key(&DBTestVersionedObject::object_id).references(&DBTestObject::object_id)),
+    sqlite_orm::make_table(std::string(ACCESS_KEYS),
+          sqlite_orm::make_column("id", &DBAccessKey::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("access_key", &DBAccessKey::access_key),
+          sqlite_orm::make_column("user_id", &DBAccessKey::user_id),
+          sqlite_orm::foreign_key(&DBAccessKey::user_id).references(&DBTestUser::user_id))
+  );
+}
+
+using TestStorage = decltype(_make_test_storage(""));
+
+struct TestDB {
+  TestStorage storage;
+  DBTestUser test_user;
+  DBTestBucket test_bucket;
+  DBTestObject test_object;
+  DBTestVersionedObject test_version;
+
+  explicit TestDB(const std::string & db_full_path)
+    : storage(_make_test_storage(db_full_path))
+  {
+    storage.open_forever();
+    storage.busy_timeout(5000);
+    storage.sync_schema();
+  }
+
+  DBTestUser get_test_user() {
+    DBTestUser user;
+    user.user_id = "user1";
+    return user;
+  }
+
+  DBTestBucket get_test_bucket() {
+    DBTestBucket bucket;
+    bucket.bucket_id = "bucket1_id";
+    bucket.bucket_name = "bucket1";
+    bucket.owner_id = "user1";
+    return bucket;
+  }
+
+  DBTestObject get_test_object() {
+    DBTestObject object;
+    object.object_id = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
+    object.bucket_id = "bucket1_id";
+    object.name = "object_name";
+    return object;
+  }
+
+  DBTestVersionedObject get_test_version() {
+    DBTestVersionedObject version;
+    version.id = 1;
+    version.object_id = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
+    version.checksum = "checksum1";
+    encode_blob(ceph::real_clock::now(), version.deletion_time);
+    version.size = rand();
+    encode_blob(ceph::real_clock::now(), version.creation_time);
+    version.object_state = 2;
+    version.version_id = "version_id_1";
+    return version;
+  }
+
+  bool compareUser(const DBTestUser & user1, const DBTestUser & user2) {
+    if (user1.user_id != user2.user_id) return false;
+    return true;
+  }
+
+  bool compareBucket(const DBTestBucket & bucket1, const DBTestBucket & bucket2) {
+    if (bucket1.bucket_id != bucket2.bucket_id) return false;
+    if (bucket1.bucket_name != bucket2.bucket_name) return false;
+    if (bucket1.owner_id != bucket2.owner_id) return false;
+    return true;
+  }
+
+  bool compareObject(const DBTestObject & obj1, const DBTestObject & obj2) {
+    if (obj1.object_id != obj2.object_id) return false;
+    if (obj1.bucket_id != obj2.bucket_id) return false;
+    if (obj1.name != obj2.name) return false;
+    return true;
+  }
+
+  bool compareVersion(const DBTestVersionedObject & v1,
+                      const DBTestVersionedObject & v2) {
+    if (v1.version_id != v2.version_id) return false;
+    if (v1.object_id != v2.object_id) return false;
+    if (v1.checksum != v2.checksum) return false;
+    if (v1.deletion_time != v2.deletion_time) return false;
+    if (v1.size != v2.size) return false;
+    if (v1.creation_time != v2.creation_time) return false;
+    if (v1.object_state != v2.object_state) return false;
+    if (v1.version_id != v2.version_id) return false;
+    return true;
+  }
+
+  void addData() {
+    test_user = get_test_user();
+    storage.replace(test_user);
+
+    test_bucket = get_test_bucket();
+    storage.replace(test_bucket);
+
+    test_object = get_test_object();
+    storage.replace(test_object);
+
+    test_version = get_test_version();
+    storage.insert(test_version);
+  }
+
+  bool checkDataExists() {
+    auto buckets = storage.get_all<DBTestBucket>();
+    if (buckets.size() != 1) return false;
+
+    auto users = storage.get_all<DBTestUser>();
+    if (users.size() != 1) return false;
+
+    auto objs = storage.get_all<DBTestObject>();
+    if (objs.size() != 1) return false;
+
+    auto versions = storage.get_all<DBTestVersionedObject>();
+    if (versions.size() != 1) return false;
+
+    auto bucket = storage.get_pointer<DBTestBucket>(test_bucket.bucket_id);
+    if (!bucket) return false;
+    if (!compareBucket(*bucket, test_bucket)) return false;
+
+    auto user = storage.get_pointer<DBTestUser>(test_user.user_id);
+    if (!user) return false;
+    if (!compareUser(*user, test_user)) return false;
+
+    auto object = storage.get_pointer<DBTestObject>(test_object.object_id);
+    if (!object) return false;
+    if (!compareObject(*object, test_object)) return false;
+
+    auto version = storage.get_pointer<DBTestVersionedObject>(test_version.id);
+    if (!version) return false;
+    if (!compareVersion(*version, test_version)) return false;
+
+    return true;
+  }
+
+};
+
+} //  namespace rgw::test::metadata::new_columns_added

--- a/src/test/rgw/sfs/compatibility_test_cases/columns_deleted.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/columns_deleted.h
@@ -1,0 +1,316 @@
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/conversion_utils.h"
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace rgw::test::metadata::columns_deleted {
+
+struct DBTestUser {
+  std::string user_id;
+  std::optional<std::string> tenant;
+  std::optional<std::string> ns;
+  std::optional<std::string> display_name;
+  std::optional<std::string> user_email;
+  std::optional<BLOB> access_keys;
+  std::optional<BLOB> swift_keys;
+  std::optional<BLOB> sub_users;
+  std::optional<unsigned char> suspended;
+  std::optional<int> max_buckets;
+  std::optional<int> op_mask;
+  std::optional<BLOB> user_caps;
+  std::optional<int> admin;
+  std::optional<int> system;
+  std::optional<std::string> placement_name;
+  std::optional<std::string> placement_storage_class;
+  std::optional<BLOB> placement_tags;
+  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> temp_url_keys;
+  std::optional<BLOB> user_quota;
+  std::optional<int> type;
+  std::optional<BLOB> mfa_ids;
+  std::optional<std::string> assumed_role_arn;
+  std::optional<BLOB> user_attrs;
+  std::optional<int> user_version;
+  std::optional<std::string> user_version_tag;
+};
+
+struct DBTestAccessKey {
+  int id;
+  std::string access_key;
+  std::string user_id;
+};
+
+struct DBTestBucket {
+  std::string bucket_name;
+  std::string bucket_id;
+  std::optional<std::string> tenant;
+  std::optional<std::string> marker;
+  std::optional<int> size;
+  std::optional<int> size_rounded;
+  std::optional<BLOB> creation_time;
+  std::optional<int> count;
+  std::optional<std::string> placement_name;
+  std::optional<std::string> placement_storage_class;
+  std::string owner_id;
+  std::optional<uint32_t> flags;
+  std::optional<std::string> zone_group;
+  std::optional<bool> has_instance_obj;
+  std::optional<BLOB> quota;
+  std::optional<bool> requester_pays;
+  std::optional<bool> has_website;
+  std::optional<BLOB> website_conf;
+  std::optional<bool> swift_versioning;
+  std::optional<std::string> swift_ver_location;
+  std::optional<BLOB> mdsearch_config;
+  std::optional<std::string> new_bucket_instance_id;
+  std::optional<BLOB> object_lock;
+  std::optional<BLOB> sync_policy_info_groups;
+  std::optional<BLOB> bucket_attrs;
+  std::optional<int> bucket_version;
+  std::optional<std::string> bucket_version_tag;
+  std::optional<BLOB> mtime;
+  bool deleted;
+};
+
+struct DBTestObject {
+  std::string object_id;
+  std::string bucket_id;
+  std::string name;
+  std::optional<size_t> size;
+  std::optional<std::string> etag;
+  std::optional<BLOB> mtime;
+  std::optional<BLOB> set_mtime;
+  std::optional<BLOB> delete_at_time;
+  std::optional<BLOB> attrs;
+  std::optional<BLOB> acls;
+  std::string extra;  // extra column that is considered as deleted
+};
+
+struct DBTestVersionedObject {
+  uint id;
+  std::string object_id;
+  std::string checksum;
+  BLOB deletion_time;
+  size_t size;
+  BLOB creation_time;
+  uint object_state;
+  std::string version_id;
+  std::string etag;
+  std::string extra;  // extra column that is considered as deleted
+};
+
+inline auto _make_test_storage(const std::string &path) {
+  return sqlite_orm::make_storage(path,
+    sqlite_orm::make_table(std::string(USERS_TABLE),
+          sqlite_orm::make_column("user_id", &DBTestUser::user_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("tenant", &DBTestUser::tenant),
+          sqlite_orm::make_column("ns", &DBTestUser::ns),
+          sqlite_orm::make_column("display_name", &DBTestUser::display_name),
+          sqlite_orm::make_column("user_email", &DBTestUser::user_email),
+          sqlite_orm::make_column("access_keys", &DBTestUser::access_keys),
+          sqlite_orm::make_column("swift_keys", &DBTestUser::swift_keys),
+          sqlite_orm::make_column("sub_users", &DBTestUser::sub_users),
+          sqlite_orm::make_column("suspended", &DBTestUser::suspended),
+          sqlite_orm::make_column("max_buckets", &DBTestUser::max_buckets),
+          sqlite_orm::make_column("op_mask", &DBTestUser::op_mask),
+          sqlite_orm::make_column("user_caps", &DBTestUser::user_caps),
+          sqlite_orm::make_column("admin", &DBTestUser::admin),
+          sqlite_orm::make_column("system", &DBTestUser::system),
+          sqlite_orm::make_column("placement_name", &DBTestUser::placement_name),
+          sqlite_orm::make_column("placement_storage_class", &DBTestUser::placement_storage_class),
+          sqlite_orm::make_column("placement_tags", &DBTestUser::placement_tags),
+          sqlite_orm::make_column("bucke_quota", &DBTestUser::bucke_quota),
+          sqlite_orm::make_column("temp_url_keys", &DBTestUser::temp_url_keys),
+          sqlite_orm::make_column("user_quota", &DBTestUser::user_quota),
+          sqlite_orm::make_column("type", &DBTestUser::type),
+          sqlite_orm::make_column("mfa_ids", &DBTestUser::mfa_ids),
+          sqlite_orm::make_column("assumed_role_arn", &DBTestUser::assumed_role_arn),
+          sqlite_orm::make_column("user_attrs", &DBTestUser::user_attrs),
+          sqlite_orm::make_column("user_version", &DBTestUser::user_version),
+          sqlite_orm::make_column("user_version_tag", &DBTestUser::user_version_tag)),
+    sqlite_orm::make_table(std::string(BUCKETS_TABLE),
+          sqlite_orm::make_column("bucket_id", &DBTestBucket::bucket_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("bucket_name", &DBTestBucket::bucket_name),
+          sqlite_orm::make_column("tenant", &DBTestBucket::tenant),
+          sqlite_orm::make_column("marker", &DBTestBucket::marker),
+          sqlite_orm::make_column("owner_id", &DBTestBucket::owner_id),
+          sqlite_orm::make_column("flags", &DBTestBucket::flags),
+          sqlite_orm::make_column("zone_group", &DBTestBucket::zone_group),
+          sqlite_orm::make_column("quota", &DBTestBucket::quota),
+          sqlite_orm::make_column("creation_time", &DBTestBucket::creation_time),
+          sqlite_orm::make_column("placement_name", &DBTestBucket::placement_name),
+          sqlite_orm::make_column("placement_storage_class", &DBTestBucket::placement_storage_class),
+          sqlite_orm::make_column("deleted", &DBTestBucket::deleted),
+          sqlite_orm::make_column("bucket_attrs", &DBTestBucket::bucket_attrs),
+          sqlite_orm::foreign_key(&DBTestBucket::owner_id).references(&DBTestUser::user_id)),
+    sqlite_orm::make_table(std::string(OBJECTS_TABLE),
+          sqlite_orm::make_column("object_id", &DBTestObject::object_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("bucket_id", &DBTestObject::bucket_id),
+          sqlite_orm::make_column("name", &DBTestObject::name),
+          sqlite_orm::make_column("size", &DBTestObject::size),
+          sqlite_orm::make_column("etag", &DBTestObject::etag),
+          sqlite_orm::make_column("mtime", &DBTestObject::mtime),
+          sqlite_orm::make_column("set_mtime", &DBTestObject::set_mtime),
+          sqlite_orm::make_column("delete_at_time", &DBTestObject::delete_at_time),
+          sqlite_orm::make_column("attrs", &DBTestObject::attrs),
+          sqlite_orm::make_column("acls", &DBTestObject::acls),
+          sqlite_orm::make_column("extra", &DBTestObject::extra),
+          sqlite_orm::foreign_key(&DBTestObject::bucket_id).references(&DBTestBucket::bucket_id)),
+    sqlite_orm::make_table(std::string(VERSIONED_OBJECTS_TABLE),
+          sqlite_orm::make_column("id", &DBTestVersionedObject::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("object_id", &DBTestVersionedObject::object_id),
+          sqlite_orm::make_column("checksum", &DBTestVersionedObject::checksum),
+          sqlite_orm::make_column("deletion_time", &DBTestVersionedObject::deletion_time),
+          sqlite_orm::make_column("size", &DBTestVersionedObject::size),
+          sqlite_orm::make_column("creation_time", &DBTestVersionedObject::creation_time),
+          sqlite_orm::make_column("object_state", &DBTestVersionedObject::object_state),
+          sqlite_orm::make_column("version_id", &DBTestVersionedObject::version_id),
+          sqlite_orm::make_column("etag", &DBTestVersionedObject::etag),
+          sqlite_orm::make_column("extra", &DBTestVersionedObject::extra),
+          sqlite_orm::foreign_key(&DBTestVersionedObject::object_id).references(&DBTestObject::object_id)),
+    sqlite_orm::make_table(std::string(ACCESS_KEYS),
+          sqlite_orm::make_column("id", &DBTestAccessKey::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("access_key", &DBTestAccessKey::access_key),
+          sqlite_orm::make_column("user_id", &DBTestAccessKey::user_id),
+          sqlite_orm::foreign_key(&DBTestAccessKey::user_id).references(&DBTestUser::user_id))
+  );
+}
+
+using TestStorage = decltype(_make_test_storage(""));
+
+struct TestDB {
+  TestStorage storage;
+  DBTestUser test_user;
+  DBTestBucket test_bucket;
+  DBTestObject test_object;
+  DBTestVersionedObject test_version;
+
+  explicit TestDB(const std::string & db_full_path)
+    : storage(_make_test_storage(db_full_path))
+  {
+    storage.open_forever();
+    storage.busy_timeout(5000);
+    storage.sync_schema();
+  }
+
+  DBTestUser get_test_user() {
+    DBTestUser user;
+    user.user_id = "user1";
+    return user;
+  }
+
+  DBTestBucket get_test_bucket() {
+    DBTestBucket bucket;
+    bucket.bucket_id = "bucket1_id";
+    bucket.bucket_name = "bucket1";
+    bucket.owner_id = "user1";
+    bucket.deleted = false;
+    return bucket;
+  }
+
+  DBTestObject get_test_object() {
+    DBTestObject object;
+    object.object_id = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
+    object.bucket_id = "bucket1_id";
+    object.name = "object_name";
+    return object;
+  }
+
+  DBTestVersionedObject get_test_version() {
+    DBTestVersionedObject version;
+    version.id = 1;
+    version.object_id = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
+    version.checksum = "checksum1";
+    encode_blob(ceph::real_clock::now(), version.deletion_time);
+    version.size = rand();
+    encode_blob(ceph::real_clock::now(), version.creation_time);
+    version.object_state = 2;
+    version.version_id = "version_id_1";
+    version.etag = "etag_1";
+    version.extra = "extra_1";
+    return version;
+  }
+
+  bool compareUser(const DBTestUser & user1, const DBTestUser & user2) {
+    if (user1.user_id != user2.user_id) return false;
+    return true;
+  }
+
+  bool compareBucket(const DBTestBucket & bucket1, const DBTestBucket & bucket2) {
+    if (bucket1.bucket_id != bucket2.bucket_id) return false;
+    if (bucket1.bucket_name != bucket2.bucket_name) return false;
+    if (bucket1.owner_id != bucket2.owner_id) return false;
+    return true;
+  }
+
+  bool compareObject(const DBTestObject & obj1, const DBTestObject & obj2) {
+    if (obj1.object_id != obj2.object_id) return false;
+    if (obj1.bucket_id != obj2.bucket_id) return false;
+    if (obj1.name != obj2.name) return false;
+    return true;
+  }
+
+  bool compareVersion(const DBTestVersionedObject & v1,
+                      const DBTestVersionedObject & v2) {
+    if (v1.version_id != v2.version_id) return false;
+    if (v1.object_id != v2.object_id) return false;
+    if (v1.checksum != v2.checksum) return false;
+    if (v1.deletion_time != v2.deletion_time) return false;
+    if (v1.size != v2.size) return false;
+    if (v1.creation_time != v2.creation_time) return false;
+    if (v1.object_state != v2.object_state) return false;
+    if (v1.version_id != v2.version_id) return false;
+    if (v1.etag != v2.etag) return false;
+    if (v1.extra != v2.extra) return false;
+    return true;
+  }
+
+  void addData() {
+    test_user = get_test_user();
+    storage.replace(test_user);
+
+    test_bucket = get_test_bucket();
+    storage.replace(test_bucket);
+
+    test_object = get_test_object();
+    storage.replace(test_object);
+
+    test_version = get_test_version();
+    storage.insert(test_version);
+  }
+
+  bool checkDataExists() {
+    auto buckets = storage.get_all<DBTestBucket>();
+    if (buckets.size() != 1) return false;
+
+    auto users = storage.get_all<DBTestUser>();
+    if (users.size() != 1) return false;
+
+    auto objs = storage.get_all<DBTestObject>();
+    if (objs.size() != 1) return false;
+
+    auto versions = storage.get_all<DBTestVersionedObject>();
+    if (versions.size() != 1) return false;
+
+    auto bucket = storage.get_pointer<DBTestBucket>(test_bucket.bucket_id);
+    if (!bucket) return false;
+    if (!compareBucket(*bucket, test_bucket)) return false;
+
+    auto user = storage.get_pointer<DBTestUser>(test_user.user_id);
+    if (!user) return false;
+    if (!compareUser(*user, test_user)) return false;
+
+    auto object = storage.get_pointer<DBTestObject>(test_object.object_id);
+    if (!object) return false;
+    if (!compareObject(*object, test_object)) return false;
+
+    auto version = storage.get_pointer<DBTestVersionedObject>(test_version.id);
+    if (!version) return false;
+    if (!compareVersion(*version, test_version)) return false;
+
+    return true;
+  }
+
+};
+
+} //  namespace rgw::test::metadata::new_columns_added

--- a/src/test/rgw/sfs/compatibility_test_cases/optional_columns_added.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/optional_columns_added.h
@@ -1,0 +1,309 @@
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/conversion_utils.h"
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace rgw::test::metadata::optional_columns_added {
+
+struct DBTestUser {
+  std::string user_id;
+  std::optional<std::string> tenant;
+  std::optional<std::string> ns;
+  std::optional<std::string> display_name;
+  std::optional<std::string> user_email;
+  std::optional<BLOB> access_keys;
+  std::optional<BLOB> swift_keys;
+  std::optional<BLOB> sub_users;
+  std::optional<unsigned char> suspended;
+  std::optional<int> max_buckets;
+  std::optional<int> op_mask;
+  std::optional<BLOB> user_caps;
+  std::optional<int> admin;
+  std::optional<int> system;
+  std::optional<std::string> placement_name;
+  std::optional<std::string> placement_storage_class;
+  std::optional<BLOB> placement_tags;
+  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> temp_url_keys;
+  std::optional<BLOB> user_quota;
+  std::optional<int> type;
+  std::optional<BLOB> mfa_ids;
+  std::optional<std::string> assumed_role_arn;
+  std::optional<BLOB> user_attrs;
+  std::optional<int> user_version;
+  std::optional<std::string> user_version_tag;
+};
+
+struct DBTestAccessKey {
+  int id;
+  std::string access_key;
+  std::string user_id;
+};
+
+struct DBTestBucket {
+  std::string bucket_name;
+  std::string bucket_id;
+  // these 2 columns will be added
+  // std::optional<std::string> tenant;
+  // std::optional<std::string> marker;
+  std::optional<int> size;
+  std::optional<int> size_rounded;
+  std::optional<BLOB> creation_time;
+  std::optional<int> count;
+  std::optional<std::string> placement_name;
+  std::optional<std::string> placement_storage_class;
+  std::string owner_id;
+  std::optional<uint32_t> flags;
+  std::optional<std::string> zone_group;
+  std::optional<bool> has_instance_obj;
+  std::optional<BLOB> quota;
+  std::optional<bool> requester_pays;
+  std::optional<bool> has_website;
+  std::optional<BLOB> website_conf;
+  std::optional<bool> swift_versioning;
+  std::optional<std::string> swift_ver_location;
+  std::optional<BLOB> mdsearch_config;
+  std::optional<std::string> new_bucket_instance_id;
+  std::optional<BLOB> object_lock;
+  std::optional<BLOB> sync_policy_info_groups;
+  std::optional<BLOB> bucket_attrs;
+  std::optional<int> bucket_version;
+  std::optional<std::string> bucket_version_tag;
+  std::optional<BLOB> mtime;
+  bool deleted;
+};
+
+struct DBTestObject {
+  std::string object_id;
+  std::string bucket_id;
+  std::string name;
+  std::optional<size_t> size;
+  std::optional<std::string> etag;
+  std::optional<BLOB> mtime;
+  std::optional<BLOB> set_mtime;
+  std::optional<BLOB> delete_at_time;
+  std::optional<BLOB> attrs;
+  std::optional<BLOB> acls;
+};
+
+struct DBTestVersionedObject {
+  uint id;
+  std::string object_id;
+  std::string checksum;
+  BLOB deletion_time;
+  size_t size;
+  BLOB creation_time;
+  uint object_state;
+  std::string version_id;
+  std::string etag;
+};
+
+inline auto _make_test_storage(const std::string &path) {
+  return sqlite_orm::make_storage(path,
+    sqlite_orm::make_table(std::string(USERS_TABLE),
+          sqlite_orm::make_column("user_id", &DBTestUser::user_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("tenant", &DBTestUser::tenant),
+          sqlite_orm::make_column("ns", &DBTestUser::ns),
+          sqlite_orm::make_column("display_name", &DBTestUser::display_name),
+          sqlite_orm::make_column("user_email", &DBTestUser::user_email),
+          sqlite_orm::make_column("access_keys", &DBTestUser::access_keys),
+          sqlite_orm::make_column("swift_keys", &DBTestUser::swift_keys),
+          sqlite_orm::make_column("sub_users", &DBTestUser::sub_users),
+          sqlite_orm::make_column("suspended", &DBTestUser::suspended),
+          sqlite_orm::make_column("max_buckets", &DBTestUser::max_buckets),
+          sqlite_orm::make_column("op_mask", &DBTestUser::op_mask),
+          sqlite_orm::make_column("user_caps", &DBTestUser::user_caps),
+          sqlite_orm::make_column("admin", &DBTestUser::admin),
+          sqlite_orm::make_column("system", &DBTestUser::system),
+          sqlite_orm::make_column("placement_name", &DBTestUser::placement_name),
+          sqlite_orm::make_column("placement_storage_class", &DBTestUser::placement_storage_class),
+          sqlite_orm::make_column("placement_tags", &DBTestUser::placement_tags),
+          sqlite_orm::make_column("bucke_quota", &DBTestUser::bucke_quota),
+          sqlite_orm::make_column("temp_url_keys", &DBTestUser::temp_url_keys),
+          sqlite_orm::make_column("user_quota", &DBTestUser::user_quota),
+          sqlite_orm::make_column("type", &DBTestUser::type),
+          sqlite_orm::make_column("mfa_ids", &DBTestUser::mfa_ids),
+          sqlite_orm::make_column("assumed_role_arn", &DBTestUser::assumed_role_arn),
+          sqlite_orm::make_column("user_attrs", &DBTestUser::user_attrs),
+          sqlite_orm::make_column("user_version", &DBTestUser::user_version),
+          sqlite_orm::make_column("user_version_tag", &DBTestUser::user_version_tag)),
+    sqlite_orm::make_table(std::string(BUCKETS_TABLE),
+          sqlite_orm::make_column("bucket_id", &DBTestBucket::bucket_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("bucket_name", &DBTestBucket::bucket_name),
+          // these 2 columns will be added
+          // sqlite_orm::make_column("tenant", &DBTestBucket::tenant),
+          // sqlite_orm::make_column("marker", &DBTestBucket::marker),
+          sqlite_orm::make_column("owner_id", &DBTestBucket::owner_id),
+          sqlite_orm::make_column("flags", &DBTestBucket::flags),
+          sqlite_orm::make_column("zone_group", &DBTestBucket::zone_group),
+          sqlite_orm::make_column("quota", &DBTestBucket::quota),
+          sqlite_orm::make_column("creation_time", &DBTestBucket::creation_time),
+          sqlite_orm::make_column("placement_name", &DBTestBucket::placement_name),
+          sqlite_orm::make_column("placement_storage_class", &DBTestBucket::placement_storage_class),
+          sqlite_orm::make_column("deleted", &DBTestBucket::deleted),
+          sqlite_orm::make_column("bucket_attrs", &DBTestBucket::bucket_attrs),
+          sqlite_orm::foreign_key(&DBTestBucket::owner_id).references(&DBTestUser::user_id)),
+    sqlite_orm::make_table(std::string(OBJECTS_TABLE),
+          sqlite_orm::make_column("object_id", &DBTestObject::object_id, sqlite_orm::primary_key()),
+          sqlite_orm::make_column("bucket_id", &DBTestObject::bucket_id),
+          sqlite_orm::make_column("name", &DBTestObject::name),
+          sqlite_orm::make_column("size", &DBTestObject::size),
+          sqlite_orm::make_column("etag", &DBTestObject::etag),
+          sqlite_orm::make_column("mtime", &DBTestObject::mtime),
+          sqlite_orm::make_column("set_mtime", &DBTestObject::set_mtime),
+          sqlite_orm::make_column("delete_at_time", &DBTestObject::delete_at_time),
+          sqlite_orm::make_column("attrs", &DBTestObject::attrs),
+          sqlite_orm::make_column("acls", &DBTestObject::acls),
+          sqlite_orm::foreign_key(&DBTestObject::bucket_id).references(&DBTestBucket::bucket_id)),
+    sqlite_orm::make_table(std::string(VERSIONED_OBJECTS_TABLE),
+          sqlite_orm::make_column("id", &DBTestVersionedObject::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("object_id", &DBTestVersionedObject::object_id),
+          sqlite_orm::make_column("checksum", &DBTestVersionedObject::checksum),
+          sqlite_orm::make_column("deletion_time", &DBTestVersionedObject::deletion_time),
+          sqlite_orm::make_column("size", &DBTestVersionedObject::size),
+          sqlite_orm::make_column("creation_time", &DBTestVersionedObject::creation_time),
+          sqlite_orm::make_column("object_state", &DBTestVersionedObject::object_state),
+          sqlite_orm::make_column("version_id", &DBTestVersionedObject::version_id),
+          sqlite_orm::make_column("etag", &DBTestVersionedObject::etag),
+          sqlite_orm::foreign_key(&DBTestVersionedObject::object_id).references(&DBTestObject::object_id)),
+    sqlite_orm::make_table(std::string(ACCESS_KEYS),
+          sqlite_orm::make_column("id", &DBAccessKey::id, sqlite_orm::autoincrement(), sqlite_orm::primary_key()),
+          sqlite_orm::make_column("access_key", &DBAccessKey::access_key),
+          sqlite_orm::make_column("user_id", &DBAccessKey::user_id),
+          sqlite_orm::foreign_key(&DBAccessKey::user_id).references(&DBTestUser::user_id))
+  );
+}
+
+using TestStorage = decltype(_make_test_storage(""));
+
+struct TestDB {
+  TestStorage storage;
+  DBTestUser test_user;
+  DBTestBucket test_bucket;
+  DBTestObject test_object;
+  DBTestVersionedObject test_version;
+
+  explicit TestDB(const std::string & db_full_path)
+    : storage(_make_test_storage(db_full_path))
+  {
+    storage.open_forever();
+    storage.busy_timeout(5000);
+    storage.sync_schema();
+  }
+
+  DBTestUser get_test_user() {
+    DBTestUser user;
+    user.user_id = "user1";
+    return user;
+  }
+
+  DBTestBucket get_test_bucket() {
+    DBTestBucket bucket;
+    bucket.bucket_id = "bucket1_id";
+    bucket.bucket_name = "bucket1";
+    bucket.owner_id = "user1";
+    return bucket;
+  }
+
+  DBTestObject get_test_object() {
+    DBTestObject object;
+    object.object_id = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
+    object.bucket_id = "bucket1_id";
+    object.name = "object_name";
+    return object;
+  }
+
+  DBTestVersionedObject get_test_version() {
+    DBTestVersionedObject version;
+    version.id = 1;
+    version.object_id = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
+    version.checksum = "checksum1";
+    encode_blob(ceph::real_clock::now(), version.deletion_time);
+    version.size = rand();
+    encode_blob(ceph::real_clock::now(), version.creation_time);
+    version.object_state = 2;
+    version.version_id = "version_id_1";
+    return version;
+  }
+
+  bool compareUser(const DBTestUser & user1, const DBTestUser & user2) {
+    if (user1.user_id != user2.user_id) return false;
+    return true;
+  }
+
+  bool compareBucket(const DBTestBucket & bucket1, const DBTestBucket & bucket2) {
+    if (bucket1.bucket_id != bucket2.bucket_id) return false;
+    if (bucket1.bucket_name != bucket2.bucket_name) return false;
+    if (bucket1.owner_id != bucket2.owner_id) return false;
+    return true;
+  }
+
+  bool compareObject(const DBTestObject & obj1, const DBTestObject & obj2) {
+    if (obj1.object_id != obj2.object_id) return false;
+    if (obj1.bucket_id != obj2.bucket_id) return false;
+    if (obj1.name != obj2.name) return false;
+    return true;
+  }
+
+  bool compareVersion(const DBTestVersionedObject & v1,
+                      const DBTestVersionedObject & v2) {
+    if (v1.version_id != v2.version_id) return false;
+    if (v1.object_id != v2.object_id) return false;
+    if (v1.checksum != v2.checksum) return false;
+    if (v1.deletion_time != v2.deletion_time) return false;
+    if (v1.size != v2.size) return false;
+    if (v1.creation_time != v2.creation_time) return false;
+    if (v1.object_state != v2.object_state) return false;
+    if (v1.version_id != v2.version_id) return false;
+    return true;
+  }
+
+  void addData() {
+    test_user = get_test_user();
+    storage.replace(test_user);
+
+    test_bucket = get_test_bucket();
+    storage.replace(test_bucket);
+
+    test_object = get_test_object();
+    storage.replace(test_object);
+
+    test_version = get_test_version();
+    storage.insert(test_version);
+  }
+
+  bool checkDataExists() {
+    auto buckets = storage.get_all<DBTestBucket>();
+    if (buckets.size() != 1) return false;
+
+    auto users = storage.get_all<DBTestUser>();
+    if (users.size() != 1) return false;
+
+    auto objs = storage.get_all<DBTestObject>();
+    if (objs.size() != 1) return false;
+
+    auto versions = storage.get_all<DBTestVersionedObject>();
+    if (versions.size() != 1) return false;
+
+    auto bucket = storage.get_pointer<DBTestBucket>(test_bucket.bucket_id);
+    if (!bucket) return false;
+    if (!compareBucket(*bucket, test_bucket)) return false;
+
+    auto user = storage.get_pointer<DBTestUser>(test_user.user_id);
+    if (!user) return false;
+    if (!compareUser(*user, test_user)) return false;
+
+    auto object = storage.get_pointer<DBTestObject>(test_object.object_id);
+    if (!object) return false;
+    if (!compareObject(*object, test_object)) return false;
+
+    auto version = storage.get_pointer<DBTestVersionedObject>(test_version.id);
+    if (!version) return false;
+    if (!compareVersion(*version, test_version)) return false;
+
+    return true;
+  }
+
+};
+
+} //  namespace rgw::test::metadata::new_columns_added

--- a/src/test/rgw/sfs/test_rgw_sfs_metadata_compatibility.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_metadata_compatibility.cc
@@ -1,0 +1,129 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/ceph_context.h"
+#include "common/ceph_time.h"
+
+#include "rgw/rgw_sal_sfs.h"
+
+#include "rgw/store/sfs/sqlite/dbconn.h"
+#include "rgw/store/sfs/sqlite/conversion_utils.h"
+
+// test cases
+#include "compatibility_test_cases/columns_deleted.h"
+#include "compatibility_test_cases/columns_added.h"
+#include "compatibility_test_cases/optional_columns_added.h"
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+
+/*
+  HINT
+  s3gw.db will create here: /tmp/rgw_sfs_tests
+*/
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace fs = std::filesystem;
+namespace metadata_tests = rgw::test::metadata;
+
+const static std::string TEST_DIR = "rgw_sfs_tests";
+
+
+class TestSFSMetadataCompatibility : public ::testing::Test {
+protected:
+  void SetUp() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::create_directory(TEST_DIR);
+  }
+
+  void TearDown() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(TEST_DIR);
+  }
+
+public:
+  static std::string getTestDir() {
+    auto test_dir = fs::temp_directory_path() / TEST_DIR;
+    return test_dir.string();
+  }
+
+  static fs::path getDBFullPath(const std::string & base_dir) {
+    auto db_full_name = "s3gw.db";
+    auto db_full_path = fs::path(base_dir) /  db_full_name;
+    return db_full_path;
+  }
+
+  static fs::path getDBFullPath() {
+    return getDBFullPath(getTestDir());
+  }
+
+};
+
+TEST_F(TestSFSMetadataCompatibility, ColumnsAdded) {
+  // checks adding extra columns.
+  // as the columns added have no default value and they cannot be empty it
+  // will throw an exception.
+  auto test_db =
+    std::make_shared<metadata_tests::columns_added::TestDB>(getDBFullPath());
+  test_db->addData();
+
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  ASSERT_THROW(new rgw::sal::SFStore(ceph_context.get(), getTestDir()),
+                sqlite_sync_exception);
+  try {
+    new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  } catch (const std::exception & e) {
+    // check the exception message
+    // this time it doesn't point the tables because it tries to drop the
+    // buckets table and as the objects table has a foreign key to buckets it
+    // throws a foreign key error.
+    EXPECT_STREQ("ERROR ACCESSING SFS METADATA. Metadata database might be corrupted or is no longer compatible",
+                  e.what());
+  }
+  // check that original data was not altered
+  EXPECT_TRUE(test_db->checkDataExists());
+}
+
+TEST_F(TestSFSMetadataCompatibility, OptionalColumnsAdded) {
+  // checks adding extra columns.
+  // as the columns added are optional no error should be thrown
+  auto test_db =
+    std::make_shared<metadata_tests::optional_columns_added::TestDB>(getDBFullPath());
+  test_db->addData();
+
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  ASSERT_NO_THROW(new rgw::sal::SFStore(ceph_context.get(), getTestDir()));
+  // check that original data was not altered
+  EXPECT_TRUE(test_db->checkDataExists());
+}
+
+TEST_F(TestSFSMetadataCompatibility, ColumnsDeleted) {
+  // creates a db that has extra columns.
+  // when the SFS database tries to sync it will detect columns removed
+  // in its schema
+  auto test_db =
+    std::make_shared<metadata_tests::columns_deleted::TestDB>(getDBFullPath());
+  test_db->addData();
+
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  // check that it throws a sqlite_sync_exception
+  ASSERT_THROW(new rgw::sal::SFStore(ceph_context.get(), getTestDir()),
+                sqlite_sync_exception);
+  try {
+    new rgw::sal::SFStore(ceph_context.get(), getTestDir());
+  } catch (const std::exception & e) {
+    // check the exception message
+    EXPECT_STREQ("ERROR ACCESSING SFS METADATA. Tables: [ objects versioned_objects ] are no longer compatible.",
+                  e.what());
+  }
+  // check that original data was not altered
+  EXPECT_TRUE(test_db->checkDataExists());
+}


### PR DESCRIPTION
Adds a check on metadata compatibility when the `SFStore` initialises.

It creates a temporary copy of the metadata database and tries to sync the schema on it.
If there are issues (exeptions) or any table is dropped due to incompatibilities between the data base and the actual metadata schema it throws a `sqlite_sync_exception`.

The execption is catched when the `SFStore` is instantiated and the error is logged before exiting `rgw`.

Previous database is not altered as all checks are done in the temporary database so we don't have data loss.

Fixes: https://github.com/aquarist-labs/s3gw/issues/178
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
