### PR TITLE
rgw/sfs: simplify SFSGC initialization/lifetime

### DIFF
--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -383,16 +383,11 @@ int SFStore::initialize(
   const DoutPrefixProvider* dpp
 ) {
   ldpp_dout(dpp, 10) << __func__ << dendl;
-  gc = new sfs::SFSGC();
-  gc->initialize(cct, this);
-  gc->start_processor();
   return 0;
 }
 
 void SFStore::finalize(void) {
   ldout(ctx(), 10) << __func__ << ": TODO" << dendl;
-  delete gc;
-  gc = nullptr;
   return;
 }
 
@@ -414,6 +409,7 @@ SFStore::SFStore(
 
   maybe_init_store();
   db_conn = std::make_shared<sfs::sqlite::DBConn>(cctx);
+  gc = std::make_shared<sfs::SFSGC>(cctx, this);
 
   // no need to be safe, we're in the ctor.
   _refresh_buckets();

--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -44,6 +44,7 @@
 namespace rgw::sal::sfs {
   class SFSGC;
 }
+
 namespace rgw::sal {
 
 class SFStore;
@@ -78,10 +79,10 @@ class SFStore : public Store {
   CephContext *const cctx;
   ceph::mutex buckets_map_lock = ceph::make_mutex("buckets_map_lock");
   std::map<std::string, sfs::BucketRef> buckets;
-  sfs::SFSGC *gc = nullptr;
 
  public:
   sfs::sqlite::DBConnRef db_conn;
+  std::shared_ptr<sfs::SFSGC> gc = nullptr;
 
   SFStore(CephContext *c, const std::filesystem::path &data_path);
   SFStore(const SFStore&) = delete;

--- a/src/rgw/store/sfs/sfs_gc.cc
+++ b/src/rgw/store/sfs/sfs_gc.cc
@@ -19,17 +19,20 @@
 
 namespace rgw::sal::sfs {
 
+SFSGC::SFSGC(CephContext *_cctx, SFStore *_store)
+  : cct(_cctx),
+    store(_store) {
+  worker = std::make_unique<GCWorker>(this, cct, this);
+  worker->create("rgw_gc");
+  down_flag = false;
+}
+
 SFSGC::~SFSGC() {
-  stop_processor();
-  finalize();
-}
-
-void SFSGC::initialize(CephContext *_cct, SFStore *_store) {
-  cct = _cct;
-  store = _store;
-}
-
-void SFSGC::finalize() {
+  down_flag = true;
+  if (worker) {
+    worker->stop();
+    worker->join();
+  }
 }
 
 int SFSGC::process() {
@@ -49,19 +52,16 @@ bool SFSGC::going_down() {
   return down_flag;
 }
 
-void SFSGC::start_processor() {
-  worker = new GCWorker(this, cct, this);
-  worker->create("rgw_gc");
+bool SFSGC::suspended() {
+  return suspend_flag;
 }
 
-void SFSGC::stop_processor() {
-  down_flag = true;
-  if (worker) {
-    worker->stop();
-    worker->join();
-    delete worker;
-  }
-  worker = nullptr;
+void SFSGC::suspend() {
+  suspend_flag = true;
+}
+
+void SFSGC::resume() {
+  suspend_flag = false;
 }
 
 unsigned SFSGC::get_subsys() const
@@ -161,14 +161,18 @@ void *SFSGC::GCWorker::entry() {
   do {
     utime_t start = ceph_clock_now();
     lsfs_dout(dpp, 2) << "start" << dendl;
-    int r = gc->process();
-    if (r < 0) {
-      lsfs_dout(dpp, 0)
-         << "ERROR: garbage collection process() returned error r="
-         << r
-         << dendl;
+
+    if (!gc->suspended()) {
+      int r = gc->process();
+      if (r < 0) {
+        lsfs_dout(dpp, 0)
+           << "ERROR: garbage collection process() returned error r="
+           << r
+           << dendl;
+      }
+      lsfs_dout(dpp, 2) << "stop" << dendl;
+
     }
-    lsfs_dout(dpp, 2) << "stop" << dendl;
 
     if (gc->going_down())
       break;

--- a/src/rgw/store/sfs/sfs_gc.h
+++ b/src/rgw/store/sfs/sfs_gc.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <memory>
+
 #include "rgw_sal.h"
 #include "rgw_sal_sfs.h"
 #include "store/sfs/types.h"
@@ -22,7 +24,8 @@ namespace rgw::sal::sfs {
 class SFSGC : public DoutPrefixProvider {
   CephContext *cct = nullptr;
   SFStore *store = nullptr;
-  std::atomic<bool> down_flag = { false };
+  std::atomic<bool> down_flag = { true };
+  std::atomic<bool> suspend_flag = { false };
   long int max_objects;
 
   class GCWorker : public Thread {
@@ -36,23 +39,22 @@ class SFSGC : public DoutPrefixProvider {
 
   public:
     GCWorker(const DoutPrefixProvider *_dpp, CephContext *_cct, SFSGC *_gc);
+
     void *entry() override;
     void stop();
   };
 
-  GCWorker *worker = nullptr;
+  std::unique_ptr<GCWorker> worker = nullptr;
 public:
-  SFSGC() = default;
+  SFSGC(CephContext *, SFStore *);
   ~SFSGC();
-
-  void initialize(CephContext *_cct, SFStore *_store);
-  void finalize();
 
   int process();
 
   bool going_down();
-  void start_processor();
-  void stop_processor();
+  bool suspended();
+  void suspend();
+  void resume();
 
   CephContext *get_cct() const override { return store->ctx(); }
   unsigned get_subsys() const;


### PR DESCRIPTION
- Lifetime of the GCWorker is now tied to the lifetime of the SFSGC object
- The garbagecollector object is created in the constructor of the SFStore
- Use smart pointers to manage object lifetime and ensure deallocation
- Remove initialize/finalize and start_/stop_processor methods, as their functionality was moved into constructors/destructors
- Prevent the construction of a dysfunctional SFSGC object by replacing the default constructor with one that requires all necessary parameters

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
