### PR TITLE
rgw/sfs: Add exception message when metadata compat check fails

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.cc
+++ b/src/rgw/driver/sfs/sqlite/dbconn.cc
@@ -1,6 +1,7 @@
 #include "dbconn.h"
 
 #include <filesystem>
+#include <string>
 #include <system_error>
 
 namespace fs = std::filesystem;
@@ -55,10 +56,14 @@ void DBConn::check_metadata_is_compatible(CephContext* ctt) {
       }
       result_message += "] are no longer compatible.";
     }
-  } catch (std::exception& e) {
+  } catch (const std::system_error& e) {
     // check for any other errors (foreign keys constrains, etc...)
     result_message =
         "Metadata database might be corrupted or is no longer compatible";
+    result_message.append(std::to_string(e.code().value()));
+    result_message.append(" - ");
+    result_message.append(e.what());
+    sync_error = true;
     sync_error = true;
   }
   // remove the temporary db


### PR DESCRIPTION
Add system_error code and message to metadata compat check failure path. The error is interesting when working on the db schema, where the sqlite_orm conversion may lead to SQL errors.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

