### PR TITLE
rgw/sfs: Fix s3tests_boto3.functional.test_s3.test_post_object_* bug

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed segfault when SFSAtomicWriter::complete is called whith mtime output
+  variable set to nullptr
+
 ## [0.7.0] - 2022-10-20
 
 ### Fixed

--- a/src/rgw/store/sfs/writer.cc
+++ b/src/rgw/store/sfs/writer.cc
@@ -107,7 +107,6 @@ int SFSAtomicWriter::complete(
 ) {
   lsfs_dout(dpp, 10) << "accounted_size: " << accounted_size
                      << ", etag: " << etag
-                     << ", mtime: " << to_iso_8601(*mtime)
                      << ", set_mtime: " << to_iso_8601(set_mtime)
                      << ", attrs: " << attrs
                      << ", delete_at: " << to_iso_8601(delete_at)
@@ -126,7 +125,9 @@ int SFSAtomicWriter::complete(
   meta.attrs = attrs;
   bucketref->finish(dpp, obj.get_name());
 
-  *mtime = meta.mtime;
+  if (mtime != nullptr) {
+    *mtime = meta.mtime;
+  }
   objref->metadata_finish(store);
   return 0;
 }


### PR DESCRIPTION
`mtime` parameter was logged but that's an output variable and might be `nullptr`.

Avoid logging it and check if it's `nullptr` before setting the value.

Fixes: https://github.com/aquarist-labs/s3gw/issues/191
Fixes: https://github.com/aquarist-labs/s3gw/issues/190
Fixes: https://github.com/aquarist-labs/s3gw/issues/182
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
