### PR TITLE
ci: force docker for s3tests

### DIFF
--- a/.github/workflows/build-test-radosgw.yml
+++ b/.github/workflows/build-test-radosgw.yml
@@ -204,6 +204,7 @@ jobs:
           export CEPH_DIR="${GITHUB_WORKSPACE}/ceph"
           export OUTPUT_DIR="${GITHUB_WORKSPACE}/s3test-results"
           export FORCE_CONTAINER=ON
+          export FORCE_DOCKER=ON
           export \
             FIXTURES="${GITHUB_WORKSPACE}/ceph/qa/rgw/store/sfs/tests/fixtures"
 


### PR DESCRIPTION
Force the use of docker for running the s3gw container during s3tests. This fixes a bug in the log collection of podman
