### PR TITLE
rgw/sfs: Lifecycle initial implementation

### DIFF
--- a/.github/workflows/build-test-radosgw.yml
+++ b/.github/workflows/build-test-radosgw.yml
@@ -99,7 +99,8 @@ jobs:
             -p 7480:7480 \
             quay.io/s3gw/run-radosgw \
               --rgw-backend-store sfs \
-              --debug-rgw 1)
+              --debug-rgw 1 \
+              --rgw-lc-debug-interval 10)
 
           wait_for_http_200 "http://127.0.0.1:7480"
 

--- a/qa/rgw/store/sfs/tests/test-sfs-lifecycle-smoke.py
+++ b/qa/rgw/store/sfs/tests/test-sfs-lifecycle-smoke.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+import sys
+import boto3, botocore
+import random
+import string
+import tempfile
+import os
+import filecmp
+import time
+
+
+class LifecycleSmokeTests(unittest.TestCase):
+    ACCESS_KEY = "test"
+    SECRET_KEY = "test"
+    URL = "http://127.0.0.1:7480"
+    BUCKET_NAME_LENGTH = 8
+    OBJECT_NAME_LENGTH = 10
+    LIFECYCLE_DEBUG_INTERVAL = 10
+
+    def setUp(self):
+        self.s3_client = boto3.client(
+            "s3",
+            endpoint_url=LifecycleSmokeTests.URL,
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        )
+
+        self.s3 = boto3.resource(
+            "s3",
+            endpoint_url=LifecycleSmokeTests.URL,
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        )
+
+        self.test_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.s3_client.close()
+        self.test_dir.cleanup()
+
+    def get_random_name(self, length) -> str:
+        letters = string.ascii_lowercase
+        result_str = "".join(random.choice(letters) for i in range(length))
+        return result_str
+
+    def get_random_bucket_name(self) -> str:
+        return self.get_random_name(LifecycleSmokeTests.BUCKET_NAME_LENGTH)
+
+    def get_random_object_name(self) -> str:
+        return self.get_random_name(LifecycleSmokeTests.OBJECT_NAME_LENGTH)
+
+    def generate_random_file(self, path, size=4):
+        # size passed is in mb
+        size = size * 1024 * 1024
+        with open(path, "wb") as fout:
+            fout.write(os.urandom(size))
+
+    def assert_bucket_exists(self, bucket_name):
+        response = self.s3_client.list_buckets()
+        found = False
+        for bucket in response["Buckets"]:
+            if bucket["Name"] == bucket_name:
+                found = True
+        self.assertTrue(found)
+
+    def upload_file_and_check(self, bucket_name, object_name):
+        test_file_path = os.path.join(self.test_dir.name, object_name.replace("/", "_"))
+        self.generate_random_file(test_file_path)
+        # upload the file
+        self.s3_client.upload_file(test_file_path, bucket_name, object_name)
+
+        # get the file and compare with the original
+        test_file_path_check = os.path.join(self.test_dir.name, "test_file_check.bin")
+        self.s3_client.download_file(bucket_name, object_name, test_file_path_check)
+        self.assertTrue(
+            filecmp.cmp(test_file_path, test_file_path_check, shallow=False)
+        )
+
+    def check_objects_exist(self, objects, objects_expected):
+        objects_found = 0
+        for obj in objects:
+            if obj["Key"] in objects_expected:
+                objects_found += 1
+        self.assertEqual(len(objects_expected), objects_found)
+        self.assertEqual(len(objects_expected), len(objects))
+
+    def create_random_buckets(self, num_buckets):
+        buckets = []
+        for i in range(num_buckets):
+            bucket_name = self.get_random_bucket_name()
+            buckets.append(bucket_name)
+            self.s3_client.create_bucket(Bucket=bucket_name)
+            self.assert_bucket_exists(bucket_name)
+        return buckets
+
+    def test_expiration(self):
+        bucket_name = self.get_random_bucket_name()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.assert_bucket_exists(bucket_name)
+        objects = [
+            "expire1/foo",
+            "expire1/bar",
+            "keep2/foo",
+            "keep2/bar",
+            "expire3/foo",
+            "expire3/bar",
+        ]
+        for obj in objects:
+            self.upload_file_and_check(bucket_name, obj)
+
+        response = self.s3_client.list_objects(Bucket=bucket_name)
+        self.check_objects_exist(response["Contents"], objects)
+
+        rules = [
+            {
+                "ID": "rule1",
+                "Expiration": {"Days": 1},
+                "Filter": {
+                   "Prefix": "expire1/"
+                },
+                "Status": "Enabled",
+            },
+            {
+                "ID": "rule2",
+                "Expiration": {"Days": 5},
+                "Filter": {
+                   "Prefix": "expire3/"
+                },
+                "Status": "Enabled",
+            },
+        ]
+        lifecycle = {"Rules": rules}
+        self.s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket_name, LifecycleConfiguration=lifecycle
+        )
+
+        # give enough time to expire.
+        # 3 cycles because:
+        #                   1st cycle won't be expired yet (not still 1 day)
+        #                   2nd cycle rgw considers the bucket at processed
+        #                       today and skips it
+        #                   3rd cycle will be fully expired
+        time.sleep(3 * LifecycleSmokeTests.LIFECYCLE_DEBUG_INTERVAL)
+        response = self.s3_client.list_objects(Bucket=bucket_name)
+        self.check_objects_exist(
+            response["Contents"],
+            ["keep2/foo", "keep2/bar", "expire3/foo", "expire3/bar"],
+        )
+
+        time.sleep(LifecycleSmokeTests.LIFECYCLE_DEBUG_INTERVAL)
+        # at this point there are still not enough cycles to count 5 days
+        response = self.s3_client.list_objects(Bucket=bucket_name)
+        self.check_objects_exist(
+            response["Contents"],
+            ["keep2/foo", "keep2/bar", "expire3/foo", "expire3/bar"],
+        )
+
+        # same logic as above for number of cycles plus
+        time.sleep(3 * LifecycleSmokeTests.LIFECYCLE_DEBUG_INTERVAL)
+        response = self.s3_client.list_objects(Bucket=bucket_name)
+        self.check_objects_exist(response["Contents"], ["keep2/foo", "keep2/bar"])
+
+    def test_lifecycle_versioning_enabled(self):
+        bucket_name = self.get_random_bucket_name()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.assert_bucket_exists(bucket_name)
+        response = self.s3_client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={"MFADelete": "Disabled", "Status": "Enabled"},
+        )
+        test_file_path_1 = os.path.join(self.test_dir.name, "test_file_1.bin")
+        self.generate_random_file(test_file_path_1)
+        # upload the file
+        self.s3_client.upload_file(test_file_path_1, bucket_name, "expire1/test")
+        # now upload again with different content
+        test_file_path_2 = os.path.join(self.test_dir.name, "test_file_2.bin")
+        self.generate_random_file(test_file_path_2)
+        self.s3_client.upload_file(test_file_path_2, bucket_name, "expire1/test")
+        response = self.s3_client.list_object_versions(Bucket=bucket_name, Prefix="")
+        self.assertTrue("Versions" in response)
+        self.assertEqual(2, len(response["Versions"]))
+        self.assertFalse("DeleteMarkers" in response)
+
+        rules = [
+            {
+                "ID": "rule1",
+                "Expiration": {"Days": 1},
+                "Filter": {
+                   "Prefix": "expire1/"
+                },
+                "Status": "Enabled",
+            }
+        ]
+        lifecycle = {"Rules": rules}
+        self.s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket_name, LifecycleConfiguration=lifecycle
+        )
+
+        # give enough time to expire.
+        # 4 cycles because:
+        #                   1st cycle won't be expired yet (not still 1 day)
+        #                   2nd cycle rgw considers the bucket at processed
+        #                       today and skips it
+        #                   3rd cycle will be fully expired
+        time.sleep(3 * LifecycleSmokeTests.LIFECYCLE_DEBUG_INTERVAL)
+        response = self.s3_client.list_object_versions(Bucket=bucket_name, Prefix="")
+        self.assertTrue("Versions" in response)
+        self.assertEqual(2, len(response["Versions"]))
+        self.assertTrue("DeleteMarkers" in response)
+        self.assertEqual(1, len(response["DeleteMarkers"]))
+
+    def test_expiration_multiple_buckets(self):
+        buckets = self.create_random_buckets(10)
+        objects = [
+            "expire1/foo",
+            "expire1/bar",
+            "keep2/foo",
+            "keep2/bar",
+            "expire3/foo",
+            "expire3/bar",
+        ]
+        rules = [
+            {
+                "ID": "rule1",
+                "Expiration": {"Days": 1},
+                "Filter": {
+                   "Prefix": "expire1/"
+                },
+                "Status": "Enabled",
+            }
+        ]
+        lifecycle = {"Rules": rules}
+        for bucket in buckets:
+            for obj in objects:
+                self.upload_file_and_check(bucket, obj)
+
+        for bucket in buckets:
+            response = self.s3_client.list_objects(Bucket=bucket)
+            self.check_objects_exist(response["Contents"], objects)
+
+        for bucket in buckets:
+            self.s3_client.put_bucket_lifecycle_configuration(
+                Bucket=bucket, LifecycleConfiguration=lifecycle
+            )
+
+        # give enough time to expire.
+        # 3 cycles because:
+        #                   1st cycle won't be expired yet (not still 1 day)
+        #                   2nd cycle rgw considers the bucket at processed
+        #                       today and skips it
+        #                   3rd cycle will be fully expired
+        time.sleep(3 * LifecycleSmokeTests.LIFECYCLE_DEBUG_INTERVAL)
+        for bucket in buckets:
+            response = self.s3_client.list_objects(Bucket=bucket)
+            self.check_objects_exist(
+                response["Contents"],
+                ["keep2/foo", "keep2/bar", "expire3/foo", "expire3/bar"],
+            )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2:
+        address_port = sys.argv.pop()
+        LifecycleSmokeTests.URL = "http://{0}".format(address_port)
+        unittest.main()
+    else:
+        print("usage: {0} ADDRESS:PORT".format(sys.argv[0]))

