### PR TITLE
rgw: add multivalue support to rgw_dns_name config option

### DIFF
--- a/doc/radosgw/s3/commons.rst
+++ b/doc/radosgw/s3/commons.rst
@@ -22,6 +22,8 @@ To configure virtual hosted buckets, you can either set ``rgw_dns_name = cname.d
 
 .. tip:: We prefer the first method, because the second method requires expensive domain certification and DNS wild cards.
 
+.. tip:: You can define multiple hostname directly with the :confval:`rgw_dns_name` parameter.
+
 Common Request Headers
 ----------------------
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -282,10 +282,11 @@ options:
 - name: rgw_dns_name
   type: str
   level: advanced
-  desc: The host name that RGW uses.
-  long_desc: This is Needed for virtual hosting of buckets to work properly, unless
+  desc: The host names that RGW uses.
+  long_desc: A comma separated list of DNS names.
+    This is Needed for virtual hosting of buckets to work properly, unless
     configured via zonegroup configuration.
-  fmt_desc: The DNS name of the served domain. See also the ``hostnames`` setting within regions.
+  fmt_desc: The DNS names of the served domains. See also the ``hostnames`` setting within zonegroups.
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -209,10 +209,14 @@ void rgw_rest_init(CephContext *cct, const rgw::sal::ZoneGroup& zone_group)
   for (const struct rgw_http_status_code *h = http_codes; h->code; h++) {
     http_status_names[h->code] = h->name;
   }
-  std::list<std::string> names;
 
+  std::list<std::string> rgw_dns_names;
+  std::string rgw_dns_names_str = cct->_conf->rgw_dns_name;
+  get_str_list(rgw_dns_names_str, ", ", rgw_dns_names);
+  hostnames_set.insert(rgw_dns_names.begin(), rgw_dns_names.end());
+
+  std::list<std::string> names;
   zone_group.get_hostnames(names);
-  hostnames_set.insert(cct->_conf->rgw_dns_name);
   hostnames_set.insert(names.begin(), names.end());
   hostnames_set.erase(""); // filter out empty hostnames
   ldout(cct, 20) << "RGW hostnames: " << hostnames_set << dendl;


### PR DESCRIPTION
Note:

This is the exact cherry-picked commit taken from the upstream [PR](https://github.com/ceph/ceph/pull/48554) 
Given that this is patching a generic non-sfs behavior, should we update the sfs's CHANGELOG.md ?

commit message:

rgw_dns_name configuration option has extended to define multiple domain values.
This option is now interpreted as a comma separated list of DNS names.

Example:

rgw_dns_name = cname.domain.com,cname2.domain2.com, cname3.domain3.com

Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
