### PR TITLE
rgw/sfs: Extract deletion usage from types.h object, Atomic Deletes

### DIFF
--- a/src/rgw/driver/sfs/sfs_gc.cc
+++ b/src/rgw/driver/sfs/sfs_gc.cc
@@ -13,6 +13,9 @@
  */
 #include "sfs_gc.h"
 
+#include <filesystem>
+#include <system_error>
+
 #include "driver/sfs/types.h"
 #include "rgw/driver/sfs/sqlite/sqlite_objects.h"
 
@@ -94,23 +97,7 @@ void SFSGC::delete_objects(const std::string& bucket_id) {
     if (max_objects <= 0) {
       break;
     }
-    auto obj_instance =
-        std::unique_ptr<Object>(Object::create_for_immediate_deletion(object));
-    delete_object(*obj_instance.get());
-  }
-}
-
-void SFSGC::delete_versioned_objects(const Object& object) {
-  sqlite::SQLiteVersionedObjects db_ver_objs(store->db_conn);
-  auto versions = db_ver_objs.get_versioned_objects(object.path.get_uuid());
-  for (auto const& version : versions) {
-    if (max_objects <= 0) {
-      break;
-    }
-
-    Object to_be_deleted(object);
-    to_be_deleted.version_id = version.id;
-    delete_versioned_object(to_be_deleted);
+    delete_object(object.uuid);
   }
 }
 
@@ -125,23 +112,26 @@ void SFSGC::delete_bucket(const std::string& bucket_id) {
   }
 }
 
