### PR TITLE
Object lock object retention

### DIFF
--- a/qa/rgw/store/sfs/tests/test-sfs-object-locking.py
+++ b/qa/rgw/store/sfs/tests/test-sfs-object-locking.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import sys
+import boto3, botocore
+import tempfile
+import time
+from datetime import datetime
+from datetime import timedelta
+
+
+class ObjectLockingTests(unittest.TestCase):
+    ACCESS_KEY = "test"
+    SECRET_KEY = "test"
+    URL = "http://127.0.0.1:7480"
+
+    BUCKET_NAME_1 = "bobjlockenabled1"
+
+    ObjVersions = {}
+
+    def setUp(self):
+        self.s3_client = boto3.client(
+            "s3",
+            endpoint_url=ObjectLockingTests.URL,
+            aws_access_key_id=ObjectLockingTests.ACCESS_KEY,
+            aws_secret_access_key=ObjectLockingTests.SECRET_KEY,
+        )
+
+        self.s3 = boto3.resource(
+            "s3",
+            endpoint_url=ObjectLockingTests.URL,
+            aws_access_key_id=ObjectLockingTests.ACCESS_KEY,
+            aws_secret_access_key=ObjectLockingTests.SECRET_KEY,
+        )
+
+        self.test_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.s3_client.close()
+        self.test_dir.cleanup()
+
+    def ensure_bucket(self, bucket_name, objLockEnabled):
+        try:
+            self.s3_client.head_bucket(Bucket=bucket_name)
+        except botocore.exceptions.ClientError:
+            self.s3_client.create_bucket(
+                Bucket=bucket_name, ObjectLockEnabledForBucket=objLockEnabled
+            )
+
+    def test_object_locking_create_bucket(self):
+        self.ensure_bucket(ObjectLockingTests.BUCKET_NAME_1, True)
+        response = self.s3_client.get_bucket_versioning(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1
+        )
+        self.assertTrue(response["Status"] == "Enabled")
+        response = self.s3_client.get_object_lock_configuration(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["ObjectLockEnabled"] == "Enabled"
+        )
+
+        try:
+            self.s3_client.put_bucket_versioning(
+                Bucket=ObjectLockingTests.BUCKET_NAME_1,
+                VersioningConfiguration={"MFADelete": "Enabled", "Status": "Suspended"},
+            )
+            self.fail("cannot suspend versioning on ObjectLockEnabled bucket")
+        except botocore.exceptions.ClientError as error:
+            self.assertTrue(error.response["ResponseMetadata"]["HTTPStatusCode"] == 409)
+
+    def check_object_retention(self, response, mode, amount, type):
+        self.assertTrue(response["Retention"]["Mode"] == mode)
+        againstDate = datetime.utcnow() + timedelta(
+            days=amount if type == "Days" else amount * 365
+        )
+        checkDate = response["Retention"]["RetainUntilDate"]
+        self.assertTrue(checkDate.year == againstDate.year)
+        self.assertTrue(checkDate.month == againstDate.month)
+        self.assertTrue(checkDate.day == againstDate.day)
+
+    def test_object_locking_bucket_object_lock_default_configuration(self):
+        self.ensure_bucket(ObjectLockingTests.BUCKET_NAME_1, True)
+
+        # set GOVERNANCE DefaultRetention over bucket
+
+        self.s3_client.put_object_lock_configuration(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            ObjectLockConfiguration={
+                "ObjectLockEnabled": "Enabled",
+                "Rule": {"DefaultRetention": {"Mode": "GOVERNANCE", "Days": 7}},
+            },
+        )
+
+        response = self.s3_client.get_object_lock_configuration(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["ObjectLockEnabled"] == "Enabled"
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["Rule"]["DefaultRetention"]["Mode"]
+            == "GOVERNANCE"
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["Rule"]["DefaultRetention"]["Days"] == 7
+        )
+
+        self.s3_client.put_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Key="key.1", Body="data.1"
+        )
+
+        response = self.s3_client.list_object_versions(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Prefix="key.1"
+        )
+
+        for version in response["Versions"]:
+            if version["Key"] == "key.1" and version["IsLatest"] == True:
+                self.ObjVersions["key.1.1"] = version["VersionId"]
+                print(self.ObjVersions["key.1.1"])
+
+        response = self.s3_client.get_object_retention(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.1"],
+        )
+
+        self.check_object_retention(response, "GOVERNANCE", 7, "Days")
+
+        # set COMPLIANCE DefaultRetention over bucket
+
+        self.s3_client.put_object_lock_configuration(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            ObjectLockConfiguration={
+                "ObjectLockEnabled": "Enabled",
+                "Rule": {"DefaultRetention": {"Mode": "COMPLIANCE", "Years": 1}},
+            },
+        )
+
+        response = self.s3_client.get_object_lock_configuration(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["ObjectLockEnabled"] == "Enabled"
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["Rule"]["DefaultRetention"]["Mode"]
+            == "COMPLIANCE"
+        )
+        self.assertTrue(
+            response["ObjectLockConfiguration"]["Rule"]["DefaultRetention"]["Years"]
+            == 1
+        )
+
+        self.s3_client.put_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Key="key.1", Body="data.2"
+        )
+
+        response = self.s3_client.list_object_versions(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Prefix="key.1"
+        )
+
+        for version in response["Versions"]:
+            if version["Key"] == "key.1" and version["IsLatest"] == True:
+                self.ObjVersions["key.1.2"] = version["VersionId"]
+                print(self.ObjVersions["key.1.2"])
+
+        response = self.s3_client.get_object_retention(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.2"],
+        )
+
+        self.check_object_retention(response, "COMPLIANCE", 1, "Years")
+
+        # # check version key.1.1 still has the GOVERNANCE retention
+
+        response = self.s3_client.get_object_retention(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.1"],
+        )
+
+        self.check_object_retention(response, "GOVERNANCE", 7, "Days")
+
+    def test_object_locking_object_compliance(self):
+        self.ensure_bucket(ObjectLockingTests.BUCKET_NAME_1, True)
+
+        retainUntilDate = datetime.utcnow() + timedelta(days=6)
+
+        self.s3_client.put_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            Body="data.3",
+            ObjectLockMode="COMPLIANCE",
+            ObjectLockRetainUntilDate=retainUntilDate,
+        )
+
+        response = self.s3_client.list_object_versions(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Prefix="key.1"
+        )
+
+        for version in response["Versions"]:
+            if version["Key"] == "key.1" and version["IsLatest"] == True:
+                self.ObjVersions["key.1.3"] = version["VersionId"]
+                print(self.ObjVersions["key.1.3"])
+
+        response = self.s3_client.get_object_retention(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.3"],
+        )
+
+        self.check_object_retention(response, "COMPLIANCE", 6, "Days")
+
+        try:
+            response = self.s3_client.delete_object(
+                Bucket=ObjectLockingTests.BUCKET_NAME_1,
+                Key="key.1",
+                VersionId=self.ObjVersions["key.1.3"],
+            )
+        except botocore.exceptions.ClientError as error:
+            self.assertTrue(error.response["ResponseMetadata"]["HTTPStatusCode"] == 403)
+            self.assertTrue(error.response["Error"]["Code"] == "AccessDenied")
+            self.assertTrue(
+                error.response["Error"]["Message"] == "forbidden by object lock"
+            )
+
+        # test deletion is allowed after retainUntilDate expires
+
+        retainUntilDate = datetime.utcnow() + timedelta(seconds=1)
+
+        self.s3_client.put_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            Body="data.3.1",
+            ObjectLockMode="COMPLIANCE",
+            ObjectLockRetainUntilDate=retainUntilDate,
+        )
+
+        response = self.s3_client.list_object_versions(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Prefix="key.1"
+        )
+
+        for version in response["Versions"]:
+            if version["Key"] == "key.1" and version["IsLatest"] == True:
+                self.ObjVersions["key.1.3.1"] = version["VersionId"]
+                print(self.ObjVersions["key.1.3.1"])
+
+        # let's wait 2 seconds so that retainUntilDate expires.
+        time.sleep(2)
+
+        response = self.s3_client.delete_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.3.1"],
+        )
+
+    def test_object_locking_object_governance(self):
+        self.ensure_bucket(ObjectLockingTests.BUCKET_NAME_1, True)
+
+        retainUntilDate = datetime.utcnow() + timedelta(days=13)
+
+        self.s3_client.put_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            Body="data.4",
+            ObjectLockMode="GOVERNANCE",
+            ObjectLockRetainUntilDate=retainUntilDate,
+        )
+
+        response = self.s3_client.list_object_versions(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Prefix="key.1"
+        )
+
+        for version in response["Versions"]:
+            if version["Key"] == "key.1" and version["IsLatest"] == True:
+                self.ObjVersions["key.1.4"] = version["VersionId"]
+                print(self.ObjVersions["key.1.4"])
+
+        response = self.s3_client.get_object_retention(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.4"],
+        )
+
+        self.check_object_retention(response, "GOVERNANCE", 13, "Days")
+
+        try:
+            response = self.s3_client.delete_object(
+                Bucket=ObjectLockingTests.BUCKET_NAME_1,
+                Key="key.1",
+                VersionId=self.ObjVersions["key.1.4"],
+            )
+        except botocore.exceptions.ClientError as error:
+            self.assertTrue(error.response["ResponseMetadata"]["HTTPStatusCode"] == 403)
+            self.assertTrue(error.response["Error"]["Code"] == "AccessDenied")
+            self.assertTrue(
+                error.response["Error"]["Message"] == "forbidden by object lock"
+            )
+
+        # test deletion is allowed with BypassGovernanceRetention
+
+        response = self.s3_client.delete_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.4"],
+            BypassGovernanceRetention=True,
+        )
+
+        self.assertTrue(response["ResponseMetadata"]["HTTPStatusCode"] == 204)
+
+        # test deletion is allowed after retainUntilDate expires
+
+        retainUntilDate = datetime.utcnow() + timedelta(seconds=1)
+
+        self.s3_client.put_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            Body="data.4.1",
+            ObjectLockMode="GOVERNANCE",
+            ObjectLockRetainUntilDate=retainUntilDate,
+        )
+
+        response = self.s3_client.list_object_versions(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1, Prefix="key.1"
+        )
+
+        for version in response["Versions"]:
+            if version["Key"] == "key.1" and version["IsLatest"] == True:
+                self.ObjVersions["key.1.4.1"] = version["VersionId"]
+                print(self.ObjVersions["key.1.4.1"])
+
+        # let's wait 2 seconds so that retainUntilDate expires.
+        time.sleep(2)
+
+        response = self.s3_client.delete_object(
+            Bucket=ObjectLockingTests.BUCKET_NAME_1,
+            Key="key.1",
+            VersionId=self.ObjVersions["key.1.4.1"],
+        )
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        address_port = sys.argv.pop()
+        ObjectLockingTests.URL = "http://{0}".format(address_port)
+        unittest.main()
+    else:
+        print("usage: {0} ADDRESS:PORT".format(sys.argv[0]))

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -75,6 +75,7 @@ void Object::metadata_finish(SFStore *store) {
   sqlite::SQLiteObjects dbobjs(store->db_conn);
   auto db_object = dbobjs.get_object(path.get_uuid());
   ceph_assert(db_object.has_value());
+  db_object->name = name;
   db_object->size = meta.size;
   db_object->etag = meta.etag;
   db_object->mtime = meta.mtime;
@@ -210,6 +211,7 @@ void Bucket::_finish_object(ObjectRef ref) {
   oinfo.mtime = ref->meta.mtime;
   oinfo.set_mtime = ref->meta.set_mtime;
   oinfo.delete_at = ref->meta.delete_at;
+  ref->deleted = false;
 
   sqlite::SQLiteObjects dbobjs(store->db_conn);
   dbobjs.store_object(oinfo);

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -135,12 +135,30 @@ int SFSAtomicWriter::complete(
   meta.mtime = ceph::real_clock::now();
   meta.set_mtime = set_mtime;
   meta.delete_at = delete_at;
+
+  // for object-locking enabled buckets, set the bucket's object-locking
+  // profile when not defined on the object itself
+  if (bucketref->get_info().obj_lock_enabled() &&
+        bucketref->get_info().obj_lock.has_rule()) {
+    auto iter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
+    if (iter == attrs.end()) {
+      real_time lock_until_date =
+        bucketref->get_info().obj_lock.get_lock_until_date(meta.mtime);
+      string mode = bucketref->get_info().obj_lock.get_mode();
+      RGWObjectRetention obj_retention(mode, lock_until_date);
+      bufferlist bl;
+      obj_retention.encode(bl);
+      attrs[RGW_ATTR_OBJECT_RETENTION] = bl;
+    }
+  }
+
   meta.attrs = attrs;
   bucketref->finish(dpp, obj.get_name());
 
   if (mtime != nullptr) {
     *mtime = meta.mtime;
   }
+
   objref->metadata_finish(store);
   return 0;
 }


### PR DESCRIPTION
Object retention features implemented:

 - Default Bucket'retention configuration for both GOVERNANCE/COMPLIANCE
   modes.
 - Default bucket's retention mode on objects when no
   explicit retention is specified on put_object().
 - Explicit retention mode set on object's versions with put_object().
 - Tested expected behavior on objects for both GOVERNANCE/COMPLIANCE modes.
 - Tested expected behavior for deletions with BypassGovernanceRetention flag set.

Fixes: https://github.com/aquarist-labs/s3gw/issues/327
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
