### PR TITLE
ci: add labels to sfs/s3gw unit tests

### DIFF
--- a/qa/rgw/store/sfs/build-radosgw.sh
+++ b/qa/rgw/store/sfs/build-radosgw.sh
@@ -112,13 +112,9 @@ _build() {
   ninja -j "${NPROC}" bin/radosgw crypto_plugins
 
   if [ "${WITH_TESTS}" == "ON" ] ; then
-    # discover tests from build.ninja so we don't need to update this after
-    # adding a new unit test
-    # SFS unittests should be named unittest_rgw_sfs_*
-    # SFS unittests should be named unittest_rgw_s3gw_*
-    IFS=" " read -r -a \
-      UNIT_TESTS <<< "$(grep -E "build unittest_rgw_sfs_|build unittest_rgw_s3gw_" build.ninja \
-                          | awk 'BEGIN {ORS=" "}; {print $4}')"
+    # discover tests from ctest tags. Selects all tests which have the tag s3gw
+    mapfile -t \
+      UNIT_TESTS <<< "$(ctest -N -L s3gw | grep "Test #" | awk '{print $3}')"
     ninja -j "${NPROC}" "${UNIT_TESTS[@]}"
   fi
 

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -271,6 +271,8 @@ target_include_directories(unittest_rgw_s3gw_telemetry
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/store/rados")
 target_link_libraries(unittest_rgw_s3gw_telemetry ${rgw_libs})
+set_tests_properties(unittest_rgw_s3gw_telemetry
+  PROPERTIES LABELS "unittest;rgw;s3gw;telemetry")
 
 add_executable(unittest_rgw_lua test_rgw_lua.cc)
 add_ceph_unittest(unittest_rgw_lua)

--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -1,34 +1,18 @@
-add_executable(unittest_rgw_sfs_sqlite_users test_rgw_sfs_sqlite_users.cc)
-add_ceph_unittest(unittest_rgw_sfs_sqlite_users)
-target_link_libraries(unittest_rgw_sfs_sqlite_users ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_sqlite_buckets test_rgw_sfs_sqlite_buckets.cc)
-add_ceph_unittest(unittest_rgw_sfs_sqlite_buckets)
-target_link_libraries(unittest_rgw_sfs_sqlite_buckets ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_sqlite_objects test_rgw_sfs_sqlite_objects.cc)
-add_ceph_unittest(unittest_rgw_sfs_sqlite_objects)
-target_link_libraries(unittest_rgw_sfs_sqlite_objects ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_sqlite_versioned_objects test_rgw_sfs_sqlite_versioned_objects.cc)
-add_ceph_unittest(unittest_rgw_sfs_sqlite_versioned_objects)
-target_link_libraries(unittest_rgw_sfs_sqlite_versioned_objects ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_sqlite_lifecycle test_rgw_sfs_sqlite_lifecycle.cc)
-add_ceph_unittest(unittest_rgw_sfs_sqlite_lifecycle)
-target_link_libraries(unittest_rgw_sfs_sqlite_lifecycle ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_sfs_bucket test_rgw_sfs_sfs_bucket.cc)
-add_ceph_unittest(unittest_rgw_sfs_sfs_bucket)
-target_link_libraries(unittest_rgw_sfs_sfs_bucket ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_sfs_user test_rgw_sfs_sfs_user.cc)
-add_ceph_unittest(unittest_rgw_sfs_sfs_user)
-target_link_libraries(unittest_rgw_sfs_sfs_user ${rgw_libs})
-
-add_executable(unittest_rgw_sfs_gc test_rgw_sfs_gc.cc)
-add_ceph_unittest(unittest_rgw_sfs_gc)
-target_link_libraries(unittest_rgw_sfs_gc ${rgw_libs})
-
 add_custom_target(unittest_rgw_sfs)
-add_dependencies(unittest_rgw_sfs unittest_rgw_sfs_sqlite_users unittest_rgw_sfs_sqlite_buckets unittest_rgw_sfs_sqlite_objects unittest_rgw_sfs_sqlite_versioned_objects unittest_rgw_sfs_sfs_bucket unittest_rgw_sfs_sfs_user unittest_rgw_sfs_gc unittest_rgw_sfs_sqlite_lifecycle)
+
+function(add_s3gw_test test_name test_path)
+  add_executable(${test_name} ${test_path})
+  add_ceph_unittest(${test_name})
+  target_link_libraries(${test_name} ${rgw_libs})
+  set_tests_properties(${test_name} PROPERTIES LABELS "unittest;rgw;sfs;s3gw")
+  add_dependencies(unittest_rgw_sfs ${test_name})
+endfunction()
+
+add_s3gw_test(unittest_rgw_sfs_sqlite_users test_rgw_sfs_sqlite_users.cc)
+add_s3gw_test(unittest_rgw_sfs_sqlite_buckets test_rgw_sfs_sqlite_buckets.cc)
+add_s3gw_test(unittest_rgw_sfs_sqlite_objects test_rgw_sfs_sqlite_objects.cc)
+add_s3gw_test(unittest_rgw_sfs_sqlite_versioned_objects test_rgw_sfs_sqlite_versioned_objects.cc)
+add_s3gw_test(unittest_rgw_sfs_sqlite_lifecycle test_rgw_sfs_sqlite_lifecycle.cc)
+add_s3gw_test(unittest_rgw_sfs_sfs_bucket test_rgw_sfs_sfs_bucket.cc)
+add_s3gw_test(unittest_rgw_sfs_sfs_user test_rgw_sfs_sfs_user.cc)
+add_s3gw_test(unittest_rgw_sfs_gc test_rgw_sfs_gc.cc)


### PR DESCRIPTION
- Add ctest labels to unit tests, identifying the ones that are specific to sfs and s3gw respectively.
- Select unit tests to build as ninja build targets based on ctests labels. All tests which are labeled with the `s3gw` label are selected.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

