### PR TITLE
rgw/sfs: Add (unique) indices

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -55,6 +55,16 @@ inline auto _make_storage(const std::string& path) {
           "versioned_object_objid_vid_unique", &DBVersionedObject::object_id,
           &DBVersionedObject::version_id
       ),
+      sqlite_orm::make_index("bucket_ownerid_idx", &DBBucket::owner_id),
+      sqlite_orm::make_index("bucket_name_idx", &DBBucket::bucket_name),
+      sqlite_orm::make_index("objects_bucketid_idx", &DBObject::bucket_id),
+      sqlite_orm::make_index("objects_bucketid_idx", &DBObject::bucket_id),
+      sqlite_orm::make_index(
+          "vobjs_versionid_idx", &DBVersionedObject::version_id
+      ),
+      sqlite_orm::make_index(
+          "vobjs_object_id_idx", &DBVersionedObject::object_id
+      ),
       sqlite_orm::make_table(
           std::string(USERS_TABLE),
           sqlite_orm::make_column(

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -51,6 +51,10 @@ class sqlite_sync_exception : public std::exception {
 inline auto _make_storage(const std::string& path) {
   return sqlite_orm::make_storage(
       path,
+      sqlite_orm::make_unique_index(
+          "versioned_object_objid_vid_unique", &DBVersionedObject::object_id,
+          &DBVersionedObject::version_id
+      ),
       sqlite_orm::make_table(
           std::string(USERS_TABLE),
           sqlite_orm::make_column(

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -141,6 +141,7 @@ protected:
     db_version.id = version;
     db_version.object_id = object->path.get_uuid();
     db_version.object_state = rgw::sal::ObjectState::COMMITTED;
+    db_version.version_id = std::to_string(version);
     db_versioned_objects.insert_versioned_object(db_version);
   }
 
@@ -152,6 +153,8 @@ protected:
                                                        object->path.get_uuid());
     ASSERT_TRUE(last_version.has_value());
     last_version->object_state = rgw::sal::ObjectState::DELETED;
+    last_version->version_id.append("_next_");
+    last_version->version_id.append(std::to_string(last_version->id));
     db_versioned_objects.insert_versioned_object(*last_version);
   }
 

--- a/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
@@ -94,6 +94,7 @@ protected:
     db_version.id = version;
     db_version.object_id = object->path.get_uuid();
     db_version.object_state = rgw::sal::ObjectState::COMMITTED;
+    db_version.version_id = std::to_string(version);
     db_versioned_objects.insert_versioned_object(db_version);
   }
 };
@@ -143,7 +144,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
-  
+
   NoDoutPrefix ndp(ceph_context.get(), 1);
   RGWEnv env;
   env.init(ceph_context.get());
@@ -157,13 +158,13 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
   std::string arg_swift_ver_location;
   RGWQuotaInfo arg_quota_info;
   RGWAccessControlPolicy arg_aclp = get_aclp_default();
-  rgw::sal::Attrs arg_attrs; 
+  rgw::sal::Attrs arg_attrs;
   {
     bufferlist acl_bl;
     arg_aclp.encode(acl_bl);
     arg_attrs[RGW_ATTR_ACL] = acl_bl;
   }
-  
+
   RGWBucketInfo arg_info = get_binfo();
   obj_version arg_objv;
   bool existed = false;
@@ -187,7 +188,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
                                 arg_req_info,               //req_info
                                 &bucket_from_create,        //bucket
                                 null_yield                  //optional_yield
-                                ), 
+                                ),
             0);
 
   EXPECT_EQ(existed, false);
@@ -196,7 +197,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
   EXPECT_EQ(bucket_from_create->get_placement_rule().name, "default");
   EXPECT_EQ(bucket_from_create->get_placement_rule().storage_class, "STANDARD");
   EXPECT_NE(bucket_from_create->get_attrs().find(RGW_ATTR_ACL), bucket_from_create->get_attrs().end());
-  
+
   EXPECT_FALSE(arg_info.flags & BUCKET_VERSIONED);
   EXPECT_FALSE(arg_info.flags & BUCKET_OBJ_LOCK_ENABLED);
 
@@ -209,7 +210,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
   }
 
   EXPECT_EQ(bucket_from_create->get_acl(), arg_aclp);
-  
+
   //@warning this triggers segfault
   //EXPECT_EQ(bucket_from_create->get_owner()->get_id().id, "usr_id");
 
@@ -219,7 +220,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromStore) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
-  
+
   NoDoutPrefix ndp(ceph_context.get(), 1);
   RGWEnv env;
   env.init(ceph_context.get());
