### PR TITLE
rgw/sfs: fix db schema typo

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -66,7 +66,7 @@ inline auto _make_storage(const std::string &path) {
           sqlite_orm::make_column("placement_name", &DBUser::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBUser::placement_storage_class),
           sqlite_orm::make_column("placement_tags", &DBUser::placement_tags),
-          sqlite_orm::make_column("bucke_quota", &DBUser::bucke_quota),
+          sqlite_orm::make_column("bucket_quota", &DBUser::bucket_quota),
           sqlite_orm::make_column("temp_url_keys", &DBUser::temp_url_keys),
           sqlite_orm::make_column("user_quota", &DBUser::user_quota),
           sqlite_orm::make_column("type", &DBUser::type),

--- a/src/rgw/driver/sfs/sqlite/sqlite_schema.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_schema.h
@@ -63,7 +63,7 @@ class SQLiteSchema {
                           sqlite_orm::make_column("placement_name", &DBUser::placement_name),
                           sqlite_orm::make_column("placement_storage_class", &DBUser::placement_storage_class),
                           sqlite_orm::make_column("placement_tags", &DBUser::placement_tags),
-                          sqlite_orm::make_column("bucke_quota", &DBUser::bucke_quota),
+                          sqlite_orm::make_column("bucket_quota", &DBUser::bucket_quota),
                           sqlite_orm::make_column("temp_url_keys", &DBUser::temp_url_keys),
                           sqlite_orm::make_column("user_quota", &DBUser::user_quota),
                           sqlite_orm::make_column("type", &DBUser::type),

--- a/src/rgw/driver/sfs/sqlite/users/users_conversions.cc
+++ b/src/rgw/driver/sfs/sqlite/users/users_conversions.cc
@@ -35,7 +35,7 @@ DBOPUserInfo get_rgw_user(const DBUser & user) {
   assign_optional_value(user.placement_name, rgw_user.uinfo.default_placement.name);
   assign_optional_value(user.placement_storage_class, rgw_user.uinfo.default_placement.storage_class);
   assign_optional_value(user.placement_tags, rgw_user.uinfo.placement_tags);
-  assign_optional_value(user.bucke_quota, rgw_user.uinfo.quota.bucket_quota);
+  assign_optional_value(user.bucket_quota, rgw_user.uinfo.quota.bucket_quota);
   assign_optional_value(user.temp_url_keys, rgw_user.uinfo.temp_url_keys);
   assign_optional_value(user.user_quota, rgw_user.uinfo.quota.user_quota);
   assign_optional_value(user.type, rgw_user.uinfo.type);
@@ -67,7 +67,7 @@ DBUser get_db_user(const DBOPUserInfo & user) {
   assign_db_value(user.uinfo.default_placement.name, db_user.placement_name);
   assign_db_value(user.uinfo.default_placement.storage_class, db_user.placement_storage_class);
   assign_db_value(user.uinfo.placement_tags, db_user.placement_tags);
-  assign_db_value(user.uinfo.quota.bucket_quota, db_user.bucke_quota);
+  assign_db_value(user.uinfo.quota.bucket_quota, db_user.bucket_quota);
   assign_db_value(user.uinfo.temp_url_keys, db_user.temp_url_keys);
   assign_db_value(user.uinfo.quota.user_quota, db_user.user_quota);
   assign_db_value(user.uinfo.type, db_user.type);

--- a/src/rgw/driver/sfs/sqlite/users/users_definitions.h
+++ b/src/rgw/driver/sfs/sqlite/users/users_definitions.h
@@ -43,7 +43,7 @@ struct DBUser {
   std::optional<std::string> placement_name;
   std::optional<std::string> placement_storage_class;
   std::optional<BLOB> placement_tags;
-  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> bucket_quota;
   std::optional<BLOB> temp_url_keys;
   std::optional<BLOB> user_quota;
   std::optional<int> type;

--- a/src/test/rgw/sfs/compatibility_test_cases/columns_added.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/columns_added.h
@@ -23,7 +23,7 @@ struct DBTestUser {
   std::optional<std::string> placement_name;
   std::optional<std::string> placement_storage_class;
   std::optional<BLOB> placement_tags;
-  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> bucket_quota;
   std::optional<BLOB> temp_url_keys;
   std::optional<BLOB> user_quota;
   std::optional<int> type;
@@ -118,7 +118,7 @@ inline auto _make_test_storage(const std::string &path) {
           sqlite_orm::make_column("placement_name", &DBTestUser::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBTestUser::placement_storage_class),
           sqlite_orm::make_column("placement_tags", &DBTestUser::placement_tags),
-          sqlite_orm::make_column("bucke_quota", &DBTestUser::bucke_quota),
+          sqlite_orm::make_column("bucket_quota", &DBTestUser::bucket_quota),
           sqlite_orm::make_column("temp_url_keys", &DBTestUser::temp_url_keys),
           sqlite_orm::make_column("user_quota", &DBTestUser::user_quota),
           sqlite_orm::make_column("type", &DBTestUser::type),

--- a/src/test/rgw/sfs/compatibility_test_cases/columns_deleted.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/columns_deleted.h
@@ -23,7 +23,7 @@ struct DBTestUser {
   std::optional<std::string> placement_name;
   std::optional<std::string> placement_storage_class;
   std::optional<BLOB> placement_tags;
-  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> bucket_quota;
   std::optional<BLOB> temp_url_keys;
   std::optional<BLOB> user_quota;
   std::optional<int> type;
@@ -119,7 +119,7 @@ inline auto _make_test_storage(const std::string &path) {
           sqlite_orm::make_column("placement_name", &DBTestUser::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBTestUser::placement_storage_class),
           sqlite_orm::make_column("placement_tags", &DBTestUser::placement_tags),
-          sqlite_orm::make_column("bucke_quota", &DBTestUser::bucke_quota),
+          sqlite_orm::make_column("bucket_quota", &DBTestUser::bucket_quota),
           sqlite_orm::make_column("temp_url_keys", &DBTestUser::temp_url_keys),
           sqlite_orm::make_column("user_quota", &DBTestUser::user_quota),
           sqlite_orm::make_column("type", &DBTestUser::type),

--- a/src/test/rgw/sfs/compatibility_test_cases/optional_columns_added.h
+++ b/src/test/rgw/sfs/compatibility_test_cases/optional_columns_added.h
@@ -23,7 +23,7 @@ struct DBTestUser {
   std::optional<std::string> placement_name;
   std::optional<std::string> placement_storage_class;
   std::optional<BLOB> placement_tags;
-  std::optional<BLOB> bucke_quota;
+  std::optional<BLOB> bucket_quota;
   std::optional<BLOB> temp_url_keys;
   std::optional<BLOB> user_quota;
   std::optional<int> type;
@@ -118,7 +118,7 @@ inline auto _make_test_storage(const std::string &path) {
           sqlite_orm::make_column("placement_name", &DBTestUser::placement_name),
           sqlite_orm::make_column("placement_storage_class", &DBTestUser::placement_storage_class),
           sqlite_orm::make_column("placement_tags", &DBTestUser::placement_tags),
-          sqlite_orm::make_column("bucke_quota", &DBTestUser::bucke_quota),
+          sqlite_orm::make_column("bucket_quota", &DBTestUser::bucket_quota),
           sqlite_orm::make_column("temp_url_keys", &DBTestUser::temp_url_keys),
           sqlite_orm::make_column("user_quota", &DBTestUser::user_quota),
           sqlite_orm::make_column("type", &DBTestUser::type),


### PR DESCRIPTION
This change modifies the database schema, thus incompatible with existing deployments.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>
