### PR TITLE
Remove Object Copy Cache

### DIFF
--- a/src/rgw/driver/sfs/object.cc
+++ b/src/rgw/driver/sfs/object.cc
@@ -441,7 +441,7 @@ void SFSObject::refresh_meta() {
     bucketref = store->get_bucket_ref(bucket->get_name());
   }
   try {
-    objref = bucketref->get_unmutexed(get_name());
+    objref = bucketref->get(get_name());
   } catch (sfs::UnknownObjectException& e) {
     // object probably not created yet?
     return;

--- a/src/rgw/driver/sfs/sfs_gc.h
+++ b/src/rgw/driver/sfs/sfs_gc.h
@@ -70,11 +70,11 @@ class SFSGC : public DoutPrefixProvider {
   void process_deleted_buckets();
 
   void delete_objects(const std::string& bucket_id);
-  void delete_versioned_objects(const std::shared_ptr<Object>& object);
+  void delete_versioned_objects(const Object& object);
 
   void delete_bucket(const std::string& bucket_id);
-  void delete_object(const std::shared_ptr<Object>& object);
-  void delete_versioned_object(const std::shared_ptr<Object>& object, uint id);
+  void delete_object(const Object& object);
+  void delete_versioned_object(const Object& object);
 };
 
 }  //  namespace rgw::sal::sfs

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -379,7 +379,7 @@ ObjectRef Bucket::get_or_create(const rgw_obj_key& key) {
   return result;
 }
 