@@ -233,13 +234,13 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromStore) {
   std::string arg_swift_ver_location;
   RGWQuotaInfo arg_quota_info;
   RGWAccessControlPolicy arg_aclp = get_aclp_default();
-  rgw::sal::Attrs arg_attrs; 
+  rgw::sal::Attrs arg_attrs;
   {
     bufferlist acl_bl;
     arg_aclp.encode(acl_bl);
     arg_attrs[RGW_ATTR_ACL] = acl_bl;
   }
-  
+
   RGWBucketInfo arg_info = get_binfo();
   obj_version arg_objv;
   bool existed = false;
@@ -263,21 +264,21 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromStore) {
                                 arg_req_info,               //req_info
                                 &bucket_from_create,        //bucket
                                 null_yield                  //optional_yield
-                                ), 
+                                ),
             0);
 
   std::unique_ptr<rgw::sal::Bucket> bucket_from_store;
 
   EXPECT_EQ(store->get_bucket(&ndp,
-                              user.get(), 
+                              user.get(),
                               arg_info.bucket,
                               &bucket_from_store,
-                              null_yield), 
+                              null_yield),
             0);
 
   EXPECT_EQ(*bucket_from_store, *bucket_from_create);
   EXPECT_NE(bucket_from_store->get_attrs().find(RGW_ATTR_ACL), bucket_from_store->get_attrs().end());
-  
+
   auto acl_bl_it = bucket_from_store->get_attrs().find(RGW_ATTR_ACL);
   {
     RGWAccessControlPolicy aclp;
@@ -293,7 +294,7 @@ TEST_F(TestSFSBucket, BucketSetAcl) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
-  
+
   NoDoutPrefix ndp(ceph_context.get(), 1);
   RGWEnv env;
   env.init(ceph_context.get());
@@ -307,13 +308,13 @@ TEST_F(TestSFSBucket, BucketSetAcl) {
   std::string arg_swift_ver_location;
   RGWQuotaInfo arg_quota_info;
   RGWAccessControlPolicy arg_aclp = get_aclp_default();
-  rgw::sal::Attrs arg_attrs; 
+  rgw::sal::Attrs arg_attrs;
   {
     bufferlist acl_bl;
     arg_aclp.encode(acl_bl);
     arg_attrs[RGW_ATTR_ACL] = acl_bl;
   }
-  
+
   RGWBucketInfo arg_info = get_binfo();
   obj_version arg_objv;
   bool existed = false;
@@ -337,16 +338,16 @@ TEST_F(TestSFSBucket, BucketSetAcl) {
                                 arg_req_info,               //req_info
                                 &bucket_from_create,        //bucket
                                 null_yield                  //optional_yield
-                                ), 
+                                ),
             0);
 
   std::unique_ptr<rgw::sal::Bucket> bucket_from_store;
 
   EXPECT_EQ(store->get_bucket(&ndp,
-                              user.get(), 
+                              user.get(),
                               arg_info.bucket,
                               &bucket_from_store,
-                              null_yield), 
+                              null_yield),
             0);
 
   RGWAccessControlPolicy arg_aclp_1 = get_aclp_1();
@@ -362,10 +363,10 @@ TEST_F(TestSFSBucket, BucketSetAcl) {
   std::unique_ptr<rgw::sal::Bucket> bucket_from_store_1;
 
   EXPECT_EQ(store->get_bucket(&ndp,
-                            user.get(), 
+                            user.get(),
                             arg_info.bucket,
                             &bucket_from_store_1,
-                            null_yield), 
+                            null_yield),
           0);
 
   EXPECT_EQ(bucket_from_store->get_acl(), bucket_from_store_1->get_acl());
@@ -375,7 +376,7 @@ TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
-  
+
   NoDoutPrefix ndp(ceph_context.get(), 1);
   RGWEnv env;
   env.init(ceph_context.get());
@@ -389,13 +390,13 @@ TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
   std::string arg_swift_ver_location;
   RGWQuotaInfo arg_quota_info;
   RGWAccessControlPolicy arg_aclp = get_aclp_default();
-  rgw::sal::Attrs arg_attrs; 
+  rgw::sal::Attrs arg_attrs;
   {
     bufferlist acl_bl;
     arg_aclp.encode(acl_bl);
     arg_attrs[RGW_ATTR_ACL] = acl_bl;
   }
-  
+
   RGWBucketInfo arg_info = get_binfo();
   obj_version arg_objv;
   bool existed = false;
@@ -419,16 +420,16 @@ TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
                                 arg_req_info,               //req_info
                                 &bucket_from_create,        //bucket
                                 null_yield                  //optional_yield
-                                ), 
+                                ),
             0);
 
   std::unique_ptr<rgw::sal::Bucket> bucket_from_store;
 
   EXPECT_EQ(store->get_bucket(&ndp,
-                              user.get(), 
+                              user.get(),
                               arg_info.bucket,
                               &bucket_from_store,
-                              null_yield), 
+                              null_yield),
             0);
 
   rgw::sal::Attrs new_attrs;
