### PR TITLE
ci: use self-hosted runners for PR verification

### DIFF
--- a/.github/workflows/build-test-radosgw.yml
+++ b/.github/workflows/build-test-radosgw.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -39,7 +39,6 @@ jobs:
         run: |
           docker run --rm \
             -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
-            -e NPROC=4 \
             -e WITH_TESTS=ON \
             quay.io/s3gw/build-radosgw:latest
 
@@ -55,23 +54,62 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y s3cmd
 
-      - name: Run smoke tests
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install Python Dependencies
         run: |
-          mkdir storage
-          docker run -d \
-            -v $GITHUB_WORKSPACE/storage:/data \
+          python3 -m pip install -r ceph/qa/rgw/store/sfs/tests/requirements.txt
+
+      - name: Run Integration tests
+        run: |
+          set -e
+          set -x
+
+          source ceph/qa/rgw/store/sfs/tests/helpers.sh
+
+          mkdir -p integration/storage
+          CONTAINER=$(docker run --rm -d \
+            -v $GITHUB_WORKSPACE/integration/storage:/data \
             -v $GITHUB_WORKSPACE/ceph/build/bin:/radosgw/bin \
             -v $GITHUB_WORKSPACE/ceph/build/lib:/radosgw/lib \
             -p 7480:7480 \
             quay.io/s3gw/run-radosgw \
               --rgw-backend-store sfs \
-              --debug-rgw 1
+              --debug-rgw 1)
 
-          sleep 5
-          # ^ This is needed to give the gateway some time to boot up.
-          # It also serves to make sure the gateway takes no more than 5 seconds
-          # to boot up.
+          wait_for_http_200 "http://127.0.0.1:7480"
 
-          echo "Running Tests:\n"
+          echo "Running Integration Tests:"
           cd ceph/qa/rgw/store/sfs/tests
-          ./run-tests.sh
+
+          python3 -m unittest test-*.py
+
+          docker kill $CONTAINER
+
+      - name: Run smoke tests
+        run: |
+          set -e
+          set -x
+
+          source ceph/qa/rgw/store/sfs/tests/helpers.sh
+
+          mkdir -p smoke/storage
+          CONTAINER=$(docker run --rm -d \
+            -v $GITHUB_WORKSPACE/smoke/storage:/data \
+            -v $GITHUB_WORKSPACE/ceph/build/bin:/radosgw/bin \
+            -v $GITHUB_WORKSPACE/ceph/build/lib:/radosgw/lib \
+            -p 7480:7480 \
+            quay.io/s3gw/run-radosgw \
+              --rgw-backend-store sfs \
+              --debug-rgw 1)
+
+          wait_for_http_200 "http://127.0.0.1:7480"
+
+          echo "Running Smoke Tests:"
+          cd ceph/qa/rgw/store/sfs/tests
+          ./sfs-smoke-test.sh 127.0.0.1:7480
+
+          docker kill $CONTAINER

--- a/qa/rgw/store/sfs/tests/helpers.sh
+++ b/qa/rgw/store/sfs/tests/helpers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# --------------------
+#
+# This file is a collection of helper functions for testing s3gw.
+# Source this in your shell(scripts) to make use of it, don't execute as script.
+
+
+# wait_for_http_200
+#
+# Takes a url and loops until the server responding at that url returns an HTTP
+# status 200 (ok), or up to one minute.
+function wait_for_http_200 {
+  local url="$1"
+
+  for _ in {1..60} ; do
+    if [[ $(curl -s -o/dev/null -w '%{http_code}' "$url") == "200" ]] ; then
+      return
+    fi
+    sleep 1
+  done
+  exit 1
+}


### PR DESCRIPTION
Use self-hosted runners to speed up builds/tests for PR verification.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

