### PR TITLE
rgw/sfs: Added prefix support when listing objects

### DIFF
--- a/qa/rgw/store/sfs/tests/test-sfs-list-objects.py
+++ b/qa/rgw/store/sfs/tests/test-sfs-list-objects.py
@@ -1,0 +1,182 @@
+# Copyright 2023 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+import sys
+import boto3, botocore
+import random
+import string
+import tempfile
+import os
+import filecmp
+
+class ListObjectsTests(unittest.TestCase):
+    ACCESS_KEY='test'
+    SECRET_KEY='test'
+    URL='http://127.0.0.1:7480'
+    BUCKET_NAME_LENGTH=8
+    OBJECT_NAME_LENGTH=10
+
+    def setUp(self):
+        self.s3_client = boto3.client('s3',
+                                endpoint_url=ListObjectsTests.URL,
+                                aws_access_key_id='test',
+                                aws_secret_access_key='test')
+
+        self.s3 = boto3.resource('s3',
+                                endpoint_url=ListObjectsTests.URL,
+                                aws_access_key_id='test',
+                                aws_secret_access_key='test')
+
+        self.test_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.s3_client.close()
+        self.test_dir.cleanup()
+
+    def get_random_name(self, length) -> str:
+        letters = string.ascii_lowercase
+        result_str = ''.join(random.choice(letters) for i in range(length))
+        return result_str
+
+    def get_random_bucket_name(self) -> str:
+        return self.get_random_name(ListObjectsTests.BUCKET_NAME_LENGTH)
+
+    def get_random_object_name(self) -> str:
+        return self.get_random_name(ListObjectsTests.OBJECT_NAME_LENGTH)
+
+    def generate_random_file(self, path, size=4):
+        # size passed is in mb
+        size = size * 1024 * 1024
+        with open(path, 'wb') as fout:
+            fout.write(os.urandom(size))
+
+    def assert_bucket_exists(self, bucket_name):
+        response = self.s3_client.list_buckets()
+        found = False
+        for bucket in response['Buckets']:
+            if (bucket['Name'] ==  bucket_name):
+                found = True
+        self.assertTrue(found)
+
+    def upload_file_and_check(self, bucket_name, object_name):
+        test_file_path = os.path.join(self.test_dir.name, object_name)
+        self.generate_random_file(test_file_path)
+        # upload the file
+        self.s3_client.upload_file(test_file_path, bucket_name, object_name)
+
+        # get the file and compare with the original
+        test_file_path_check = os.path.join(self.test_dir.name, 'test_file_check.bin')
+        self.s3_client.download_file(bucket_name, object_name, test_file_path_check)
+        self.assertTrue(filecmp.cmp(test_file_path, test_file_path_check, shallow=False))
+
+    def check_list_response_prefix(self, list_resp, objects_expected, prefix):
+        self.assertTrue('ResponseMetadata' in list_resp)
+        self.assertTrue('HTTPStatusCode' in list_resp['ResponseMetadata'])
+        self.assertTrue(200, list_resp['ResponseMetadata']['HTTPStatusCode'])
+        if (len(objects_expected) > 0):
+            self.assertTrue('Contents' in list_resp)
+            self.assertEqual(len(list_resp['Contents']), len(objects_expected))
+            found_objects = []
+            for obj in list_resp['Contents']:
+                self.assertTrue('Key' in obj)
+                if (obj['Key'] in objects_expected):
+                    found_objects.append(obj['Key'])
+            self.assertEqual(len(found_objects), len(objects_expected))
+        else:
+            self.assertFalse('Contents' in list_resp)
+        # check the prefix in the response
+        self.assertTrue('Prefix' in list_resp)
+        self.assertEqual(list_resp['Prefix'], prefix)
+
+    def test_list_objects_no_prefix(self):
+        bucket_name = self.get_random_bucket_name()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.assert_bucket_exists(bucket_name)
+        # objects to upload
+        objects = [
+            'prefix_obj1.bin',
+            'prefix_obj2.bin',
+            'prefix_obj3.bin',
+            'prefix_obj4.bin',
+            'test_file_1.bin',
+            'another_file.bin'
+        ]
+        for obj in objects:
+            self.upload_file_and_check(bucket_name, obj)
+        # list all objects
+        objs_ret = self.s3_client.list_objects(Bucket=bucket_name)
+        self.check_list_response_prefix(objs_ret, objects, '')
+
+    def test_list_objects_with_prefix(self):
+        bucket_name = self.get_random_bucket_name()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.assert_bucket_exists(bucket_name)
+        # objects to upload
+        objects = [
+            'prefix_obj1.bin',
+            'prefix_obj2.bin',
+            'prefix_obj3.bin',
+            'prefix_obj4.bin',
+            'test_file_1.bin',
+            'another_file.bin'
+        ]
+        for obj in objects:
+            self.upload_file_and_check(bucket_name, obj)
+        # list all objects with prefix equal to 'prefix'
+        objs_ret = self.s3_client.list_objects(Bucket=bucket_name, Prefix='prefix')
+        expected_objects = [
+            'prefix_obj1.bin',
+            'prefix_obj2.bin',
+            'prefix_obj3.bin',
+            'prefix_obj4.bin'
+        ]
+        self.check_list_response_prefix(objs_ret, expected_objects, 'prefix')
+
+        # check with 'test' prefix
+        objs_ret = self.s3_client.list_objects(Bucket=bucket_name, Prefix='test')
+        expected_objects = [
+            'test_file_1.bin'
+        ]
+        self.check_list_response_prefix(objs_ret, expected_objects, 'test')
+
+        # check with 'another' prefix
+        objs_ret = self.s3_client.list_objects(Bucket=bucket_name, Prefix='another')
+        expected_objects = [
+            'another_file.bin'
+        ]
+        self.check_list_response_prefix(objs_ret, expected_objects, 'another')
+
+        # list all objects with prefix equal to 'pr'
+        objs_ret = self.s3_client.list_objects(Bucket=bucket_name, Prefix='pr')
+        expected_objects = [
+            'prefix_obj1.bin',
+            'prefix_obj2.bin',
+            'prefix_obj3.bin',
+            'prefix_obj4.bin'
+        ]
+        self.check_list_response_prefix(objs_ret, expected_objects, 'pr')
+
+        # list all objects with prefix equal to 'nothing'
+        objs_ret = self.s3_client.list_objects(Bucket=bucket_name, Prefix='nothing')
+        expected_objects = []
+        self.check_list_response_prefix(objs_ret, expected_objects, 'nothing')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 2:
+        address_port = sys.argv.pop()
+        ListObjectsTests.URL = 'http://{0}'.format(address_port)
+        unittest.main()
+    else:
+        print ('usage: {0} ADDRESS:PORT'.format(sys.argv[0]))

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+
+### Added
+
+- Added prefix support when listing objects and object versions
+
 ## [0.9.0] - 2022-12-01
 
 ### Fixed

