### PR TITLE
rgw/sfs: fix build-radosgw.sh not compiling sfs unittests

### DIFF
--- a/qa/rgw/store/sfs/build-radosgw.sh
+++ b/qa/rgw/store/sfs/build-radosgw.sh
@@ -114,11 +114,11 @@ _build() {
   if [ "${WITH_TESTS}" == "ON" ] ; then
     # discover tests from build.ninja so we don't need to update this after
     # adding a new unit test
-    # SFS unittests should be named unittest_rgw_sfs*
+    # SFS unittests should be named unittest_rgw_sfs_*
+    # SFS unittests should be named unittest_rgw_s3gw_*
     IFS=" " read -r -a \
-      UNIT_TESTS <<< "$(awk '/build unittest_rgw_(sfs|s3gw)/ {
-                               print $4
-                             }' build.ninja)"
+      UNIT_TESTS <<< "$(grep -E "build unittest_rgw_sfs_|build unittest_rgw_s3gw_" build.ninja \
+                          | awk 'BEGIN {ORS=" "}; {print $4}')"
     ninja -j "${NPROC}" "${UNIT_TESTS[@]}"
   fi
 


### PR DESCRIPTION
The UNIT_TESTS variable in the script was initialized with a value that was not capturing all the sfs related unittests.

Fixes: https://github.com/aquarist-labs/s3gw/issues/449
Signed-off-by: Giuseppe Baccini <giuseppe.baccini@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

