### PR TITLE
rgw/sfs: fix condition variable in release builds

### DIFF
--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -559,7 +559,11 @@ SFStore::~SFStore() {
   shutdown = true;
 
   if (filesystem_stats_updater.joinable()) {
+#ifdef CEPH_DEBUG_MUTEX
     filesystem_stats_updater_cvar.notify_all(true);
+#else
+    filesystem_stats_updater_cvar.notify_all();
+#endif  // CEPH_DEBUG_MUTEX
     filesystem_stats_updater.join();
   }
 }


### PR DESCRIPTION
The ceph::condition_variable.notify_all() method takes an optional boolean parameter. For release builds,
std::condition_variable.notify_all() is used instead, which doesn't take any parameters. This #ifdef guards the use of the debug variant and restricts is usage to debug builds, allowing release builds to proceed.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

