### PR TITLE
Don't make sqlite_orm storage copies

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -197,13 +197,14 @@ inline auto _make_storage(const std::string& path) {
 using Storage = decltype(_make_storage(""));
 
 class DBConn {
-  Storage storage;
+  const std::unique_ptr<Storage> storage;
 
  public:
   sqlite3* sqlite_db;
 
-  DBConn(CephContext* cct) : storage(_make_storage(getDBPath(cct))) {
-    storage.on_open = [this](sqlite3* db) {
+  DBConn(CephContext* cct)
+      : storage(std::make_unique<Storage>(_make_storage(getDBPath(cct)))) {
+    storage->on_open = [this](sqlite3* db) {
       sqlite_db = db;
 
       sqlite3_extended_result_codes(db, 1);
@@ -215,17 +216,17 @@ class DBConn {
           0, 0, 0
       );
     };
-    storage.open_forever();
-    storage.busy_timeout(5000);
+    storage->open_forever();
+    storage->busy_timeout(5000);
     check_metadata_is_compatible(cct);
-    storage.sync_schema();
+    storage->sync_schema();
   }
   virtual ~DBConn() = default;
 
   DBConn(const DBConn&) = delete;
   DBConn& operator=(const DBConn&) = delete;
 
-  inline auto get_storage() { return storage; }
+  Storage* get_storage() { return storage.get(); }
 
   std::string getDBPath(CephContext* cct) const {
     auto rgw_sfs_path = cct->_conf.get_val<std::string>("rgw_sfs_data_path");

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -34,7 +34,7 @@ std::optional<DBOPBucketInfo> SQLiteBuckets::get_bucket(
     const std::string& bucket_id
 ) const {
   auto storage = conn->get_storage();
-  auto bucket = storage.get_pointer<DBBucket>(bucket_id);
+  auto bucket = storage->get_pointer<DBBucket>(bucket_id);
   std::optional<DBOPBucketInfo> ret_value;
   if (bucket) {
     ret_value = get_rgw_bucket(*bucket);
@@ -47,38 +47,38 @@ std::vector<DBOPBucketInfo> SQLiteBuckets::get_bucket_by_name(
 ) const {
   auto storage = conn->get_storage();
   return get_rgw_buckets(
-      storage.get_all<DBBucket>(where(c(&DBBucket::bucket_name) = bucket_name))
+      storage->get_all<DBBucket>(where(c(&DBBucket::bucket_name) = bucket_name))
   );
 }
 
 void SQLiteBuckets::store_bucket(const DBOPBucketInfo& bucket) const {
   auto storage = conn->get_storage();
   auto db_bucket = get_db_bucket(bucket);
-  storage.replace(db_bucket);
+  storage->replace(db_bucket);
 }
 
 void SQLiteBuckets::remove_bucket(const std::string& bucket_name) const {
   auto storage = conn->get_storage();
-  storage.remove<DBBucket>(bucket_name);
+  storage->remove<DBBucket>(bucket_name);
 }
 
 std::vector<std::string> SQLiteBuckets::get_bucket_ids() const {
   auto storage = conn->get_storage();
-  return storage.select(&DBBucket::bucket_name);
+  return storage->select(&DBBucket::bucket_name);
 }
 
 std::vector<std::string> SQLiteBuckets::get_bucket_ids(
     const std::string& user_id
 ) const {
   auto storage = conn->get_storage();
-  return storage.select(
+  return storage->select(
       &DBBucket::bucket_name, where(c(&DBBucket::owner_id) = user_id)
   );
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets() const {
   auto storage = conn->get_storage();
-  return get_rgw_buckets(storage.get_all<DBBucket>());
+  return get_rgw_buckets(storage->get_all<DBBucket>());
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets(
@@ -86,13 +86,13 @@ std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets(
 ) const {
   auto storage = conn->get_storage();
   return get_rgw_buckets(
-      storage.get_all<DBBucket>(where(c(&DBBucket::owner_id) = user_id))
+      storage->get_all<DBBucket>(where(c(&DBBucket::owner_id) = user_id))
   );
 }
 
 std::vector<std::string> SQLiteBuckets::get_deleted_buckets_ids() const {
   auto storage = conn->get_storage();
-  return storage.select(
+  return storage->select(
       &DBBucket::bucket_id, where(c(&DBBucket::deleted) = true)
   );
 }

--- a/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
@@ -20,7 +20,7 @@ SQLiteLifecycle::SQLiteLifecycle(DBConnRef _conn) : conn(_conn) {}
 
 DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
   auto storage = conn->get_storage();
-  auto head = storage.get_pointer<DBOPLCHead>(oid);
+  auto head = storage->get_pointer<DBOPLCHead>(oid);
   DBOPLCHead ret_value;
   if (head) {
     ret_value = *head;
@@ -29,7 +29,7 @@ DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
     // LC was not executed yet.
     // create an empty entry
     DBOPLCHead new_head{oid, "", 0};
-    storage.replace(new_head);
+    storage->replace(new_head);
     ret_value = new_head;
   }
   return ret_value;
@@ -37,19 +37,19 @@ DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
 
 void SQLiteLifecycle::store_head(const DBOPLCHead& head) const {
   auto storage = conn->get_storage();
-  storage.replace(head);
+  storage->replace(head);
 }
 
 void SQLiteLifecycle::remove_head(const std::string& oid) const {
   auto storage = conn->get_storage();
-  storage.remove<DBOPLCHead>(oid);
+  storage->remove<DBOPLCHead>(oid);
 }
 
 std::optional<DBOPLCEntry> SQLiteLifecycle::get_entry(
     const std::string& oid, const std::string& marker
 ) const {
   auto storage = conn->get_storage();
-  auto db_entry = storage.get_pointer<DBOPLCEntry>(oid, marker);
+  auto db_entry = storage->get_pointer<DBOPLCEntry>(oid, marker);
   std::optional<DBOPLCEntry> ret_value;
   if (db_entry) {
     ret_value = *db_entry;
@@ -61,7 +61,7 @@ std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
     const std::string& oid, const std::string& marker
 ) const {
   auto storage = conn->get_storage();
-  auto db_entries = storage.get_all<DBOPLCEntry>(
+  auto db_entries = storage->get_all<DBOPLCEntry>(
       where(
           is_equal(&DBOPLCEntry::lc_index, oid) and
           greater_than(&DBOPLCEntry::bucket_name, marker)
@@ -78,21 +78,21 @@ std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
 
 void SQLiteLifecycle::store_entry(const DBOPLCEntry& entry) const {
   auto storage = conn->get_storage();
-  storage.replace(entry);
+  storage->replace(entry);
 }
 
 void SQLiteLifecycle::remove_entry(
     const std::string& oid, const std::string& marker
 ) const {
   auto storage = conn->get_storage();
-  storage.remove<DBOPLCEntry>(oid, marker);
+  storage->remove<DBOPLCEntry>(oid, marker);
 }
 
 std::vector<DBOPLCEntry> SQLiteLifecycle::list_entries(
     const std::string& oid, const std::string& marker, uint32_t max_entries
 ) const {
   auto storage = conn->get_storage();
-  return storage.get_all<DBOPLCEntry>(
+  return storage->get_all<DBOPLCEntry>(
       where(
           is_equal(&DBOPLCEntry::lc_index, oid) and
           greater_than(&DBOPLCEntry::bucket_name, marker)

--- a/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
@@ -45,15 +45,15 @@ std::vector<DBOPObjectInfo> SQLiteObjects::get_objects(
 ) const {
   auto storage = conn->get_storage();
   auto objects =
-      storage.get_all<DBObject>(where(is_equal(&DBObject::bucket_id, bucket_id))
-      );
+      storage->get_all<DBObject>(where(is_equal(&DBObject::bucket_id, bucket_id)
+      ));
   return get_rgw_objects(objects);
 }
 
 std::optional<DBOPObjectInfo> SQLiteObjects::get_object(const uuid_d& uuid
 ) const {
   auto storage = conn->get_storage();
-  auto object = storage.get_pointer<DBObject>(uuid.to_string());
+  auto object = storage->get_pointer<DBObject>(uuid.to_string());
   std::optional<DBOPObjectInfo> ret_value;
   if (object) {
     ret_value = get_rgw_object(*object);
@@ -65,7 +65,7 @@ std::optional<DBOPObjectInfo> SQLiteObjects::get_object(
     const std::string& bucket_id, const std::string& object_name
 ) const {
   auto storage = conn->get_storage();
-  auto objects = storage.get_all<DBObject>(where(
+  auto objects = storage->get_all<DBObject>(where(
       is_equal(&DBObject::bucket_id, bucket_id) and
       is_equal(&DBObject::name, object_name)
   ));
@@ -80,23 +80,23 @@ std::optional<DBOPObjectInfo> SQLiteObjects::get_object(
 void SQLiteObjects::store_object(const DBOPObjectInfo& object) const {
   auto storage = conn->get_storage();
   auto db_object = get_db_object(object);
-  storage.replace(db_object);
+  storage->replace(db_object);
 }
 
 void SQLiteObjects::remove_object(const uuid_d& uuid) const {
   auto storage = conn->get_storage();
-  storage.remove<DBObject>(uuid.to_string());
+  storage->remove<DBObject>(uuid.to_string());
 }
 
 std::vector<uuid_d> SQLiteObjects::get_object_ids() const {
   auto storage = conn->get_storage();
-  return get_rgw_uuids(storage.select(&DBObject::object_id));
+  return get_rgw_uuids(storage->select(&DBObject::object_id));
 }
 
 std::vector<uuid_d> SQLiteObjects::get_object_ids(const std::string& bucket_id
 ) const {
   auto storage = conn->get_storage();
-  return get_rgw_uuids(storage.select(
+  return get_rgw_uuids(storage->select(
       &DBObject::object_id, where(c(&DBObject::bucket_id) = bucket_id)
   ));
 }

--- a/src/rgw/driver/sfs/sqlite/sqlite_users.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_users.cc
@@ -27,7 +27,7 @@ SQLiteUsers::SQLiteUsers(DBConnRef _conn) : conn(_conn) {}
 std::optional<DBOPUserInfo> SQLiteUsers::get_user(const std::string& userid
 ) const {
   auto storage = conn->get_storage();
-  auto user = storage.get_pointer<DBUser>(userid);
+  auto user = storage->get_pointer<DBUser>(userid);
   std::optional<DBOPUserInfo> ret_value;
   if (user) {
     ret_value = get_rgw_user(*user);
@@ -53,7 +53,7 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(
   auto user_id = _get_user_id_by_access_key(storage, key);
   std::optional<DBOPUserInfo> ret_value;
   if (user_id.has_value()) {
-    auto user = storage.get_pointer<DBUser>(user_id);
+    auto user = storage->get_pointer<DBUser>(user_id);
     if (user) {
       ret_value = get_rgw_user(*user);
     }
@@ -63,27 +63,27 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(
 
 std::vector<std::string> SQLiteUsers::get_user_ids() const {
   auto storage = conn->get_storage();
-  return storage.select(&DBUser::user_id);
+  return storage->select(&DBUser::user_id);
 }
 
 void SQLiteUsers::store_user(const DBOPUserInfo& user) const {
   auto storage = conn->get_storage();
   auto db_user = get_db_user(user);
-  storage.replace(db_user);
+  storage->replace(db_user);
   _store_access_keys(storage, user);
 }
 
 void SQLiteUsers::remove_user(const std::string& userid) const {
   auto storage = conn->get_storage();
   _remove_access_keys(storage, userid);
-  storage.remove<DBUser>(userid);
+  storage->remove<DBUser>(userid);
 }
 
 template <class... Args>
 std::vector<DBOPUserInfo> SQLiteUsers::get_users_by(Args... args) const {
   std::vector<DBOPUserInfo> users_return;
   auto storage = conn->get_storage();
-  auto users = storage.get_all<DBUser>(args...);
+  auto users = storage->get_all<DBUser>(args...);
   for (auto& user : users) {
     users_return.push_back(get_rgw_user(user));
   }
@@ -91,7 +91,7 @@ std::vector<DBOPUserInfo> SQLiteUsers::get_users_by(Args... args) const {
 }
 
 void SQLiteUsers::_store_access_keys(
-    rgw::sal::sfs::sqlite::Storage storage, const DBOPUserInfo& user
+    rgw::sal::sfs::sqlite::Storage* storage, const DBOPUserInfo& user
 ) const {
   // remove existing keys for the user (in case any of them had changed)
   _remove_access_keys(storage, user.uinfo.user_id.id);
@@ -99,21 +99,21 @@ void SQLiteUsers::_store_access_keys(
     DBAccessKey db_key;
     db_key.access_key = key.first;
     db_key.user_id = user.uinfo.user_id.id;
-    storage.insert(db_key);
+    storage->insert(db_key);
   }
 }
 
 void SQLiteUsers::_remove_access_keys(
-    rgw::sal::sfs::sqlite::Storage storage, const std::string& userid
+    rgw::sal::sfs::sqlite::Storage* storage, const std::string& userid
 ) const {
-  storage.remove_all<DBAccessKey>(where(c(&DBAccessKey::user_id) = userid));
+  storage->remove_all<DBAccessKey>(where(c(&DBAccessKey::user_id) = userid));
 }
 
 std::optional<std::string> SQLiteUsers::_get_user_id_by_access_key(
-    rgw::sal::sfs::sqlite::Storage storage, const std::string& key
+    rgw::sal::sfs::sqlite::Storage* storage, const std::string& key
 ) const {
   auto keys =
-      storage.get_all<DBAccessKey>(where(c(&DBAccessKey::access_key) = key));
+      storage->get_all<DBAccessKey>(where(c(&DBAccessKey::access_key) = key));
   std::optional<std::string> ret_value;
   if (keys.size() > 0) {
     // in case we have 2 keys that are equal in different users we return

--- a/src/rgw/driver/sfs/sqlite/sqlite_users.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_users.h
@@ -41,13 +41,13 @@ class SQLiteUsers {
   std::vector<DBOPUserInfo> get_users_by(Args... args) const;
 
   void _store_access_keys(
-      rgw::sal::sfs::sqlite::Storage storage, const DBOPUserInfo& user
+      rgw::sal::sfs::sqlite::Storage* storage, const DBOPUserInfo& user
   ) const;
   void _remove_access_keys(
-      rgw::sal::sfs::sqlite::Storage storage, const std::string& userid
+      rgw::sal::sfs::sqlite::Storage* storage, const std::string& userid
   ) const;
   std::optional<std::string> _get_user_id_by_access_key(
-      rgw::sal::sfs::sqlite::Storage storage, const std::string& key
+      rgw::sal::sfs::sqlite::Storage* storage, const std::string& key
   ) const;
 };
 

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -33,7 +33,7 @@ SQLiteVersionedObjects::SQLiteVersionedObjects(DBConnRef _conn) : conn(_conn) {}
 std::optional<DBOPVersionedObjectInfo>
 SQLiteVersionedObjects::get_versioned_object(uint id) const {
   auto storage = conn->get_storage();
-  auto object = storage.get_pointer<DBVersionedObject>(id);
+  auto object = storage->get_pointer<DBVersionedObject>(id);
   std::optional<DBOPVersionedObjectInfo> ret_value;
   if (object) {
     ret_value = get_rgw_versioned_object(*object);
@@ -45,7 +45,7 @@ std::optional<DBOPVersionedObjectInfo>
 SQLiteVersionedObjects::get_versioned_object(const std::string& version_id
 ) const {
   auto storage = conn->get_storage();
-  auto versioned_objects = storage.get_all<DBVersionedObject>(
+  auto versioned_objects = storage->get_all<DBVersionedObject>(
       where(c(&DBVersionedObject::version_id) = version_id)
   );
   ceph_assert(versioned_objects.size() <= 1);
@@ -61,7 +61,7 @@ uint SQLiteVersionedObjects::insert_versioned_object(
 ) const {
   auto storage = conn->get_storage();
   auto db_object = get_db_versioned_object(object);
-  return storage.insert(db_object);
+  return storage->insert(db_object);
 }
 
 void SQLiteVersionedObjects::store_versioned_object(
@@ -69,17 +69,17 @@ void SQLiteVersionedObjects::store_versioned_object(
 ) const {
   auto storage = conn->get_storage();
   auto db_object = get_db_versioned_object(object);
-  storage.update(db_object);
+  storage->update(db_object);
 }
 
 void SQLiteVersionedObjects::remove_versioned_object(uint id) const {
   auto storage = conn->get_storage();
-  storage.remove<DBVersionedObject>(id);
+  storage->remove<DBVersionedObject>(id);
 }
 
 std::vector<uint> SQLiteVersionedObjects::get_versioned_object_ids() const {
   auto storage = conn->get_storage();
-  return storage.select(&DBVersionedObject::id);
+  return storage->select(&DBVersionedObject::id);
 }
 
 std::vector<uint> SQLiteVersionedObjects::get_versioned_object_ids(
@@ -87,7 +87,7 @@ std::vector<uint> SQLiteVersionedObjects::get_versioned_object_ids(
 ) const {
   auto storage = conn->get_storage();
   auto uuid = object_id.to_string();
-  return storage.select(
+  return storage->select(
       &DBVersionedObject::id, where(c(&DBVersionedObject::object_id) = uuid)
   );
 }
@@ -96,7 +96,7 @@ std::vector<DBOPVersionedObjectInfo>
 SQLiteVersionedObjects::get_versioned_objects(const uuid_d& object_id) const {
   auto storage = conn->get_storage();
   auto uuid = object_id.to_string();
-  auto versioned_objects = storage.get_all<DBVersionedObject>(
+  auto versioned_objects = storage->get_all<DBVersionedObject>(
       where(c(&DBVersionedObject::object_id) = uuid)
   );
   return get_rgw_versioned_objects(versioned_objects);
@@ -106,14 +106,14 @@ std::optional<DBOPVersionedObjectInfo>
 SQLiteVersionedObjects::get_last_versioned_object(const uuid_d& object_id
 ) const {
   auto storage = conn->get_storage();
-  auto last_version_id = storage.max(
+  auto last_version_id = storage->max(
       &DBVersionedObject::id,
       where(c(&DBVersionedObject::object_id) = object_id.to_string())
   );
   std::optional<DBOPVersionedObjectInfo> ret_value;
   if (last_version_id) {
     auto last_version =
-        storage.get_pointer<DBVersionedObject>(*last_version_id);
+        storage->get_pointer<DBVersionedObject>(*last_version_id);
     if (last_version) {
       ret_value = get_rgw_versioned_object(*last_version);
     }

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -403,9 +403,9 @@ http::status SFSStatusPage::render(std::ostream& os) {
 
   os << "<h2>SQLite</h2>\n"
      << "<ul>\n"
-     << "<li> filename: " << db.filename() << "</li>\n"
-     << "<li> libversion: " << db.libversion() << "</li>\n"
-     << "<li> total_changes: " << db.total_changes() << "</li>\n";
+     << "<li> filename: " << db->filename() << "</li>\n"
+     << "<li> libversion: " << db->libversion() << "</li>\n"
+     << "<li> total_changes: " << db->total_changes() << "</li>\n";
 
   int current;
   int highwater;

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -192,16 +192,16 @@ void createDBBucketBasic(const std::string & user,
   db_bucket.bucket_name = name;
   db_bucket.bucket_id = bucket_id;
   db_bucket.owner_id = user;
-  storage.replace(db_bucket);
+  storage->replace(db_bucket);
 }
 
 void deleteDBBucketBasic(const std::string & bucket_id,
                         const std::shared_ptr<DBConn> & conn) {
   auto storage = conn->get_storage();
-  auto bucket = storage.get_pointer<DBBucket>(bucket_id);
+  auto bucket = storage->get_pointer<DBBucket>(bucket_id);
   ASSERT_TRUE(bucket != nullptr);
   bucket->deleted = true;
-  storage.replace(*bucket);
+  storage->replace(*bucket);
 }
 
 TEST_F(TestSFSSQLiteBuckets, CreateAndGet) {
@@ -483,9 +483,9 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   db_bucket.bucket_id = "test_storage_id";
 
   // we have to use replace because the primary key of rgw_bucket is a string
-  storage.replace(db_bucket);
+  storage->replace(db_bucket);
 
-  auto bucket = storage.get_pointer<DBBucket>("test_storage_id");
+  auto bucket = storage->get_pointer<DBBucket>("test_storage_id");
 
   ASSERT_NE(bucket, nullptr);
   ASSERT_EQ(bucket->bucket_name, "test_storage");
@@ -503,7 +503,7 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   auto db_bucket_2 = get_db_bucket(rgw_bucket_2);
 
   // we have to use replace because the primary key of rgw_bucket is a string
-  storage.replace(db_bucket_2);
+  storage->replace(db_bucket_2);
 
   // now use the SqliteBuckets method, so user is already converted
   auto ret_bucket = db_buckets.get_bucket("BucketID1");
@@ -528,7 +528,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketForNonExistingUser) {
 
   EXPECT_THROW({
     try {
-        storage.replace(db_bucket);;
+        storage->replace(db_bucket);;
     } catch( const std::system_error & e ) {
         EXPECT_STREQ( "FOREIGN KEY constraint failed: constraint failed", e.what() );
         throw;
@@ -553,7 +553,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketOwnerNotSet) {
 
   EXPECT_THROW({
     try {
-        storage.replace(db_bucket);
+        storage->replace(db_bucket);
     } catch( const std::system_error & e ) {
         EXPECT_STREQ( "FOREIGN KEY constraint failed: constraint failed", e.what() );
         throw;

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
@@ -318,7 +318,7 @@ TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
 
   EXPECT_THROW({
     try {
-        storage.replace(db_object);;
+        storage->replace(db_object);;
     } catch( const std::system_error & e ) {
         EXPECT_STREQ( "FOREIGN KEY constraint failed: constraint failed", e.what() );
         throw;

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -324,9 +324,9 @@ TEST_F(TestSFSSQLiteUsers, UseStorage) {
   db_user.user_id = "test_storage";
 
   // we have to use replace because the primary key of rgw_user is a string
-  storage.replace(db_user);
+  storage->replace(db_user);
 
-  auto user = storage.get_pointer<DBUser>("test_storage");
+  auto user = storage->get_pointer<DBUser>("test_storage");
 
   ASSERT_NE(user, nullptr);
   ASSERT_EQ(user->user_id, "test_storage");
@@ -342,7 +342,7 @@ TEST_F(TestSFSSQLiteUsers, UseStorage) {
   auto db_user_2 = get_db_user(rgw_user_2);
 
   // we have to use replace because the primary key of rgw_user is a string
-  storage.replace(db_user_2);
+  storage->replace(db_user_2);
 
   // now use the SqliteUsers method, so user is already converted
   auto ret_user = db_users.get_user("test1");

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -439,7 +439,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateObjectForNonExistingBucket) {
 
   EXPECT_THROW({
     try {
-        storage.replace(db_object);;
+        storage->replace(db_object);;
     } catch( const std::system_error & e ) {
         EXPECT_STREQ( "FOREIGN KEY constraint failed: constraint failed", e.what() );
         throw;
@@ -466,21 +466,21 @@ TEST_F(TestSFSSQLiteVersionedObjects, Testobject_stateConversion) {
   ASSERT_EQ(0, db_object.object_state);
 
   db_object.object_state = 1;
-  storage.replace(db_object);
+  storage->replace(db_object);
 
   auto ret_object = db_objects.get_versioned_object(db_object.id);
   ASSERT_TRUE(ret_object.has_value());
   ASSERT_EQ(rgw::sal::ObjectState::COMMITTED, ret_object->object_state);
 
   db_object.object_state = 2;
-  storage.replace(db_object);
+  storage->replace(db_object);
 
   ret_object = db_objects.get_versioned_object(db_object.id);
   ASSERT_TRUE(ret_object.has_value());
   ASSERT_EQ(rgw::sal::ObjectState::LOCKED, ret_object->object_state);
 
   db_object.object_state = 3;
-  storage.replace(db_object);
+  storage->replace(db_object);
 
   ret_object = db_objects.get_versioned_object(db_object.id);
   ASSERT_TRUE(ret_object.has_value());
@@ -506,7 +506,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, Testobject_stateBadValue) {
   ASSERT_EQ(0, db_object.object_state);
 
   db_object.object_state = 10;
-  storage.replace(db_object);
+  storage->replace(db_object);
 
   EXPECT_THROW({
     try {


### PR DESCRIPTION
No longer make copies when calling get_storage().

Copying the sqlite_orm storage type creates a new SQLite database connection. Problematic, for example, when using the SQLite in-memory database option. On every get_storage() you would end up with a new, empty database.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