--- a/src/rgw/driver/sfs/CMakeLists.txt
+++ b/src/rgw/driver/sfs/CMakeLists.txt
@@ -21,6 +21,7 @@ set(sfs_srcs
     sqlite/sqlite_buckets.cc
     sqlite/sqlite_objects.cc
     sqlite/sqlite_versioned_objects.cc
+    sqlite/sqlite_lifecycle.cc
     sqlite/users/users_conversions.cc
     sqlite/buckets/bucket_conversions.cc
     sqlite/objects/object_conversions.cc
@@ -36,6 +37,7 @@ set(sfs_srcs
     sfs_bucket.cc
     sfs_gc.cc
     sfs_user.cc
+    sfs_lc.cc
     )
 
 add_library(sfs STATIC ${sfs_srcs})

--- a/src/rgw/driver/sfs/bucket.cc
+++ b/src/rgw/driver/sfs/bucket.cc
@@ -265,6 +265,14 @@ int SFSBucket::merge_and_store_attrs(
       acls.decode(lval);
     }
   }
+  for (auto& it : attrs) {
+    auto it_find = new_attrs.find(it.first);
+    if (it_find == new_attrs.end()) {
+      // this is an old attr that is not defined in the new_attrs
+      // delete it
+      attrs.erase(it.first);
+    }
+  }
 
   sfs::get_meta_buckets(get_store().db_conn)
       ->store_bucket(sfs::sqlite::DBOPBucketInfo(get_info(), get_attrs()));

