### PR TITLE
rgw/sfs: Generate delete markers for non existing objects

### DIFF
--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
   multiparts for an object while finishing a different object.
 - Fixed a few SQLite users operations that did not acquire the required locks
   when accessing the database.
+- Fixed issue when deleting a non-existing object with versioning enabled.
 
 ## [0.6.0] - 2022-09-29
 

--- a/src/rgw/store/sfs/types.h
+++ b/src/rgw/store/sfs/types.h
@@ -364,6 +364,8 @@ class Bucket {
 
   void delete_object(ObjectRef objref, const rgw_obj_key & key);
 
+  std::string create_non_existing_object_delete_marker(const rgw_obj_key & key);
+
   MultipartUploadRef get_multipart(
     const std::string &upload_id,
     const std::string &oid,


### PR DESCRIPTION
Adds code for adding a delete marker when deleting an object that doesn't exist.

According to the [AWS documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html) when deleting an object it should reply with no errors even if the object doesn't exist.

This means we create a delete-marker version for the object when versioning is enabled.

This also fixes the s3-test
test_versioning_multi_object_delete_with_marker_create which is exactly that test case.

**Note**
When undeleting delete markers (or deleting all versions of an object), if the object ends up having no version we just remove it from the in-memory objects map.
This is something that also could happen manually deleting all the version for an object and it was causing a segfault due to a `ceph_assert` before this pull request.

The Garbage collector could then permanently remove those objects without a version which are, in fact, no longer reachable.


**s3-test test**
```bash
S3TEST_CONF=s3tests.conf ./virtualenv/bin/nosetests -v -s s3tests_boto3.functional.test_s3:test_versioning_multi_object_delete_with_marker_create
/home/xavi/dev/0xavi0/s3-tests/virtualenv/lib/python3.6/site-packages/boto3/compat.py:88: PythonDeprecationWarning: Boto3 will no longer support Python 3.6 starting May 30, 2022. To continue receiving service updates, bug fixes, and security updates please upgrade to Python 3.7 or later. More information can be found here: https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/
  warnings.warn(warning, PythonDeprecationWarning)
Done with cleanup of buckets in tests.
Done with cleanup of buckets in tests.
Done with cleanup of buckets in tests.
s3tests_boto3.functional.test_s3.test_versioning_multi_object_delete_with_marker_create ... ok
Done with cleanup of buckets in tests.
Done with cleanup of buckets in tests.
Done with cleanup of buckets in tests.

----------------------------------------------------------------------
Ran 1 test in 0.278s

OK
```

Fixes: https://github.com/aquarist-labs/s3gw/issues/186
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>




## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