-void SFSGC::delete_object(const Object& object) {
-  // delete its versions first
-  delete_versioned_objects(object);
-  if (max_objects > 0) {
-    object.delete_object_metadata(store);
-    object.delete_object_data(store, true);
-    lsfs_dout(this, 30) << "Deleted object: " << object.path.get_uuid()
-                        << dendl;
-    --max_objects;
+void SFSGC::delete_object(const uuid_d& id) {
+  ObjectDeleter deleter(store->get_data_path(), store->db_conn, id);
+  std::vector<uint> versions_deleted;
+  try {
+    versions_deleted = deleter.delete_all();
+  } catch (const std::system_error& e) {
+    lsfs_dout(this, 30) << "Failed to delete object " << id
+                        << " retrying next iteration." << dendl;
+    return;
   }
-}
 
-void SFSGC::delete_versioned_object(const Object& object) {
-  object.delete_object_version(store);
-  object.delete_object_data(store, false);
-  lsfs_dout(this, 30) << "Deleted version: (" << object.path.get_uuid() << ","
-                      << object.version_id << ")" << dendl;
+  try {
+    deleter.delete_version_data(versions_deleted);
+    deleter.delete_data_directory();
+  } catch (const std::filesystem::filesystem_error& e) {
+    lsfs_dout(this, 10) << "Error while deleting object " << id
+                        << " data. Orphaned files may exists." << dendl;
+  }
+  lsfs_dout(this, 30) << "Deleted object " << id << ". "
+                      << versions_deleted.size() << " versions." << dendl;
   --max_objects;
 }
 

--- a/src/rgw/driver/sfs/sfs_gc.h
+++ b/src/rgw/driver/sfs/sfs_gc.h
@@ -70,11 +70,8 @@ class SFSGC : public DoutPrefixProvider {
   void process_deleted_buckets();
 
   void delete_objects(const std::string& bucket_id);
-  void delete_versioned_objects(const Object& object);
-
+  void delete_object(const uuid_d& id);
   void delete_bucket(const std::string& bucket_id);
-  void delete_object(const Object& object);
-  void delete_versioned_object(const Object& object);
 };
 
 }  //  namespace rgw::sal::sfs

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -16,7 +16,11 @@
 
 #include <memory>
 #include <string>
+#include <system_error>
 
+#include "dbconn.h"
+#include "driver/sfs/uuid_path.h"
+#include "objects/object_definitions.h"
 #include "rgw/driver/sfs/object_state.h"
 #include "rgw/driver/sfs/sqlite/sqlite_buckets.h"
 #include "rgw/driver/sfs/sqlite/sqlite_objects.h"
@@ -24,19 +28,12 @@
 #include "rgw/driver/sfs/types.h"
 #include "rgw/rgw_sal_sfs.h"
 #include "rgw_sal_sfs.h"
+#include "versioned_object/versioned_object_definitions.h"
 
 namespace rgw::sal::sfs {
 
 Object::Object(const std::string& _name, const uuid_d& _uuid)
     : name(_name), path(_uuid), deleted(false) {}
-
-Object* Object::create_for_immediate_deletion(
-    const sqlite::DBOPObjectInfo& object
-) {
-  Object* result = new Object(object.name, object.uuid);
-  result->deleted = true;
-  return result;
-}
 
 Object* Object::create_for_query(
     const std::string& name, const uuid_d& uuid, bool deleted, uint version_id
@@ -167,8 +164,14 @@ Object* Object::try_create_fetch_from_database(
   return result;
 }
 
-std::filesystem::path Object::get_storage_path() const {
+std::filesystem::path Object::get_storage_path(
+    const UUIDPath& path, uint version_id
+) {
   return path.to_path() / std::to_string(version_id);
+}
+
+std::filesystem::path Object::get_storage_path() const {
+  return get_storage_path(path, version_id);
 }
 
 const Object::Meta Object::get_meta() const {
@@ -264,27 +267,48 @@ void Object::metadata_finish(SFStore* store) {
   db_versioned_objs.store_versioned_object(*db_versioned_object);
 }
 
-int Object::delete_object_version(SFStore* store) const {
-  // remove metadata
-  sqlite::SQLiteVersionedObjects db_versioned_objs(store->db_conn);
+ObjectDeleter::ObjectDeleter(
+    const std::filesystem::path _data_path, sqlite::DBConnRef _dbconn,
+    const uuid_d& _uuid
+)
+    : data_path(_data_path), dbconn(_dbconn), uuid(_uuid) {}
+
+void ObjectDeleter::delete_version(uint version_id) const {
+  sqlite::SQLiteVersionedObjects db_versioned_objs(dbconn);
   db_versioned_objs.remove_versioned_object(version_id);
-  return 0;
 }
 
-void Object::delete_object_metadata(SFStore* store) const {
-  // remove metadata
-  sqlite::SQLiteObjects db_objs(store->db_conn);
-  db_objs.remove_object(path.get_uuid());
-}
-
-void Object::delete_object_data(SFStore* store, bool all) const {
-  if (all) {
-    // remove object folder
-    std::filesystem::remove(store->get_data_path() / path.to_path());
-  } else {
-    // remove object data
-    std::filesystem::remove(store->get_data_path() / get_storage_path());
+void ObjectDeleter::delete_version_data(std::vector<uint> versions) const {
+  for (const auto& version : versions) {
+    std::filesystem::remove(
+        data_path / Object::get_storage_path(uuid, version)
+    );
   }
+}
+
+void ObjectDeleter::delete_data_directory() const {
+  std::filesystem::remove(data_path / uuid.to_path());
+}
+
+std::vector<uint> ObjectDeleter::delete_all() const {
+  auto storage = dbconn->get_storage();
+  auto transaction = storage.transaction_guard();
+  // TODO(irq0) Replace with 'delete .. returning' when sqlite_orm
+  // supports that
+  std::vector<uint> result = storage.select(
+      &sqlite::DBVersionedObject::id,
+      sqlite_orm::where(
+          sqlite_orm::c(&sqlite::DBVersionedObject::object_id) =
+              uuid.get_uuid().to_string()
+      )
+  );
+  storage.remove_all<sqlite::DBVersionedObject>(sqlite_orm::where(
+      sqlite_orm::c(&sqlite::DBVersionedObject::object_id) =
+          uuid.get_uuid().to_string()
+  ));
+  storage.remove<sqlite::DBObject>(uuid.get_uuid().to_string());
+  transaction.commit();
+  return result;
 }
 
 void MultipartObject::_abort(const DoutPrefixProvider* dpp) {

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -67,9 +67,6 @@ class Object {
         deleted(false) {}
 
  public:
-  static Object* create_for_immediate_deletion(
-      const sqlite::DBOPObjectInfo& object
-  );
   static Object* create_for_query(
       const std::string& name, const uuid_d& uuid, bool deleted, uint version_id
   );
@@ -103,6 +100,9 @@ class Object {
   Attrs get_attrs();
   void update_attrs(const Attrs& update);
 
+  static std::filesystem::path get_storage_path(
+      const UUIDPath& path, uint version_id
+  );
   std::filesystem::path get_storage_path() const;
 
   /// Update version and commit to database
@@ -122,12 +122,29 @@ class Object {
 
   /// Commit attrs to database
   void metadata_flush_attrs(SFStore* store);
+};
 
-  int delete_object_version(SFStore* store) const;
-  void delete_object_metadata(SFStore* store) const;
-  /// Delete object _data_ (e.g payload of PUT operations) from disk.
-  // Set all=true to delete all versions, not just this version.
-  void delete_object_data(SFStore* store, bool all) const;
+/// Object and object version delete utility
+class ObjectDeleter {
+ private:
+  std::filesystem::path data_path;
+  sqlite::DBConnRef dbconn;
+  UUIDPath uuid;
+
+ public:
+  ObjectDeleter(
+      const std::filesystem::path data_path, sqlite::DBConnRef _dbconn,
+      const uuid_d& _uuid
+  );
+  /// Delete version database entry
+  void delete_version(uint version_id) const;
+  /// Delete version object data
+  void delete_version_data(std::vector<uint> versions) const;
+  /// Delete object _data_ including all versions.
+  void delete_data_directory() const;
+  /// Delete all versions and the object entry. NOT the data.
+  /// Returns version ids deleted.
+  std::vector<uint> delete_all() const;
 };
 
 using ObjectRef = std::shared_ptr<Object>;

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -163,7 +163,10 @@ void SFSAtomicWriter::cleanup() noexcept {
   }
 
   try {
-    objref->delete_object_version(store);
+    sfs::ObjectDeleter deleter(
+        object_path, store->db_conn, objref->path.get_uuid()
+    );
+    deleter.delete_version(objref->version_id);
   } catch (const std::system_error& e) {
     lsfs_dout(dpp, -1)
         << fmt::format(

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -145,12 +145,11 @@ protected:
     db_versioned_objects.insert_versioned_object(db_version);
   }
 
-  void deleteTestObject(std::shared_ptr<rgw::sal::sfs::Object> & object,
+  void deleteTestObject(uuid_d id,
                         DBConnRef conn) {
     // delete mark the object
     SQLiteVersionedObjects db_versioned_objects(conn);
-    auto last_version = db_versioned_objects.get_last_versioned_object(
-                                                       object->path.get_uuid());
+    auto last_version = db_versioned_objects.get_last_versioned_object(id);
     ASSERT_TRUE(last_version.has_value());
     last_version->object_state = rgw::sal::ObjectState::DELETED;
     last_version->version_id.append("_next_");
@@ -166,9 +165,7 @@ protected:
     SQLiteObjects db_objects(conn);
     auto objects = db_objects.get_objects(bucket_id);
     for (auto & object: objects) {
-        auto objptr = std::shared_ptr<rgw::sal::sfs::Object>(
-	    rgw::sal::sfs::Object::create_for_immediate_deletion(object));
-        deleteTestObject(objptr, conn);
+        deleteTestObject(object.uuid, conn);
     }
     bucket->deleted = true;
     db_buckets.store_bucket(*bucket);
@@ -295,34 +292,26 @@ TEST_F(TestSFSGC, TestDeletedBucketsMaxObjects) {
 
   gc->process();
 
-  // only 1 file should be removed
-  EXPECT_EQ(getStoreDataFileCount(), 4);
+  // one object with 2 versions disappears
+  EXPECT_EQ(getStoreDataFileCount(), 3);
   EXPECT_TRUE(databaseFileExists());
   // the object is still reachable in the db
-  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
   EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
 
   gc->process();
 
-  // one more version removed
+  // no new deletes -> no change
   EXPECT_EQ(getStoreDataFileCount(), 3);
   EXPECT_TRUE(databaseFileExists());
   // the object is still reachable in the db (versions removed)
-  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
+  EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
   EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
 
   gc->process();
-  // one more version removed
+  // no new deletes -> no change
   EXPECT_EQ(getStoreDataFileCount(), 3);
   EXPECT_TRUE(databaseFileExists());
-  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
-  EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
-
-  gc->process();
-  // one more version removed
-  EXPECT_EQ(getStoreDataFileCount(), 3);
-  EXPECT_TRUE(databaseFileExists());
-  // the object is finally removed
   EXPECT_EQ(0, getNumberObjectsForBucket("test_bucket_2", store->db_conn));
   EXPECT_EQ(1, getNumberObjectsForBucket("test_bucket_1", store->db_conn));
 }


### PR DESCRIPTION
Object and object version deletion becomes a new ObjectDeleter utility that knows how to delete database entries and data on disk.

Add atomic object + all versions delete method.

Use the new delete all in the GC to remove objects one at a time instead of one version at a time.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