--- a/src/rgw/driver/sfs/sfs_bucket.cc
+++ b/src/rgw/driver/sfs/sfs_bucket.cc
@@ -28,11 +28,18 @@ int SFStore::set_buckets_enabled(
 }
 
 int SFStore::get_bucket(
-    User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket
+    User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* result
 ) {
-  // TODO implement get_bucket by RGWBucketInfo
-  ldout(ctx(), 10) << __func__ << ": TODO get_bucket by RGWBucketInfo" << dendl;
-  return -ENOTSUP;
+  std::lock_guard l(buckets_map_lock);
+  auto it = buckets.find(i.bucket.name);
+  if (it == buckets.end()) {
+    return -ENOENT;
+  }
+  auto bucketref = it->second;
+
+  auto bucket = make_unique<SFSBucket>(this, bucketref);
+  result->reset(bucket.release());
+  return 0;
 }
 
 int SFStore::get_bucket(

--- a/src/rgw/driver/sfs/sfs_lc.cc
+++ b/src/rgw/driver/sfs/sfs_lc.cc
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#include "sfs_lc.h"
+
+#include <common/dout.h>
+
+#include <vector>
+
+#include "sqlite/sqlite_lifecycle.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::sal::sfs {
+
+SFSLifecycle::SFSLifecycle(SFStore* _st) : store(_st) {}
+
+int SFSLifecycle::get_entry(
+    const std::string& oid, const std::string& marker,
+    std::unique_ptr<LCEntry>* entry
+) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  auto db_entry = sqlite_lc.get_entry(oid, marker);
+  if (!db_entry) {
+    return -ENOENT;
+  }
+  *entry = std::make_unique<rgw::sal::StoreLifecycle::StoreLCEntry>(
+      db_entry->bucket_name, db_entry->start_time, db_entry->status
+  );
+  return 0;
+}
+
+int SFSLifecycle::get_next_entry(
+    const std::string& oid, const std::string& marker,
+    std::unique_ptr<LCEntry>* entry
+) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  auto db_entry = sqlite_lc.get_next_entry(oid, marker);
+  if (!db_entry) {
+    std::string empty;
+    *entry =
+        std::make_unique<rgw::sal::StoreLifecycle::StoreLCEntry>(empty, 0, 0);
+  } else {
+    *entry = std::make_unique<rgw::sal::StoreLifecycle::StoreLCEntry>(
+        db_entry->bucket_name, db_entry->start_time, db_entry->status
+    );
+  }
+  return 0;
+}
+
+int SFSLifecycle::set_entry(const std::string& oid, LCEntry& entry) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  rgw::sal::sfs::sqlite::DBOPLCEntry db_entry{
+      oid, entry.get_bucket(), entry.get_start_time(), entry.get_status()};
+  sqlite_lc.store_entry(db_entry);
+  return 0;
+}
+
+int SFSLifecycle::list_entries(
+    const std::string& oid, const std::string& marker, uint32_t max_entries,
+    std::vector<std::unique_ptr<LCEntry>>& entries
+) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  auto db_entries = sqlite_lc.list_entries(oid, marker, max_entries);
+  for (auto& db_entry : db_entries) {
+    entries.push_back(std::make_unique<rgw::sal::StoreLifecycle::StoreLCEntry>(
+        db_entry.bucket_name, db_entry.start_time, db_entry.status
+    ));
+  }
+  return 0;
+}
+
+int SFSLifecycle::rm_entry(const std::string& oid, LCEntry& entry) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  sqlite_lc.remove_entry(oid, entry.get_bucket());
+  return 0;
+}
+
+int SFSLifecycle::get_head(
+    const std::string& oid, std::unique_ptr<LCHead>* head
+) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  auto db_head = sqlite_lc.get_head(oid);
+  *head = std::make_unique<rgw::sal::StoreLifecycle::StoreLCHead>(
+      db_head.start_date, 0, db_head.marker
+  );
+  return 0;
+}
+
+int SFSLifecycle::put_head(const std::string& oid, LCHead& head) {
+  rgw::sal::sfs::sqlite::SQLiteLifecycle sqlite_lc(store->db_conn);
+  rgw::sal::sfs::sqlite::DBOPLCHead db_head{
+      oid, head.get_marker(), head.get_start_date()};
+  sqlite_lc.store_head(db_head);
+  return 0;
+}
+
+std::unique_ptr<LCSerializer> SFSLifecycle::get_serializer(
+    const std::string& lock_name, const std::string& oid,
+    const std::string& cookie
+) {
+  // creates or returns the mutex in the map for the given oid
+  std::timed_mutex& mutex = mutex_map[oid];
+  return std::make_unique<LCSFSSerializer>(
+      mutex, store, oid, lock_name, cookie
+  );
+}
+
+}  // namespace rgw::sal::sfs

