### PR TITLE
Remove WRITING state

### DIFF
--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -145,7 +145,6 @@ int SFSMultipartUpload::complete(
   auto parts_it = parts.cbegin();
   auto etags_it = part_etags.cbegin();
 
-  outobj->metadata_change_version_state(store, ObjectState::WRITING);
   for (; parts_it != parts.cend() && etags_it != part_etags.cend();
        ++parts_it, ++etags_it) {
     ceph_assert(etags_it->first >= 0);

--- a/src/rgw/driver/sfs/object.cc
+++ b/src/rgw/driver/sfs/object.cc
@@ -230,7 +230,6 @@ int SFSObject::copy_object(
     return -EEXIST;
   }
 
-  dstref->metadata_change_version_state(store, ObjectState::WRITING);
   lsfs_dout(dpp, 10) << "copying file from '" << srcpath << "' to '" << dstpath
                      << "'" << dendl;
   std::filesystem::create_directories(dstpath.parent_path());

--- a/src/rgw/driver/sfs/object_state.h
+++ b/src/rgw/driver/sfs/object_state.h
@@ -18,7 +18,6 @@ namespace rgw::sal {
 
 enum class ObjectState {
   OPEN = 0,
-  WRITING,
   COMMITTED,
   LOCKED,
   DELETED,

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -80,8 +80,6 @@ int SFSAtomicWriter::process(bufferlist&& data, uint64_t offset) {
   lsfs_dout(dpp, 10) << "data len: " << data.length() << ", offset: " << offset
                      << dendl;
 
-  objref->metadata_change_version_state(store, ObjectState::WRITING);
-
   std::filesystem::path object_path =
       store->get_data_path() / objref->get_storage_path();
   ceph_assert(std::filesystem::exists(object_path));

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -677,7 +677,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestUpdate) {
   ASSERT_TRUE(ret_ver_object.has_value());
   compareVersionedObjects(object, *ret_ver_object);
 
-  object.object_state = rgw::sal::ObjectState::WRITING;
+  object.object_state = rgw::sal::ObjectState::OPEN;
   db_versioned_objects->store_versioned_object(object);
 
   ret_ver_object = db_versioned_objects->get_versioned_object(1);

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -470,23 +470,16 @@ TEST_F(TestSFSSQLiteVersionedObjects, Testobject_stateConversion) {
 
   auto ret_object = db_objects.get_versioned_object(db_object.id);
   ASSERT_TRUE(ret_object.has_value());
-  ASSERT_EQ(rgw::sal::ObjectState::WRITING, ret_object->object_state);
+  ASSERT_EQ(rgw::sal::ObjectState::COMMITTED, ret_object->object_state);
 
   db_object.object_state = 2;
   storage.replace(db_object);
 
   ret_object = db_objects.get_versioned_object(db_object.id);
   ASSERT_TRUE(ret_object.has_value());
-  ASSERT_EQ(rgw::sal::ObjectState::COMMITTED, ret_object->object_state);
-
-  db_object.object_state = 3;
-  storage.replace(db_object);
-
-  ret_object = db_objects.get_versioned_object(db_object.id);
-  ASSERT_TRUE(ret_object.has_value());
   ASSERT_EQ(rgw::sal::ObjectState::LOCKED, ret_object->object_state);
 
-  db_object.object_state = 4;
+  db_object.object_state = 3;
   storage.replace(db_object);
 
   ret_object = db_objects.get_versioned_object(db_object.id);


### PR DESCRIPTION
Based on #124. Only relevant commits are the two with WRITING in the message

Removes the WRITING state, as we don't actually use it, but updating it wastes a lot of cycles.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

