### PR TITLE
rgw/sfs: Add delimiter support when listing objects

### DIFF
--- a/qa/rgw/store/sfs/tests/sfs-smoke-test.sh
+++ b/qa/rgw/store/sfs/tests/sfs-smoke-test.sh
@@ -76,7 +76,7 @@ s3 get s3://${bucket}/dne.bin && exit 1
 must_have=("obj1.bin" "obj1.bin.2" "my/obj1.bin")
 ifs_old=$IFS
 IFS=$'\n'
-lst=($(s3 ls s3://${bucket}))
+lst=($(s3 ls -r s3://${bucket}))
 
 [[ ${#lst[@]} -eq 3 ]] || exit 1
 for what in ${must_have[@]} ; do
@@ -115,7 +115,7 @@ do_copy() {
   md5_copy=$(md5sum -b obj1.bin.copy.${dst_bucket} | cut -f1 -d' ')
   [[ "${md5_copy}" == "${md5_obj1}" ]] || exit 1
 
-  if ! s3 ls s3://${dst_bucket} | grep -q obj1.bin.copy ; then
+  if ! s3 ls -r s3://${dst_bucket} | grep -q obj1.bin.copy ; then
     exit 1
   fi
 }
@@ -132,13 +132,13 @@ do_copy ${newbucket}
 s3 del --recursive --force s3://${bucket}
 
 # list the bucket, it should be empty
-lst=($(s3 ls s3://${bucket}))
+lst=($(s3 ls -r s3://${bucket}))
 [[ ${#lst[@]} -eq 0 ]] || exit 1
 
 # remove the bucket
 s3 rb s3://${bucket}
 
 # should no longer be available
-s3 ls s3://${bucket} && exit 1
+s3 ls -r s3://${bucket} && exit 1
 
 exit 0

--- a/src/rgw/store/sfs/CHANGELOG.md
+++ b/src/rgw/store/sfs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 ### Added
 
 - Added prefix support when listing objects and object versions
+- Added delimiter support when listing objects and object versions
 
 ## [0.9.0] - 2022-12-01
 

--- a/src/rgw/store/sfs/bucket.cc
+++ b/src/rgw/store/sfs/bucket.cc
@@ -81,6 +81,10 @@ int SFSBucket::list(const DoutPrefixProvider *dpp, ListParams &params, int max,
 
     auto last_version = db_versioned_objects.get_last_versioned_object(objref->path.get_uuid());
     if (last_version->object_state == rgw::sal::ObjectState::COMMITTED) {
+      // check for delimiter
+      if (check_add_common_prefix(dpp, name, params, 0, results, y)) {
+        continue;
+      }
       auto obj = _get_object(objref);
       rgw_bucket_dir_entry dirent;
       dirent.key = cls_rgw_obj_key(name, objref->instance);
@@ -104,6 +108,10 @@ int SFSBucket::list_versions(const DoutPrefixProvider *dpp, ListParams &params,
   for (const auto &[name, objref]: bucket->objects) {
     if (use_prefix && name.rfind(params.prefix, 0) != 0) continue;
     lsfs_dout(dpp, 10) << "object: " << name << dendl;
+    // check for delimiter
+    if (check_add_common_prefix(dpp, name, params, 0, results, y)) {
+      continue;
+    }
     // get all available versions from db
     sfs::sqlite::SQLiteVersionedObjects db_versioned_objects(store->db_conn);
     auto last_version = db_versioned_objects.get_last_versioned_object(objref->path.get_uuid());
@@ -128,6 +136,29 @@ int SFSBucket::list_versions(const DoutPrefixProvider *dpp, ListParams &params,
   }
   lsfs_dout(dpp, 10) << "found " << results.objs.size() << " objects" << dendl;
   return 0;
+}
+
+bool SFSBucket::check_add_common_prefix(const DoutPrefixProvider *dpp,
+                                const std::string & object_name,
+                                ListParams &params,
+                                int max,
+                                ListResults &results,
+                                optional_yield y) {
+  if (!params.delim.empty()) {
+    const int delim_pos = object_name.find(params.delim, params.prefix.size());
+    if (delim_pos >= 0) {
+      /* extract key -with trailing delimiter- for CommonPrefix */
+      const std::string& prefix_key =
+      object_name.substr(0, delim_pos + params.delim.length());
+
+      if (results.common_prefixes.find(prefix_key) ==
+                          results.common_prefixes.end()) {
+        results.common_prefixes[prefix_key] = true;
+      }
+      return true;
+    }
+  }
+  return false;
 }
 
 int SFSBucket::remove_bucket(const DoutPrefixProvider *dpp,

--- a/src/rgw/store/sfs/bucket.h
+++ b/src/rgw/store/sfs/bucket.h
@@ -68,6 +68,13 @@ class SFSBucket : public Bucket {
                       ListResults &results,
                       optional_yield y);
 
+  bool check_add_common_prefix(const DoutPrefixProvider *dpp,
+                                const std::string & object_name,
+                                ListParams &params,
+                                int max,
+                                ListResults &results,
+                                optional_yield y);
+
  public:
   SFSBucket(SFStore *_store, sfs::BucketRef _bucket);
   SFSBucket& operator=(const SFSBucket&) = delete;


### PR DESCRIPTION
This is implemented the same way that prefix support, as all objects are still cached in memory.

*Note for reviewers:*
I had to change the smoke tests because `s3cmd` uses the default delimiter `/` if we don't make the list recursive.
That's why we now need the `-r` parameter.
Otherwise it lists folders. 
```bash
$ s3 ls s3://test                              
                          DIR  s3://test/folder/
2023-01-10 10:19           66  s3://test/file1.bin
2023-01-10 10:19           66  s3://test/file2.bin

$ s3 ls -r s3://test    
2023-01-10 10:19           66  s3://test/file1.bin
2023-01-10 10:19           66  s3://test/file2.bin
2023-01-10 10:19           66  s3://test/folder/file3.bin
```



Fixes: https://github.com/aquarist-labs/s3gw/issues/306
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