--- a/src/rgw/driver/sfs/sfs_lc.h
+++ b/src/rgw/driver/sfs/sfs_lc.h
@@ -1,0 +1,80 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#pragma once
+
+#include <chrono>
+#include <mutex>
+
+#include "rgw_lc.h"
+#include "rgw_sal.h"
+#include "rgw_sal_sfs.h"
+
+namespace rgw::sal::sfs {
+
+class LCSFSSerializer : public StoreLCSerializer {
+  std::timed_mutex& mutex;
+
+ public:
+  LCSFSSerializer(
+      std::timed_mutex& m, SFStore* store, const std::string& oid,
+      const std::string& lock_name, const std::string& cookie
+  )
+      : mutex(m) {}
+
+  virtual int try_lock(
+      const DoutPrefixProvider* dpp, utime_t dur, optional_yield y
+  ) override {
+    if (mutex.try_lock_for(std::chrono::seconds(dur))) {
+      return 0;
+    }
+    return -EBUSY;
+  }
+  virtual int unlock() override {
+    mutex.unlock();
+    return 0;
+  }
+};
+
+class SFSLifecycle : public StoreLifecycle {
+  SFStore* store;
+  std::map<std::string, std::timed_mutex> mutex_map;
+
+ public:
+  SFSLifecycle(SFStore* _st);
+
+  using StoreLifecycle::get_entry;
+  virtual int get_entry(
+      const std::string& oid, const std::string& marker,
+      std::unique_ptr<LCEntry>* entry
+  ) override;
+  virtual int get_next_entry(
+      const std::string& oid, const std::string& marker,
+      std::unique_ptr<LCEntry>* entry
+  ) override;
+  virtual int set_entry(const std::string& oid, LCEntry& entry) override;
+  virtual int list_entries(
+      const std::string& oid, const std::string& marker, uint32_t max_entries,
+      std::vector<std::unique_ptr<LCEntry>>& entries
+  ) override;
+  virtual int rm_entry(const std::string& oid, LCEntry& entry) override;
+  virtual int get_head(const std::string& oid, std::unique_ptr<LCHead>* head)
+      override;
+  virtual int put_head(const std::string& oid, LCHead& head) override;
+  virtual std::unique_ptr<LCSerializer> get_serializer(
+      const std::string& lock_name, const std::string& oid,
+      const std::string& cookie
+  ) override;
+};
+
+}  // namespace rgw::sal::sfs

