### PR TITLE
rgw: fix order of initialization and use in SFSGC

### DIFF
--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -459,6 +459,7 @@ int SFStore::initialize(
   const DoutPrefixProvider* dpp
 ) {
   ldpp_dout(dpp, 10) << __func__ << dendl;
+  gc->initialize();
   return 0;
 }
 

--- a/src/rgw/store/sfs/sfs_gc.cc
+++ b/src/rgw/store/sfs/sfs_gc.cc
@@ -15,7 +15,6 @@
 
 #include "store/sfs/sqlite/sqlite_objects.h"
 
-#define dout_subsys ceph_subsys_rgw
 
 namespace rgw::sal::sfs {
 
@@ -23,13 +22,11 @@ SFSGC::SFSGC(CephContext *_cctx, SFStore *_store)
   : cct(_cctx),
     store(_store) {
   worker = std::make_unique<GCWorker>(this, cct, this);
-  worker->create("rgw_gc");
-  down_flag = false;
 }
 
 SFSGC::~SFSGC() {
   down_flag = true;
-  if (worker) {
+  if (worker->is_started()) {
     worker->stop();
     worker->join();
   }
@@ -52,6 +49,16 @@ bool SFSGC::going_down() {
   return down_flag;
 }
 
+/*
+ * The constructor must have finished before the worker thread can be created,
+ * because otherwise the logging will dereference an invalid pointer, since the
+ * SFSGC instance is a prefix provider for the logging in the worker thread
+ */
+void SFSGC::initialize() {
+  worker->create("rgw_gc");
+  down_flag = false;
+}
+
 bool SFSGC::suspended() {
   return suspend_flag;
 }
@@ -62,11 +69,6 @@ void SFSGC::suspend() {
 
 void SFSGC::resume() {
   suspend_flag = false;
-}
-
-unsigned SFSGC::get_subsys() const
-{
-  return dout_subsys;
 }
 
 std::ostream& SFSGC::gen_prefix(std::ostream& out) const

--- a/src/rgw/store/sfs/sfs_gc.h
+++ b/src/rgw/store/sfs/sfs_gc.h
@@ -19,6 +19,9 @@
 #include "rgw_sal_sfs.h"
 #include "store/sfs/types.h"
 
+#define sfs_dout_subsys ceph_subsys_rgw
+
+
 namespace rgw::sal::sfs {
 
 class SFSGC : public DoutPrefixProvider {
@@ -52,14 +55,15 @@ public:
   int process();
 
   bool going_down();
+  void initialize();
   bool suspended();
   void suspend();
   void resume();
 
   CephContext *get_cct() const override { return store->ctx(); }
-  unsigned get_subsys() const;
+  unsigned get_subsys() const override { return sfs_dout_subsys; }
 
-  std::ostream& gen_prefix(std::ostream& out) const;
+  std::ostream& gen_prefix(std::ostream& out) const override;
 
   std::string get_cls_name() const { return "SFSGC"; }
 


### PR DESCRIPTION
Fix the order of initialization and use of the SFSGC. The worker thread can not start running until the SFSGC object has been completely allocated, because the SFSGC object is the dout prefix provider and a pointer to the SFSGC instance would be invalid until the constructor has finished.
Since the worker thread might want to print something out, this would resuult in an invalid pointer dereference.

Upon stopping, the SFSGC must query the worker thread if it has started, because an SFSGC instance could be created without calling `SFSGC::initialize()`. In this case calling `join()` on the worker has to be prevented.

Fixes bugs introduced in:
f7dbf8bd3d806c8887e42975b56a01e45ccfef5a

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