-ObjectRef Bucket::get_unmutexed(const std::string& name) {
+ObjectRef Bucket::get(const std::string& name) {
   auto maybe_result = Object::try_create_with_last_version_from_database_fetch(
       store, name, info.bucket.bucket_id
   );
@@ -388,10 +388,6 @@ ObjectRef Bucket::get_unmutexed(const std::string& name) {
     throw UnknownObjectException();
   }
   return std::shared_ptr<Object>(maybe_result);
-}
-
-ObjectRef Bucket::get(const std::string& name) {
-  return get_unmutexed(name);
 }
 
 std::vector<ObjectRef> Bucket::get_all() {

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -107,7 +107,7 @@ Object* Object::create_commit_new_object(
   return result;
 }
 
-Object* Object::try_create_with_last_version_from_database_fetch(
+Object* Object::try_create_with_last_version_fetch_from_database(
     SFStore* store, const std::string& name, const std::string& bucket_id
 ) {
   sqlite::SQLiteObjects objs(store->db_conn);
@@ -137,7 +137,7 @@ Object* Object::try_create_with_last_version_from_database_fetch(
   return result;
 }
 
-Object* Object::try_create_from_database_fetch(
+Object* Object::try_create_fetch_from_database(
     SFStore* store, const std::string& name, const std::string& bucket_id,
     const std::string& version_id
 ) {
@@ -339,7 +339,7 @@ bool Bucket::want_specific_version(const rgw_obj_key& key) {
 ObjectRef Bucket::get_or_create(const rgw_obj_key& key) {
   ObjectRef result;
 
-  auto maybe_result = Object::try_create_with_last_version_from_database_fetch(
+  auto maybe_result = Object::try_create_with_last_version_fetch_from_database(
       store, key.name, info.bucket.bucket_id
   );
 
@@ -357,7 +357,7 @@ ObjectRef Bucket::get_or_create(const rgw_obj_key& key) {
   } else if (want_specific_version(key) && maybe_result->instance != key.instance) {
     // requested version is not last
 
-    auto specific_version_object = Object::try_create_from_database_fetch(
+    auto specific_version_object = Object::try_create_fetch_from_database(
         store, key.name, info.bucket.bucket_id, key.instance
     );
 
@@ -380,7 +380,7 @@ ObjectRef Bucket::get_or_create(const rgw_obj_key& key) {
 }
 
 ObjectRef Bucket::get(const std::string& name) {
-  auto maybe_result = Object::try_create_with_last_version_from_database_fetch(
+  auto maybe_result = Object::try_create_with_last_version_fetch_from_database(
       store, name, info.bucket.bucket_id
   );
 

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -332,11 +332,8 @@ void MultipartUpload::abort(const DoutPrefixProvider* dpp) {
   objref.reset();
 }
 
-bool Bucket::want_specific_version(const rgw_obj_key& key) {
-  return !key.instance.empty();
-}
-
 ObjectRef Bucket::get_or_create(const rgw_obj_key& key) {
+  const bool wants_specific_version = !key.instance.empty();
   ObjectRef result;
 
   auto maybe_result = Object::try_create_with_last_version_fetch_from_database(
@@ -351,10 +348,10 @@ ObjectRef Bucket::get_or_create(const rgw_obj_key& key) {
   }
 
   // an object exists with at least 1 version
-  if (want_specific_version(key) && maybe_result->instance == key.instance) {
+  if (wants_specific_version && maybe_result->instance == key.instance) {
     // requested version happens to be the last version
     result.reset(maybe_result);
-  } else if (want_specific_version(key) && maybe_result->instance != key.instance) {
+  } else if (wants_specific_version && maybe_result->instance != key.instance) {
     // requested version is not last
 
     auto specific_version_object = Object::try_create_fetch_from_database(

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -93,7 +93,8 @@ Object* Object::create_commit_new_object(
   oinfo.bucket_id = bucket_id;
   oinfo.name = result->name;
 
-  // TODO(irq0) make object and version insert a transaction
+  // TODO(https://github.com/aquarist-labs/s3gw/issues/378) make
+  // object and version insert a transaction
   sqlite::SQLiteObjects dbobjs(store->db_conn);
   dbobjs.store_object(oinfo);
 

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -85,10 +85,9 @@ class Object {
       const std::string* version_id
   );
 
-  static Object* try_create_with_last_version_from_database_fetch(
-      SFStore* store, const std::string& name, const std::string& bucket_id
-  );
-  static Object* try_create_from_database_fetch(
+  static Object* try_create_with_last_version_fetch_from_database(
+      SFStore* store, const std::string& name, const std::string& bucket_id);
+  static Object* try_create_fetch_from_database(
       SFStore* store, const std::string& name, const std::string& bucket_id,
       const std::string& version_id
   );

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -105,26 +105,28 @@ class Object {
 
   std::filesystem::path get_storage_path() const;
 
-  // Update version and commit to database
+  /// Update version and commit to database
   void update_commit_new_version(SFStore* store, const std::string& version_id);
 
-  // Change obj version state.
+  /// Change obj version state.
   // Use this for example to update objs to in flight states like
   // WRITING.
   // Special case: DELETED sets this to deleted
   // and commits a deletion time
   void metadata_change_version_state(SFStore* store, ObjectState state);
 
-  // Commit all object state to database
+  /// Commit all object state to database
   // Including meta and attrs
   // Sets obj version state to COMMITTED
   void metadata_finish(SFStore* store);
 
-  // Commit attrs to database
+  /// Commit attrs to database
   void metadata_flush_attrs(SFStore* store);
 
   int delete_object_version(SFStore* store) const;
   void delete_object_metadata(SFStore* store) const;
+  /// Delete object _data_ (e.g payload of PUT operations) from disk.
+  // Set all=true to delete all versions, not just this version.
   void delete_object_data(SFStore* store, bool all) const;
 };
 
@@ -355,30 +357,20 @@ class Bucket {
   bool want_specific_version(const rgw_obj_key& key);
 
  public:
-  // Return object ref for key
-  // Object does not need to not exist
-  // if it doesn't it will be created, added to cache
-  // if it does
-  //  we return that
-  // if key.instance is not empty and instance != stored instance
-  //  we create additionally a new version
+  /// Return object for key. Do everything necessary to retrieve or
+  // create this object including object version.
   ObjectRef get_or_create(const rgw_obj_key& key);
 
-  // Get object from cache (with/without mutex).
-  // Caller is expected to take obj_map_lock
-  ObjectRef get_unmutexed(const std::string& name);
+  /// Get existing object by name. Throws if it doesn't exist.
   ObjectRef get(const std::string& name);
-  // Get copy of all object in cache
+  /// Get copy of all objects
   std::vector<ObjectRef> get_all();
 
-  // S3 delete object operation: deletes a version
-  // or creates a deleted tombstone
-  // Updates cached object to deleted version
+  /// S3 delete object operation: delete version or create tombstone.
   void delete_object(ObjectRef objref, const rgw_obj_key& key);
 
-  // Delete a non existing object
-  // creates object in database and cache
-  // toumbstone version that object
+  /// Delete a non-existing object. Creates object with toumbstone
+  // version in database.
   std::string create_non_existing_object_delete_marker(const rgw_obj_key& key);
 
   MultipartUploadRef get_multipart(

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -86,7 +86,8 @@ class Object {
   );
 
   static Object* try_create_with_last_version_fetch_from_database(
-      SFStore* store, const std::string& name, const std::string& bucket_id);
+      SFStore* store, const std::string& name, const std::string& bucket_id
+  );
   static Object* try_create_fetch_from_database(
       SFStore* store, const std::string& name, const std::string& bucket_id,
       const std::string& version_id
@@ -351,9 +352,6 @@ class Bucket {
   rgw_placement_rule& get_placement_rule() { return info.placement_rule; }
 
   uint32_t get_flags() const { return info.flags; }
-
- private:
-  bool want_specific_version(const rgw_obj_key& key);
 
  public:
   /// Return object for key. Do everything necessary to retrieve or

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -120,7 +120,8 @@ protected:
                                                 const std::string & bucket_id,
                                                 const std::string & name,
                                                 DBConnRef conn) {
-    auto object = std::make_shared<rgw::sal::sfs::Object>(name);
+    auto object = std::shared_ptr<rgw::sal::sfs::Object>(
+	rgw::sal::sfs::Object::create_for_testing(name));
     SQLiteObjects db_objects(conn);
     DBOPObjectInfo db_object;
     db_object.uuid = object->path.get_uuid();
@@ -162,9 +163,8 @@ protected:
     SQLiteObjects db_objects(conn);
     auto objects = db_objects.get_objects(bucket_id);
     for (auto & object: objects) {
-        auto objptr = std::make_shared<rgw::sal::sfs::Object>(object.name,
-                                                              object.uuid,
-                                                              false);
+        auto objptr = std::shared_ptr<rgw::sal::sfs::Object>(
+	    rgw::sal::sfs::Object::create_for_immediate_deletion(object));
         deleteTestObject(objptr, conn);
     }
     bucket->deleted = true;

--- a/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
@@ -62,7 +62,8 @@ protected:
                                                 const std::string & bucket_id,
                                                 const std::string & name,
                                                 DBConnRef conn) {
-    auto object = std::make_shared<rgw::sal::sfs::Object>(name);
+    auto object = std::shared_ptr<rgw::sal::sfs::Object>(
+	rgw::sal::sfs::Object::create_for_testing(name));
     SQLiteObjects db_objects(conn);
     DBOPObjectInfo db_object;
     db_object.uuid = object->path.get_uuid();
@@ -132,8 +133,8 @@ void compareListEntry(const rgw_bucket_dir_entry & entry,
                       std::shared_ptr<rgw::sal::sfs::Object> object,
                       const std::string & username) {
   EXPECT_EQ(entry.key.name, object->name);
-  EXPECT_EQ(entry.meta.etag, object->meta.etag);
-  EXPECT_EQ(entry.meta.mtime, object->meta.mtime);
+  EXPECT_EQ(entry.meta.etag, object->get_meta().etag);
+  EXPECT_EQ(entry.meta.mtime, object->get_meta().mtime);
   EXPECT_EQ(entry.meta.owner_display_name, username + "_display_name");
   EXPECT_EQ(entry.meta.owner, username);
 }

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -22,7 +22,6 @@ const static std::string TEST_DIR = "rgw_sfs_tests";
 
 const static std::string TEST_USERNAME = "test_username";
 const static std::string TEST_BUCKET = "test_bucket";
-const static std::string TEST_OBJECT_NAME = "test_object";
 const static std::string TEST_OBJECT_ID = "80943a6d-9f72-4001-bac0-a9a036be8c49";
 const static std::string TEST_OBJECT_ID_1 = "9f06d9d3-307f-4c98-865b-cd3b087acc4f";
 const static std::string TEST_OBJECT_ID_2 = "af06d9d3-307f-4c98-865b-cd3b087acc4f";


### PR DESCRIPTION
Removes the object copy cache to reduce mutexes in the hot path and to enable us to replace linear time object list filters with (indexed) SQL queries.

Split into two parts: 1. Refactoring to encapsulate Object and access to the objects cache better. 2. Remove the cache. 

No new tests. Changes already covered by existing tests.

Issue https://github.com/aquarist-labs/s3gw/issues/214
Prepares code base for https://github.com/aquarist-labs/s3gw/issues/203

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