--- a/src/rgw/driver/sfs/sqlite/lifecycle/lifecycle_definitions.h
+++ b/src/rgw/driver/sfs/sqlite/lifecycle/lifecycle_definitions.h
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#pragma once
+
+#include <string>
+
+#include "rgw_common.h"
+
+namespace rgw::sal::sfs::sqlite {
+
+struct DBOPLCHead {
+  std::string lc_index;  // primary key
+  std::string marker;
+  long start_date;
+};
+
+struct DBOPLCEntry {
+  std::string lc_index;     // composite primary key
+  std::string bucket_name;  // composite primary key
+  uint64_t start_time;
+  uint32_t status;
+};
+
+}  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
@@ -1,0 +1,104 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#include "sqlite_lifecycle.h"
+
+using namespace sqlite_orm;
+namespace rgw::sal::sfs::sqlite {
+
+SQLiteLifecycle::SQLiteLifecycle(DBConnRef _conn) : conn(_conn) {}
+
+DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
+  auto storage = conn->get_storage();
+  auto head = storage.get_pointer<DBOPLCHead>(oid);
+  DBOPLCHead ret_value;
+  if (head) {
+    ret_value = *head;
+  } else {
+    // there's still no head.
+    // LC was not executed yet.
+    // create an empty entry
+    DBOPLCHead new_head{oid, "", 0};
+    storage.replace(new_head);
+    ret_value = new_head;
+  }
+  return ret_value;
+}
+
+void SQLiteLifecycle::store_head(const DBOPLCHead& head) const {
+  auto storage = conn->get_storage();
+  storage.replace(head);
+}
+
+void SQLiteLifecycle::remove_head(const std::string& oid) const {
+  auto storage = conn->get_storage();
+  storage.remove<DBOPLCHead>(oid);
+}
+
+std::optional<DBOPLCEntry> SQLiteLifecycle::get_entry(
+    const std::string& oid, const std::string& marker
+) const {
+  auto storage = conn->get_storage();
+  auto db_entry = storage.get_pointer<DBOPLCEntry>(oid, marker);
+  std::optional<DBOPLCEntry> ret_value;
+  if (db_entry) {
+    ret_value = *db_entry;
+  }
+  return ret_value;
+}
+
+std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
+    const std::string& oid, const std::string& marker
+) const {
+  auto storage = conn->get_storage();
+  auto db_entries = storage.get_all<DBOPLCEntry>(
+      where(
+          is_equal(&DBOPLCEntry::lc_index, oid) and
+          greater_than(&DBOPLCEntry::bucket_name, marker)
+      ),
+      order_by(&DBOPLCEntry::bucket_name).asc(), limit(1)
+  );
+  std::optional<DBOPLCEntry> ret_value;
+  // should return 1 entry or none
+  if (db_entries.size() == 1) {
+    ret_value = db_entries[0];
+  }
+  return ret_value;
+}
+
+void SQLiteLifecycle::store_entry(const DBOPLCEntry& entry) const {
+  auto storage = conn->get_storage();
+  storage.replace(entry);
+}
+
+void SQLiteLifecycle::remove_entry(
+    const std::string& oid, const std::string& marker
+) const {
+  auto storage = conn->get_storage();
+  storage.remove<DBOPLCEntry>(oid, marker);
+}
+
+std::vector<DBOPLCEntry> SQLiteLifecycle::list_entries(
+    const std::string& oid, const std::string& marker, uint32_t max_entries
+) const {
+  auto storage = conn->get_storage();
+  return storage.get_all<DBOPLCEntry>(
+      where(
+          is_equal(&DBOPLCEntry::lc_index, oid) and
+          greater_than(&DBOPLCEntry::bucket_name, marker)
+      ),
+      order_by(&DBOPLCEntry::bucket_name).asc(), limit(max_entries)
+  );
+}
+
+}  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.h
@@ -1,0 +1,49 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#pragma once
+
+#include "dbconn.h"
+#include "lifecycle/lifecycle_definitions.h"
+
+namespace rgw::sal::sfs::sqlite {
+
+class SQLiteLifecycle {
+  DBConnRef conn;
+
+ public:
+  explicit SQLiteLifecycle(DBConnRef _conn);
+  virtual ~SQLiteLifecycle() = default;
+
+  SQLiteLifecycle(const SQLiteLifecycle&) = delete;
+  SQLiteLifecycle& operator=(const SQLiteLifecycle&) = delete;
+
+  DBOPLCHead get_head(const std::string& oid) const;
+  void store_head(const DBOPLCHead& head) const;
+  void remove_head(const std::string& oid) const;
+
+  std::optional<DBOPLCEntry> get_entry(
+      const std::string& oid, const std::string& marker
+  ) const;
+  std::optional<DBOPLCEntry> get_next_entry(
+      const std::string& oid, const std::string& marker
+  ) const;
+  void store_entry(const DBOPLCEntry& entry) const;
+  void remove_entry(const std::string& oid, const std::string& marker) const;
+
+  std::vector<DBOPLCEntry> list_entries(
+      const std::string& oid, const std::string& marker, uint32_t max_entries
+  ) const;
+};
+
+}  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -28,6 +28,7 @@
 #include "common/errno.h"
 #include "driver/sfs/notification.h"
 #include "driver/sfs/sfs_gc.h"
+#include "driver/sfs/sfs_lc.h"
 #include "driver/sfs/sqlite/dbconn.h"
 #include "driver/sfs/writer.h"
 #include "include/util.h"