@@ -451,10 +452,10 @@ TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
   std::unique_ptr<rgw::sal::Bucket> bucket_from_store_1;
 
   EXPECT_EQ(store->get_bucket(&ndp,
-                            user.get(), 
+                            user.get(),
                             arg_info.bucket,
                             &bucket_from_store_1,
-                            null_yield), 
+                            null_yield),
           0);
 
   EXPECT_EQ(bucket_from_store_1->get_attrs(), new_attrs);

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -357,11 +357,13 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateAndUpdate) {
   ASSERT_TRUE(ret_ver_object.has_value());
   compareVersionedObjects(versioned_object, *ret_ver_object);
 
-  // update the size
+  // update the size, add new version
   auto original_size = versioned_object.size;
-  versioned_object.size = 1999;
-  //versioned_object.id = 2;
-  db_versioned_objects->insert_versioned_object(versioned_object);
+  auto new_versioned = versioned_object;
+  new_versioned.size = 1999;
+  new_versioned.id = 2;
+  new_versioned.version_id = "2";
+  db_versioned_objects->insert_versioned_object(new_versioned);
 
   // get the first version
   ret_ver_object = db_versioned_objects->get_versioned_object(versioned_object.id);
@@ -382,9 +384,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateAndUpdate) {
   ret_ver_object = db_versioned_objects->get_versioned_object(2);
   ASSERT_TRUE(ret_ver_object.has_value());
   ASSERT_EQ(1999, ret_ver_object->size);
-  versioned_object.id = 2;
-  versioned_object.size = 1999;
-  compareVersionedObjects(versioned_object, *ret_ver_object);
+  compareVersionedObjects(new_versioned, *ret_ver_object);
 }
 
 TEST_F(TestSFSSQLiteVersionedObjects, GetExisting) {
@@ -550,9 +550,11 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreCreatesNewVersions) {
   // just update the size
   auto original_size = object.size;
   object.size = 1;
+  object.version_id = "test_version_id_2";
   db_versioned_objects->insert_versioned_object(object);
 
   // change nothing, but it should also create a new version
+  object.version_id = "test_version_id_3";
   db_versioned_objects->insert_versioned_object(object);
   auto ids = db_versioned_objects->get_versioned_object_ids();
   ASSERT_EQ(3, ids.size());
@@ -564,18 +566,21 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreCreatesNewVersions) {
   ASSERT_TRUE(ret_object.has_value());
   object.size = original_size;
   object.id = 1;
+  object.version_id = "test_version_id_1";
   compareVersionedObjects(object, *ret_object);
 
   ret_object = db_versioned_objects->get_versioned_object(2);
   ASSERT_TRUE(ret_object.has_value());
   object.size = 1;
   object.id = 2;
+  object.version_id = "test_version_id_2";
   compareVersionedObjects(object, *ret_object);
 
   ret_object = db_versioned_objects->get_versioned_object(3);
   ASSERT_TRUE(ret_object.has_value());
   object.size = 1;
   object.id = 3;
+  object.version_id = "test_version_id_3";
   compareVersionedObjects(object, *ret_object);
 }
 
@@ -605,6 +610,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, GetLastVersion) {
 
   // just update the size, and add a new version
   object.size = 1999;
+  object.version_id = "test_version_id_2";
   db_versioned_objects->insert_versioned_object(object);
 
   // now it should return the last one
@@ -636,27 +642,34 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestInsertIncreaseID) {
 
   auto object = createTestVersionedObject(1, TEST_OBJECT_ID, "1");
   EXPECT_EQ(1, db_versioned_objects->insert_versioned_object(object));
+  object.version_id = "test_version_id_2";
   EXPECT_EQ(2, db_versioned_objects->insert_versioned_object(object));
+  object.version_id = "test_version_id_3";
   EXPECT_EQ(3, db_versioned_objects->insert_versioned_object(object));
+  object.version_id = "test_version_id_4";
   EXPECT_EQ(4, db_versioned_objects->insert_versioned_object(object));
 
   auto ret_ver_object = db_versioned_objects->get_versioned_object(1);
   ASSERT_TRUE(ret_ver_object.has_value());
+  object.version_id = "test_version_id_1";
   compareVersionedObjects(object, *ret_ver_object);
 
   ret_ver_object = db_versioned_objects->get_versioned_object(2);
   ASSERT_TRUE(ret_ver_object.has_value());
   object.id = 2;
+  object.version_id = "test_version_id_2";
   compareVersionedObjects(object, *ret_ver_object);
 
   ret_ver_object = db_versioned_objects->get_versioned_object(3);
   ASSERT_TRUE(ret_ver_object.has_value());
   object.id = 3;
+  object.version_id = "test_version_id_3";
   compareVersionedObjects(object, *ret_ver_object);
 
   ret_ver_object = db_versioned_objects->get_versioned_object(4);
   ASSERT_TRUE(ret_ver_object.has_value());
   object.id = 4;
+  object.version_id = "test_version_id_4";
   compareVersionedObjects(object, *ret_ver_object);
 
   ret_ver_object = db_versioned_objects->get_versioned_object(5);


### PR DESCRIPTION
Add unique index on versioned_object (object_id, version_id). Fix unit tests, that are now expected to update version_id.
This should help us uncover bugs in the versioning logic, as repeated inserts with the same (object_id, version_id) now fail.

Add indices on frequently queried columns. 

Violated unique constraints will make sqlite_orm throw a system_error. It will generate a message + backtrace and an internal server error on the client side. 