--- a/src/rgw/store/sfs/bucket.cc
+++ b/src/rgw/store/sfs/bucket.cc
@@ -71,10 +71,12 @@ int SFSBucket::list(const DoutPrefixProvider *dpp, ListParams &params, int max,
   if (params.list_versions) {
     return list_versions(dpp, params, max, results, y);
   }
-  
+
   std::lock_guard l(bucket->obj_map_lock);
   sfs::sqlite::SQLiteVersionedObjects db_versioned_objects(store->db_conn);
+  auto use_prefix = !params.prefix.empty();
   for (const auto &[name, objref]: bucket->objects) {
+    if (use_prefix && name.rfind(params.prefix, 0) != 0) continue;
     lsfs_dout(dpp, 10) << "object: " << name << dendl;
 
     auto last_version = db_versioned_objects.get_last_versioned_object(objref->path.get_uuid());
@@ -98,7 +100,9 @@ int SFSBucket::list(const DoutPrefixProvider *dpp, ListParams &params, int max,
 int SFSBucket::list_versions(const DoutPrefixProvider *dpp, ListParams &params,
                       int, ListResults &results, optional_yield y) {
   std::lock_guard l(bucket->obj_map_lock);
+  auto use_prefix = !params.prefix.empty();
   for (const auto &[name, objref]: bucket->objects) {
+    if (use_prefix && name.rfind(params.prefix, 0) != 0) continue;
     lsfs_dout(dpp, 10) << "object: " << name << dendl;
     // get all available versions from db
     sfs::sqlite::SQLiteVersionedObjects db_versioned_objects(store->db_conn);


### PR DESCRIPTION
Adds support for prefix when listing objects and object versions.

Right now as we're catching all the objects in memory only the filter is needed.
In future versions, when we don't have all the objects cached in memory a new query to `sqlite` metadata will be needed.

Fixes: https://github.com/aquarist-labs/s3gw/issues/261
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

**Test example**  (PR includes s3 boto tests)
```bash
$ s3cmd -c ./s3cfg mb s3://test
Bucket 's3://test/' created

$ s3cmd -c ./s3cfg put prefixtest_bla* s3://test/
upload: 'prefixtest_bla1.txt' -> 's3://test/prefixtest_bla1.txt'  [1 of 3]
 15 of 15   100% in    0s   614.75 B/s  done
upload: 'prefixtest_bla2.txt' -> 's3://test/prefixtest_bla2.txt'  [2 of 3]
 15 of 15   100% in    0s   559.62 B/s  done
upload: 'prefixtest_bla3.txt' -> 's3://test/prefixtest_bla3.txt'  [3 of 3]
 15 of 15   100% in    0s   661.61 B/s  done

$ s3cmd -c ./s3cfg put bla4.txt s3://test/
upload: 'bla4.txt' -> 's3://test/bla4.txt'  [1 of 1]
 15 of 15   100% in    0s   581.17 B/s  done

$ s3cmd -c ./s3cfg ls s3://test/prefix    
2023-01-03 14:49           15  s3://test/prefixtest_bla1.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla2.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla3.txt

$ s3cmd -c ./s3cfg ls s3://test/pr    
2023-01-03 14:49           15  s3://test/prefixtest_bla1.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla2.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla3.txt

$ s3cmd -c ./s3cfg ls s3://test/bl
2023-01-03 14:50           15  s3://test/bla4.txt

$ s3cmd -c ./s3cfg ls s3://test/  
2023-01-03 14:50           15  s3://test/bla4.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla1.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla2.txt
2023-01-03 14:49           15  s3://test/prefixtest_bla3.txt
```



## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