@@ -64,12 +65,10 @@ namespace rgw::sal {
 
 // Lifecycle {{{
 std::unique_ptr<Lifecycle> SFStore::get_lifecycle(void) {
-  ldout(ctx(), 10) << __func__ << ": TODO" << dendl;
-  return nullptr;
+  return std::make_unique<sfs::SFSLifecycle>(this);
 }
 RGWLC* SFStore::get_rgwlc(void) {
-  ldout(ctx(), 10) << __func__ << ": TODO" << dendl;
-  return nullptr;
+  return lc;
 }
 
 // }}}
@@ -466,6 +465,9 @@ http::status SFSStatusPage::render(std::ostream& os) {
 int SFStore::initialize(CephContext* cct, const DoutPrefixProvider* dpp) {
   ldpp_dout(dpp, 10) << __func__ << dendl;
   gc->initialize();
+  lc = new RGWLC();
+  lc->initialize(cct, this);
+  lc->start_processor();
   return 0;
 }
 

--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -115,6 +115,7 @@ class SFStore : public StoreDriver {
   CephContext* const cctx;
   ceph::mutex buckets_map_lock = ceph::make_mutex("buckets_map_lock");
   std::map<std::string, sfs::BucketRef> buckets;
+  RGWLC* lc = nullptr;
 
   // Signal shutdown condition to service threads
   bool shutdown;

--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -14,6 +14,10 @@ add_executable(unittest_rgw_sfs_sqlite_versioned_objects test_rgw_sfs_sqlite_ver
 add_ceph_unittest(unittest_rgw_sfs_sqlite_versioned_objects)
 target_link_libraries(unittest_rgw_sfs_sqlite_versioned_objects ${rgw_libs})
 
+add_executable(unittest_rgw_sfs_sqlite_lifecycle test_rgw_sfs_sqlite_lifecycle.cc)
+add_ceph_unittest(unittest_rgw_sfs_sqlite_lifecycle)
+target_link_libraries(unittest_rgw_sfs_sqlite_lifecycle ${rgw_libs})
+
 add_executable(unittest_rgw_sfs_sfs_bucket test_rgw_sfs_sfs_bucket.cc)
 add_ceph_unittest(unittest_rgw_sfs_sfs_bucket)
 target_link_libraries(unittest_rgw_sfs_sfs_bucket ${rgw_libs})

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_lifecycle.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_lifecycle.cc
@@ -1,0 +1,280 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/ceph_context.h"
+#include "rgw/driver/sfs/sqlite/dbconn.h"
+#include "rgw/driver/sfs/sqlite/sqlite_lifecycle.h"
+
+#include "rgw/rgw_sal_sfs.h"
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+
+using namespace rgw::sal::sfs::sqlite;
+
+namespace fs = std::filesystem;
+const static std::string TEST_DIR = "rgw_sfs_tests";
+const static std::string LC_SHARD = "lc.0";
+
+class TestSFSSQLiteLifecycle : public ::testing::Test {
+protected:
+  void SetUp() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::create_directory(TEST_DIR);
+  }
+
+  void TearDown() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(TEST_DIR);
+  }
+
+  std::string getTestDir() const {
+    auto test_dir = fs::temp_directory_path() / TEST_DIR;
+    return test_dir.string();
+  }
+
+  fs::path getDBFullPath(const std::string & base_dir) const {
+    auto db_full_name = "s3gw.db";
+    auto db_full_path = fs::path(base_dir) /  db_full_name;
+    return db_full_path;
+  }
+
+  fs::path getDBFullPath() const {
+    return getDBFullPath(getTestDir());
+  }
+};
+
+std::string getLCBucketName(const rgw::sal::sfs::sqlite::DBOPBucketInfo & bucket) {
+  return ":" + bucket.binfo.bucket.name + ":" + bucket.binfo.bucket.marker;
+}
+
+TEST_F(TestSFSSQLiteLifecycle, GetHeadFirstTime) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+  auto db_lc = std::make_shared<SQLiteLifecycle>(conn);
+
+  // first time we call get_head there is no head and we create an empty one
+  auto lc_head = db_lc->get_head(LC_SHARD);
+  ASSERT_TRUE(lc_head.has_value());
+  ASSERT_EQ(lc_head->lc_index, LC_SHARD);
+  ASSERT_EQ(lc_head->marker, "");
+  ASSERT_EQ(lc_head->start_date, 0);
+}
+
+TEST_F(TestSFSSQLiteLifecycle, StoreHead) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+  auto db_lc = std::make_shared<SQLiteLifecycle>(conn);
+
+  DBOPLCHead db_head { LC_SHARD, "bucket_name_marker", 12345 };
+  db_lc->store_head(db_head);
+
+  auto lc_head = db_lc->get_head(LC_SHARD);
+  ASSERT_TRUE(lc_head.has_value());
+  ASSERT_EQ(lc_head->lc_index, LC_SHARD);
+  ASSERT_EQ(lc_head->marker, "bucket_name_marker");
+  ASSERT_EQ(lc_head->start_date, 12345);
+}
+
+TEST_F(TestSFSSQLiteLifecycle, StoreDeleteHead) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+  auto db_lc = std::make_shared<SQLiteLifecycle>(conn);
+
+  DBOPLCHead db_head { LC_SHARD, "bucket_name_marker", 12345 };
+  db_lc->store_head(db_head);
+
+  auto lc_head = db_lc->get_head(LC_SHARD);
+  ASSERT_TRUE(lc_head.has_value());
+  ASSERT_EQ(lc_head->lc_index, LC_SHARD);
+  ASSERT_EQ(lc_head->marker, "bucket_name_marker");
+  ASSERT_EQ(lc_head->start_date, 12345);
+
+  db_lc->remove_head(LC_SHARD);
+  // now head is not stored so we create an empty one when calling get
+  lc_head = db_lc->get_head(LC_SHARD);
+  ASSERT_TRUE(lc_head.has_value());
+  ASSERT_EQ(lc_head->lc_index, LC_SHARD);
+  ASSERT_EQ(lc_head->marker, "");
+  ASSERT_EQ(lc_head->start_date, 0);
+}
+
+TEST_F(TestSFSSQLiteLifecycle, StoreGetEntry) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+  auto db_lc = std::make_shared<SQLiteLifecycle>(conn);
+
+  // first look for a non existing entry
+  auto db_entry_not_found = db_lc->get_entry(LC_SHARD, "bucket_name_marker");
+  ASSERT_FALSE(db_entry_not_found.has_value());
+
+  // store entry
+  DBOPLEntry db_entry { LC_SHARD, "bucket_name_marker", 12345, 123 };
+  db_lc->store_entry(db_entry);
+
+  auto db_entry_found = db_lc->get_entry(LC_SHARD, "bucket_name_marker");
+  ASSERT_TRUE(db_entry_found.has_value());
+  ASSERT_EQ(db_entry_found->lc_index, LC_SHARD);
+  ASSERT_EQ(db_entry_found->bucket_name, "bucket_name_marker");
+  ASSERT_EQ(db_entry_found->start_time, 12345);
+  ASSERT_EQ(db_entry_found->status, 123);
+}
+
+TEST_F(TestSFSSQLiteLifecycle, GetNextEntry) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+  auto db_lc = std::make_shared<SQLiteLifecycle>(conn);
+
+  // returns nothing when there are no entries
+  auto no_entries = db_lc->get_next_entry(LC_SHARD, "");
+  ASSERT_FALSE(no_entries.has_value());
+
+  // store a few entries
+  DBOPLEntry db_entry_1 { LC_SHARD, "bucket_1", 1111, 1 };
+  DBOPLEntry db_entry_2 { LC_SHARD, "bucket_2", 2222, 2 };
+  DBOPLEntry db_entry_3 { LC_SHARD, "bucket_3", 3333, 3 };
+  DBOPLEntry db_entry_4 { LC_SHARD, "bucket_4", 4444, 4 };
+  DBOPLEntry db_entry_5 { LC_SHARD, "a_bucket_5", 5555, 5 };
+  db_lc->store_entry(db_entry_1);
+  db_lc->store_entry(db_entry_2);
+  db_lc->store_entry(db_entry_3);
+  db_lc->store_entry(db_entry_4);
+  db_lc->store_entry(db_entry_5);
+
+  // get next entry with marker = ""
+  auto marker_empty = db_lc->get_next_entry(LC_SHARD, "");
+  ASSERT_TRUE(marker_empty.has_value());
+  ASSERT_EQ(marker_empty->lc_index, LC_SHARD);
+  ASSERT_EQ(marker_empty->bucket_name, "a_bucket_5");
+  ASSERT_EQ(marker_empty->start_time, 5555);
+  ASSERT_EQ(marker_empty->status, 5);
+
+  // get next entry with marker = "a_bucket_5"
+  auto a_bucket_5 = db_lc->get_next_entry(LC_SHARD, "a_bucket_5");
+  ASSERT_TRUE(a_bucket_5.has_value());
+  ASSERT_EQ(a_bucket_5->lc_index, LC_SHARD);
+  ASSERT_EQ(a_bucket_5->bucket_name, "bucket_1");
+  ASSERT_EQ(a_bucket_5->start_time, 1111);
+  ASSERT_EQ(a_bucket_5->status, 1);
+
+  // get next entry with marker = "bucket_1"
+  auto bucket_1 = db_lc->get_next_entry(LC_SHARD, "bucket_1");
+  ASSERT_TRUE(bucket_1.has_value());
+  ASSERT_EQ(bucket_1->lc_index, LC_SHARD);
+  ASSERT_EQ(bucket_1->bucket_name, "bucket_2");
+  ASSERT_EQ(bucket_1->start_time, 2222);
+  ASSERT_EQ(bucket_1->status, 2);
+
+  // get next entry with marker = "bucket_2"
+  auto bucket_2 = db_lc->get_next_entry(LC_SHARD, "bucket_2");
+  ASSERT_TRUE(bucket_2.has_value());
+  ASSERT_EQ(bucket_2->lc_index, LC_SHARD);
+  ASSERT_EQ(bucket_2->bucket_name, "bucket_3");
+  ASSERT_EQ(bucket_2->start_time, 3333);
+  ASSERT_EQ(bucket_2->status, 3);
+
+  // get next entry with marker = "bucket_3"
+  auto bucket_3 = db_lc->get_next_entry(LC_SHARD, "bucket_3");
+  ASSERT_TRUE(bucket_3.has_value());
+  ASSERT_EQ(bucket_3->lc_index, LC_SHARD);
+  ASSERT_EQ(bucket_3->bucket_name, "bucket_4");
+  ASSERT_EQ(bucket_3->start_time, 4444);
+  ASSERT_EQ(bucket_3->status, 4);
+
+  // get next entry with marker = "bucket_4"
+  auto bucket_4 = db_lc->get_next_entry(LC_SHARD, "bucket_4");
+  ASSERT_FALSE(bucket_4.has_value());
+}
+
+TEST_F(TestSFSSQLiteLifecycle, ListEntries) {
+  auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
+  ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+
+  EXPECT_FALSE(fs::exists(getDBFullPath()));
+  DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
+  auto db_lc = std::make_shared<SQLiteLifecycle>(conn);
+
+  // store a few entries
+  DBOPLEntry db_entry_1 { LC_SHARD, "bucket_1", 1111, 1 };
+  DBOPLEntry db_entry_2 { LC_SHARD, "bucket_2", 2222, 2 };
+  DBOPLEntry db_entry_3 { LC_SHARD, "bucket_3", 3333, 3 };
+  DBOPLEntry db_entry_4 { LC_SHARD, "bucket_4", 4444, 4 };
+  DBOPLEntry db_entry_5 { LC_SHARD, "a_bucket_5", 5555, 5 };
+  db_lc->store_entry(db_entry_1);
+  db_lc->store_entry(db_entry_2);
+  db_lc->store_entry(db_entry_3);
+  db_lc->store_entry(db_entry_4);
+  db_lc->store_entry(db_entry_5);
+
+  // list entryes with marker = "" and 1 entry
+  auto entries = db_lc->list_entries(LC_SHARD, "", 1);
+  ASSERT_EQ(entries.size(), 1);
+  ASSERT_EQ(entries[0].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[0].bucket_name, "a_bucket_5");
+  ASSERT_EQ(entries[0].start_time, 5555);
+  ASSERT_EQ(entries[0].status, 5);
+
+  entries = db_lc->list_entries(LC_SHARD, "", 2);
+  ASSERT_EQ(entries.size(), 2);
+  ASSERT_EQ(entries[0].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[0].bucket_name, "a_bucket_5");
+  ASSERT_EQ(entries[0].start_time, 5555);
+  ASSERT_EQ(entries[0].status, 5);
+
+  ASSERT_EQ(entries[1].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[1].bucket_name, "bucket_1");
+  ASSERT_EQ(entries[1].start_time, 1111);
+  ASSERT_EQ(entries[1].status, 1);
+
+  entries = db_lc->list_entries(LC_SHARD, "", 10);
+  ASSERT_EQ(entries.size(), 5);
+  ASSERT_EQ(entries[0].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[0].bucket_name, "a_bucket_5");
+  ASSERT_EQ(entries[0].start_time, 5555);
+  ASSERT_EQ(entries[0].status, 5);
+
+  ASSERT_EQ(entries[1].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[1].bucket_name, "bucket_1");
+  ASSERT_EQ(entries[1].start_time, 1111);
+  ASSERT_EQ(entries[1].status, 1);
+
+  ASSERT_EQ(entries[2].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[2].bucket_name, "bucket_2");
+  ASSERT_EQ(entries[2].start_time, 2222);
+  ASSERT_EQ(entries[2].status, 2);
+
+  ASSERT_EQ(entries[3].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[3].bucket_name, "bucket_3");
+  ASSERT_EQ(entries[3].start_time, 3333);
+  ASSERT_EQ(entries[3].status, 3);
+
+  ASSERT_EQ(entries[4].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[4].bucket_name, "bucket_4");
+  ASSERT_EQ(entries[4].start_time, 4444);
+  ASSERT_EQ(entries[4].status, 4);
+
+  // list not from the beginning
+  entries = db_lc->list_entries(LC_SHARD, "bucket_3", 10);
+  ASSERT_EQ(entries.size(), 1);
+  ASSERT_EQ(entries[0].lc_index, LC_SHARD);
+  ASSERT_EQ(entries[0].bucket_name, "bucket_4");
+  ASSERT_EQ(entries[0].start_time, 4444);
+  ASSERT_EQ(entries[0].status, 4);
+}


