### PR TITLE
ci/fix: Keep the `.note.ABI-tag` section

### DIFF
--- a/qa/rgw/store/sfs/build-radosgw.sh
+++ b/qa/rgw/store/sfs/build-radosgw.sh
@@ -14,6 +14,7 @@ SFS_CCACHE_DIR=${SFS_CCACHE_DIR:-"${CEPH_DIR}/build.ccache"}
 WITH_TESTS=${WITH_TESTS:-"OFF"}
 RUN_TESTS=${RUN_TESTS:-"OFF"}
 WITH_RADOSGW_DBSTORE=${WITH_RADOSGW_DBSTORE:-"OFF"}
+ALLOCATOR=${ALLOCATOR:-"tcmalloc"}
 
 CEPH_CMAKE_ARGS=(
   "-DCMAKE_C_COMPILER=gcc-11"
@@ -22,6 +23,7 @@ CEPH_CMAKE_ARGS=(
   "-DWITH_PYTHON3=3"
   "-DWITH_CCACHE=ON"
   "-DWITH_TESTS=ON"
+  "-DALLOCATOR=${ALLOCATOR}"
   "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
   "-DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
   "-DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
@@ -76,8 +78,8 @@ strip_radosgw() {
 
   echo "Stripping files ..."
   strip --strip-debug --strip-unneeded \
-    --remove-section=.comment --remove-section=.note.* \
     --keep-section=.GCC.command.line \
+    --remove-section=.comment \
     ${CEPH_DIR}/build/bin/radosgw \
     ${CEPH_DIR}/build/lib/*.so
 }


### PR DESCRIPTION
Keep the `.note.*` section when stripping the binaries during a release build.

The LSB specifies that a binary shall contain a `.note.ABI-tag` section, containing information about the expected kernel/system ABI [1]. On most systems this is not enforced, but some (like Oracle 9) enforce this and missing this section causes the binary to fail execution with and "exec format error".

[1]: https://refspecs.linuxfoundation.org/LSB_1.2.0/gLSB/noteabitag.html

Fixes: aquarist-labs/s3gw#305

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
