### PR TITLE
SQLite Performance

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -134,6 +134,7 @@ class DBConn {
   : storage(_make_storage(getDBPath(cct))) {
     storage.on_open = [this](sqlite3 *db) {
       sqlite_db = db;
+      sqlite3_busy_timeout(db, 10000);
     };
     storage.open_forever();
     storage.busy_timeout(5000);

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -134,6 +134,8 @@ class DBConn {
   : storage(_make_storage(getDBPath(cct))) {
     storage.on_open = [this](sqlite3 *db) {
       sqlite_db = db;
+
+      sqlite3_extended_result_codes(db, 1);
       sqlite3_busy_timeout(db, 10000);
     };
     storage.open_forever();

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 
+#include <sqlite3.h>
 #include <memory>
 #include <filesystem>
 #include "common/ceph_mutex.h"
@@ -127,7 +128,6 @@ class DBConn {
   Storage storage;
 
  public:
-  ceph::shared_mutex rwlock = ceph::make_shared_mutex("dbconn::rwlock");
   sqlite3 *sqlite_db;
 
   DBConn(CephContext *cct)

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -137,6 +137,7 @@ class DBConn {
 
       sqlite3_extended_result_codes(db, 1);
       sqlite3_busy_timeout(db, 10000);
+      sqlite3_exec(db, "PRAGMA journal_mode=WAL;PRAGMA synchronous=normal;PRAGMA temp_store = memory;PRAGMA mmap_size = 30000000000;", 0, 0, 0);
     };
     storage.open_forever();
     storage.busy_timeout(5000);

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -29,7 +29,6 @@ std::vector<DBOPBucketInfo> get_rgw_buckets(const std::vector<DBBucket> & db_buc
 }
 
 std::optional<DBOPBucketInfo> SQLiteBuckets::get_bucket(const std::string & bucket_id) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto bucket = storage.get_pointer<DBBucket>(bucket_id);
   std::optional<DBOPBucketInfo> ret_value;
@@ -40,50 +39,42 @@ std::optional<DBOPBucketInfo> SQLiteBuckets::get_bucket(const std::string & buck
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_bucket_by_name(const std::string & bucket_name) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return get_rgw_buckets(storage.get_all<DBBucket>(where(c(&DBBucket::bucket_name) = bucket_name)));
 }
 
 void SQLiteBuckets::store_bucket(const DBOPBucketInfo & bucket) const {
-  std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto db_bucket = get_db_bucket(bucket);
   storage.replace(db_bucket);
 }
 
 void SQLiteBuckets::remove_bucket(const std::string & bucket_name) const {
-  std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   storage.remove<DBBucket>(bucket_name);
 }
 
 std::vector<std::string> SQLiteBuckets::get_bucket_ids() const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return storage.select(&DBBucket::bucket_name);
 }
 
 std::vector<std::string> SQLiteBuckets::get_bucket_ids(const std::string & user_id) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return storage.select(&DBBucket::bucket_name, where(c(&DBBucket::owner_id) = user_id));
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets() const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return get_rgw_buckets(storage.get_all<DBBucket>());
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets(const std::string & user_id) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return get_rgw_buckets(storage.get_all<DBBucket>(where(c(&DBBucket::owner_id) = user_id)));
 }
 
 std::vector<std::string> SQLiteBuckets::get_deleted_buckets_ids() const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return storage.select(&DBBucket::bucket_id,
                         where(c(&DBBucket::deleted) = true));

--- a/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
@@ -43,7 +43,6 @@ SQLiteObjects::SQLiteObjects(DBConnRef _conn) : conn(_conn) { }
 std::vector<DBOPObjectInfo> SQLiteObjects::get_objects(
   const std::string &bucket_id
 ) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto objects = storage.get_all<DBObject>(
     where(is_equal(&DBObject::bucket_id, bucket_id))
@@ -52,7 +51,6 @@ std::vector<DBOPObjectInfo> SQLiteObjects::get_objects(
 }
 
 std::optional<DBOPObjectInfo> SQLiteObjects::get_object(const uuid_d & uuid) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto object = storage.get_pointer<DBObject>(uuid.to_string());
   std::optional<DBOPObjectInfo> ret_value;
@@ -64,7 +62,6 @@ std::optional<DBOPObjectInfo> SQLiteObjects::get_object(const uuid_d & uuid) con
 
 std::optional<DBOPObjectInfo> SQLiteObjects::get_object(const std::string & bucket_id,
                                                         const std::string & object_name) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto objects = storage.get_all<DBObject>(where(is_equal(&DBObject::bucket_id, bucket_id) and is_equal(&DBObject::name, object_name)));
   std::optional<DBOPObjectInfo> ret_value;
@@ -76,26 +73,22 @@ std::optional<DBOPObjectInfo> SQLiteObjects::get_object(const std::string & buck
 }
 
 void SQLiteObjects::store_object(const DBOPObjectInfo & object) const {
-  std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto db_object = get_db_object(object);
   storage.replace(db_object);
 }
 
 void SQLiteObjects::remove_object(const uuid_d & uuid) const {
-  std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   storage.remove<DBObject>(uuid.to_string());
 }
 
 std::vector<uuid_d> SQLiteObjects::get_object_ids() const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return get_rgw_uuids(storage.select(&DBObject::object_id));
 }
 
 std::vector<uuid_d> SQLiteObjects::get_object_ids(const std::string & bucket_id) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return get_rgw_uuids(storage.select(&DBObject::object_id, where(c(&DBObject::bucket_id) = bucket_id)));
 }

--- a/src/rgw/driver/sfs/sqlite/sqlite_users.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_users.cc
@@ -24,7 +24,6 @@ namespace rgw::sal::sfs::sqlite {
 SQLiteUsers::SQLiteUsers(DBConnRef _conn) : conn(_conn) { }
 
 std::optional<DBOPUserInfo> SQLiteUsers::get_user(const std::string & userid) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto user = storage.get_pointer<DBUser>(userid);
   std::optional<DBOPUserInfo> ret_value;
@@ -44,7 +43,6 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_email(const std::string & e
 }
 
 std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(const std::string & key) const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto user_id = _get_user_id_by_access_key(storage, key);
   std::optional<DBOPUserInfo> ret_value;
@@ -58,13 +56,11 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(const std::strin
 }
 
 std::vector<std::string> SQLiteUsers::get_user_ids() const {
-  std::shared_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   return storage.select(&DBUser::user_id);
 }
 
 void SQLiteUsers::store_user(const DBOPUserInfo & user) const {
-  std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   auto db_user = get_db_user(user);
   storage.replace(db_user);
@@ -72,7 +68,6 @@ void SQLiteUsers::store_user(const DBOPUserInfo & user) const {
 }
 
 void SQLiteUsers::remove_user(const std::string & userid) const {
-  std::unique_lock l(conn->rwlock);
   auto storage = conn->get_storage();
   _remove_access_keys(storage, userid);
   storage.remove<DBUser>(userid);
@@ -80,7 +75,6 @@ void SQLiteUsers::remove_user(const std::string & userid) const {
 
 template<class... Args>
 std::vector<DBOPUserInfo> SQLiteUsers::get_users_by(Args... args) const {
-  std::shared_lock l(conn->rwlock);
   std::vector<DBOPUserInfo> users_return;
   auto storage = conn->get_storage();
   auto users = storage.get_all<DBUser>(args...);


### PR DESCRIPTION
Remove rw mutexes around sqlite operations in favor of a busy timeout.

Enable some performance tuning options in SQLite like WOL mode.