### PR DESCRIPTION
Initial PR implementing lifecycle.
This PR tries to use the existing rgw's lifecycle, so all the
lifecycle functinalities that upstream `rgw` support should be also
supported (obviously if the features needed are already implemented in
`sfs`).

It also takes benefit of sharding which is done by rgw's code.

When a bucket is changed to add lifecycle confuguration it is added to a
shard id based on a hash function.

Every shard has a `head` which stores the point where a particular shard
id is being processed.

The advantage of splitting things into buckets is being able to run
lifecycle checks and actions in parallel tasks.

Currently, the following s3 tests pass: (And when tagging is supported many other s3 tests will pass as well) 
```bash
test_lifecycle_set
test_lifecycle_get
test_lifecycle_get_no_id
test_lifecycle_expiration
test_lifecyclev2_expiration
test_lifecycle_expiration_versioning_enabled
test_lifecycle_id_too_long
test_lifecycle_same_id
test_lifecycle_invalid_status
test_lifecycle_set_date
test_lifecycle_set_invalid_date
test_lifecycle_expiration_date
test_lifecycle_expiration_days0
test_lifecycle_expiration_header_put
test_lifecycle_set_noncurrent
test_lifecycle_set_deletemarker
test_lifecycle_set_filter
test_lifecycle_set_empty_filter
test_lifecycle_set_multipart
test_lifecycle_transition_set_invalid_date
```

Fixes: https://github.com/aquarist-labs/s3gw/issues/322
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

