### PR TITLE
ci: avoid OOMing the worker node

### DIFF
--- a/.github/workflows/build-test-radosgw.yml
+++ b/.github/workflows/build-test-radosgw.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           docker run --rm \
             -v $GITHUB_WORKSPACE/ceph:/srv/ceph \
+            -e NPROC=16 \
             -e WITH_TESTS=ON \
             quay.io/s3gw/build-radosgw:latest
 


### PR DESCRIPTION
- Restrict the number of cores used to compile the s3gw to avoid OOMing the worker node

The self-hosted github worker nodes are somewhat sensitive with respect to memory usage and can actually completely crash from coming under memory pressure.
Restricting the number of cores used for compiling the s3gw will cost some performance, but avoid hangs due to nodes crashing from memory exhaustion.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

