### PR TITLE
ci: Don't run sfs unit tests in the background

### DIFF
--- a/.github/workflows/build-test-radosgw.yml
+++ b/.github/workflows/build-test-radosgw.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run SFS unit tests
         run: |
-          docker run -d \
+          docker run \
             -v $GITHUB_WORKSPACE/ceph/build/bin:/radosgw/bin \
             -v $GITHUB_WORKSPACE/ceph/build/lib:/radosgw/lib \
             quay.io/s3gw/run-radosgw-tests


### PR DESCRIPTION
This fixes the CI to show the results of the unit tests. It was running the contained with `-d`, so the results were not shown in the workflow logs.

Fixes: https://github.com/aquarist-labs/s3gw/issues/283
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
