### PR TITLE
sfs: adapt tests to sqlite WAL mode

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.cc
+++ b/src/rgw/driver/sfs/sqlite/dbconn.cc
@@ -1,6 +1,7 @@
 #include "dbconn.h"
 
 #include <filesystem>
+#include <system_error>
 
 namespace fs = std::filesystem;
 namespace orm = sqlite_orm;
@@ -18,6 +19,13 @@ std::string get_temporary_db_path(CephContext *ctt) {
 void DBConn::check_metadata_is_compatible(CephContext *ctt) {
     // create a copy of the actual metadata
     fs::copy(getDBPath(ctt), get_temporary_db_path(ctt));
+    try {
+      fs::copy(getDBPath(ctt) + "-wal", get_temporary_db_path(ctt) + "-wal");
+    } catch (const std::filesystem::filesystem_error& e) {
+      if (e.code() != std::errc::no_such_file_or_directory) {
+        throw e;
+      }
+    }
 
     // try to sync the storage based on the temporary db
     // in case something goes wrong show possible errors and return
@@ -55,6 +63,14 @@ void DBConn::check_metadata_is_compatible(CephContext *ctt) {
     }
     // remove the temporary db
     fs::remove(get_temporary_db_path(ctt));
+
+    try {
+      fs::remove(get_temporary_db_path(ctt) + "-wal");
+    } catch (const std::filesystem::filesystem_error& e) {
+      if (e.code() != std::errc::no_such_file_or_directory) {
+        throw e;
+      }
+    }
 
     // if there was a sync issue, throw an exception
     if (sync_error) {

--- a/src/test/rgw/sfs/compatibility_test_cases/columns_added.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/columns_added.h
@@ -186,6 +186,14 @@ struct TestDB {
   explicit TestDB(const std::string & db_full_path)
     : storage(_make_test_storage(db_full_path))
   {
+    storage.on_open = [](sqlite3* db) {
+      sqlite3_extended_result_codes(db, 1);
+      sqlite3_busy_timeout(db, 10000);
+      sqlite3_exec(db,
+                   "PRAGMA journal_mode=WAL;PRAGMA synchronous=normal;"
+                   "PRAGMA temp_store = memory;PRAGMA mmap_size = 30000000000;",
+                   0, 0, 0);
+    };
     storage.open_forever();
     storage.busy_timeout(5000);
     storage.sync_schema();

--- a/src/test/rgw/sfs/compatibility_test_cases/columns_deleted.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/columns_deleted.h
@@ -188,6 +188,14 @@ struct TestDB {
   explicit TestDB(const std::string & db_full_path)
     : storage(_make_test_storage(db_full_path))
   {
+    storage.on_open = [](sqlite3* db) {
+      sqlite3_extended_result_codes(db, 1);
+      sqlite3_busy_timeout(db, 10000);
+      sqlite3_exec(db,
+                   "PRAGMA journal_mode=WAL;PRAGMA synchronous=normal;"
+                   "PRAGMA temp_store = memory;PRAGMA mmap_size = 30000000000;",
+                   0, 0, 0);
+    };
     storage.open_forever();
     storage.busy_timeout(5000);
     storage.sync_schema();

--- a/src/test/rgw/sfs/compatibility_test_cases/optional_columns_added.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/optional_columns_added.h
@@ -186,6 +186,14 @@ struct TestDB {
   explicit TestDB(const std::string & db_full_path)
     : storage(_make_test_storage(db_full_path))
   {
+    storage.on_open = [](sqlite3* db) {
+      sqlite3_extended_result_codes(db, 1);
+      sqlite3_busy_timeout(db, 10000);
+      sqlite3_exec(db,
+                   "PRAGMA journal_mode=WAL;PRAGMA synchronous=normal;"
+                   "PRAGMA temp_store = memory;PRAGMA mmap_size = 30000000000;",
+                   0, 0, 0);
+    };
     storage.open_forever();
     storage.busy_timeout(5000);
     storage.sync_schema();


### PR DESCRIPTION
Since the SQLite WAL PR, there is now more then one database file. This makes the tests fail, as they assume a single database file.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>
