### PR TITLE
ci: add new sfs unit tests and fixes GC test

### DIFF
--- a/.github/workflows/build-radosgw.yml
+++ b/.github/workflows/build-radosgw.yml
@@ -60,6 +60,8 @@ jobs:
             ceph/build/bin/unittest_rgw_sfs_sqlite_objects \
             ceph/build/bin/unittest_rgw_sfs_sqlite_versioned_objects \
             ceph/build/bin/unittest_rgw_sfs_sfs_bucket \
+            ceph/build/bin/unittest_rgw_sfs_metadata_compatibility \
+            ceph/build/bin/unittest_rgw_sfs_gc \
             ceph/build/lib/libceph-common.so \
             ceph/build/lib/libceph-common.so.2 \
             ceph/build/lib/libradosgw.so \

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Fixed
+
+- Fixed unittest_rgw_sfs_gc unit test
+
 ## [0.8.0] - 2022-11-10
 
 ### Fixed

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -131,6 +131,7 @@ protected:
     DBOPVersionedObjectInfo db_version;
     db_version.id = version;
     db_version.object_id = object->path.get_uuid();
+    db_version.object_state = rgw::sal::ObjectState::COMMITTED;
     db_versioned_objects.insert_versioned_object(db_version);
   }
 


### PR DESCRIPTION
Adds newly added unit tests so they're found when running the testcontainer.

It also fixes the `unittest_rgw_sfs_gc` that was throwing an exception in certain circumstances when converting a version object.

Fix is done in this same commit as the goal is to have the newly added tests and prevent other open PRs to be blocked.

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
