### PR TITLE
rgw/sfs: Fix LastModified when getting obj header

### DIFF
--- a/src/rgw/driver/sfs/object.cc
+++ b/src/rgw/driver/sfs/object.cc
@@ -55,6 +55,9 @@ int SFSObject::SFSReadOp::prepare(
   lsfs_dout(dpp, 10) << "bucket: " << source->bucket->get_name()
                      << ", obj: " << source->get_name()
                      << ", size: " << source->get_obj_size() << dendl;
+  if (params.lastmod) {
+    *params.lastmod = source->get_mtime();
+  }
   return 0;
 }
 


### PR DESCRIPTION
When getting the header of an object `rgw` uses the `RGWGetObj` op, which uses `SFSReadOp`.
It assigns the `LastModified` field in the header from `lastmod`.

This PR assigns the lastmod value from `mtime`, because it was previously not set and it was returning always Unix time 0.

Fixes: https://github.com/aquarist-labs/s3gw/issues/289

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

**Before change**
```bash
$ aws --endpoint=http://127.0.0.1:7480 s3api head-object --bucket supertest --key expire1/obj2 
{
    "AcceptRanges": "bytes",
    "LastModified": "Thu, 01 Jan 1970 00:00:00 GMT",
    "ContentLength": 19834,
    "ETag": "\"05e5b1ae9ae89c3f19dd006a1b75d1ff\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```

**After change**
```bash
$ aws --endpoint=http://127.0.0.1:7480 s3api head-object --bucket supertest --key expire1/obj2 
{
    "AcceptRanges": "bytes",
    "LastModified": "Tue, 04 Apr 2023 09:46:27 GMT",
    "ContentLength": 19834,
    "ETag": "\"05e5b1ae9ae89c3f19dd006a1b75d1ff\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```

This also fixes the following **lifecycle s3tests**:

* test_lifecycle_expiration_header_put
* test_lifecycle_expiration_header_head
* test_lifecycle_expiration_header_tags_head
* test_lifecycle_expiration_header_and_tags_head

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

