### PR TITLE
rgw/sfs: GC remove deleted objects and nocurrent versions

### DIFF
--- a/src/rgw/driver/sfs/sfs_errors.h
+++ b/src/rgw/driver/sfs/sfs_errors.h
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#pragma once
+
+#define ERR_SFS_METADATA_DELETE_ERROR 5000

--- a/src/rgw/driver/sfs/sfs_gc.h
+++ b/src/rgw/driver/sfs/sfs_gc.h
@@ -28,6 +28,7 @@ class SFSGC : public DoutPrefixProvider {
   std::atomic<bool> down_flag = {true};
   std::atomic<bool> suspend_flag = {false};
   long int max_objects;
+  std::unique_ptr<sfs::ObjectDeleter> deleter;
 
   class GCWorker : public Thread {
     const DoutPrefixProvider* dpp = nullptr;
@@ -67,14 +68,19 @@ class SFSGC : public DoutPrefixProvider {
   std::string get_cls_name() const { return "SFSGC"; }
 
  private:
-  void process_deleted_buckets();
+  int process_deleted_buckets();
+  int process_deleted_versions();
 
-  void delete_objects(const std::string& bucket_id);
-  void delete_versioned_objects(const Object& object);
+  int delete_objects(const std::string& bucket_id);
+  int delete_bucket(const std::string& bucket_id);
 
-  void delete_bucket(const std::string& bucket_id);
-  void delete_object(const Object& object);
-  void delete_versioned_object(const Object& object);
+  int delete_object(const uuid_d& uuid, bool& whole_object_deleted);
+  int delete_version(const uuid_d& uuid, uint version);
+
+  void log_gc_error(int error, const uuid_d& uuid) const;
+  void log_gc_error(int error, const uuid_d& uuid, uint version) const;
+
+  bool able_to_continue_after_error(int error) const;
 };
 
 }  //  namespace rgw::sal::sfs

--- a/src/rgw/driver/sfs/sqlite/sqlite_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_objects.h
@@ -36,6 +36,7 @@ class SQLiteObjects {
 
   void store_object(const DBOPObjectInfo& object) const;
   void remove_object(const uuid_d& uuid) const;
+  std::vector<uint> remove_object_recursive(const uuid_d& uuid) const;
 
   std::vector<uuid_d> get_object_ids() const;
   std::vector<uuid_d> get_object_ids(const std::string& bucket_id) const;

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -121,4 +121,29 @@ SQLiteVersionedObjects::get_last_versioned_object(const uuid_d& object_id
   return ret_value;
 }
 
+std::vector<DBOPVersionedObjectInfo>
+SQLiteVersionedObjects::get_deleted_versioned_objects_highest_priority_first(
+    uint max_objects
+) const {
+  auto storage = conn->get_storage();
+  if (max_objects > 0) {
+    auto versioned_objects = storage.get_all<DBVersionedObject>(
+        where(
+            c(&DBVersionedObject::object_state) =
+                static_cast<uint>(ObjectState::DELETED)
+        ),
+        order_by(&DBVersionedObject::size).desc(), limit(max_objects)
+    );
+    return get_rgw_versioned_objects(versioned_objects);
+  }
+  auto versioned_objects = storage.get_all<DBVersionedObject>(
+      where(
+          c(&DBVersionedObject::object_state) =
+              static_cast<uint>(ObjectState::DELETED)
+      ),
+      order_by(&DBVersionedObject::size).desc()
+  );
+  return get_rgw_versioned_objects(versioned_objects);
+}
+
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
@@ -46,6 +46,10 @@ class SQLiteVersionedObjects {
   std::optional<DBOPVersionedObjectInfo> get_last_versioned_object(
       const uuid_d& object_id
   ) const;
+
+  std::vector<DBOPVersionedObjectInfo>
+  get_deleted_versioned_objects_highest_priority_first(uint max_objects = 0)
+      const;
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -122,12 +122,33 @@ class Object {
 
   /// Commit attrs to database
   void metadata_flush_attrs(SFStore* store);
+};
 
-  int delete_object_version(SFStore* store) const;
-  void delete_object_metadata(SFStore* store) const;
-  /// Delete object _data_ (e.g payload of PUT operations) from disk.
-  // Set all=true to delete all versions, not just this version.
-  void delete_object_data(SFStore* store, bool all) const;
+/// Object and object version delete utility
+class ObjectDeleter {
+ private:
+  sqlite::DBConnRef dbconn;
+  std::filesystem::path base_path;
+
+ public:
+  ObjectDeleter(
+      sqlite::DBConnRef _dbconn, const std::filesystem::path& _base_path
+  );
+
+  /// Delete object and its versions (data and metadata)
+  int delete_object(const uuid_d& uuid) const;
+
+  /// Delete version (data and metadata)
+  int delete_version(const uuid_d& uuid, uint version) const;
+
+  int delete_version_metadata(const uuid_d& uuid, uint version) const;
+  int delete_version_data(const uuid_d& uuid, uint version) const;
+  // deletes the object and versions metadata.
+  // returns the versions deleted so we can download the data in filesystem
+  int delete_object_metadata(const uuid_d& uuid, std::vector<uint>& versions)
+      const;
+  int delete_object_data(const uuid_d& uuid, const std::vector<uint>& versions)
+      const;
 };
 
 using ObjectRef = std::shared_ptr<Object>;

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -163,7 +163,8 @@ void SFSAtomicWriter::cleanup() noexcept {
   }
 
   try {
-    objref->delete_object_version(store);
+    sfs::ObjectDeleter deleter(store->db_conn, store->get_data_path());
+    deleter.delete_version(objref->path.get_uuid(), objref->version_id);
   } catch (const std::system_error& e) {
     lsfs_dout(dpp, -1)
         << fmt::format(

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
@@ -1,18 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "common/ceph_context.h"
-#include "rgw/driver/sfs/sqlite/dbconn.h"
-#include "rgw/driver/sfs/sqlite/sqlite_objects.h"
-#include "rgw/driver/sfs/sqlite/sqlite_buckets.h"
-#include "rgw/driver/sfs/sqlite/sqlite_users.h"
-#include "rgw/driver/sfs/sqlite/objects/object_conversions.h"
-
-#include "rgw/rgw_sal_sfs.h"
+#include <gtest/gtest.h>
 
 #include <filesystem>
-#include <gtest/gtest.h>
 #include <memory>
+
+#include "common/ceph_context.h"
+#include "rgw/driver/sfs/sqlite/dbconn.h"
+#include "rgw/driver/sfs/sqlite/objects/object_conversions.h"
+#include "rgw/driver/sfs/sqlite/sqlite_buckets.h"
+#include "rgw/driver/sfs/sqlite/sqlite_objects.h"
+#include "rgw/driver/sfs/sqlite/sqlite_users.h"
+#include "rgw/rgw_sal_sfs.h"
 
 using namespace rgw::sal::sfs::sqlite;
 
@@ -20,7 +20,7 @@ namespace fs = std::filesystem;
 const static std::string TEST_DIR = "rgw_sfs_tests";
 
 class TestSFSSQLiteObjects : public ::testing::Test {
-protected:
+ protected:
   void SetUp() override {
     fs::current_path(fs::temp_directory_path());
     fs::create_directory(TEST_DIR);
@@ -36,24 +36,24 @@ protected:
     return test_dir.string();
   }
 
-  fs::path getDBFullPath(const std::string & base_dir) const {
+  fs::path getDBFullPath(const std::string& base_dir) const {
     auto db_full_name = "s3gw.db";
-    auto db_full_path = fs::path(base_dir) /  db_full_name;
+    auto db_full_path = fs::path(base_dir) / db_full_name;
     return db_full_path;
   }
 
-  fs::path getDBFullPath() const {
-    return getDBFullPath(getTestDir());
-  }
+  fs::path getDBFullPath() const { return getDBFullPath(getTestDir()); }
 
-  void createUser(const std::string & username, DBConnRef conn) {
+  void createUser(const std::string& username, DBConnRef conn) {
     SQLiteUsers users(conn);
     DBOPUserInfo user;
     user.uinfo.user_id.id = username;
     users.store_user(user);
   }
 
-  void createBucket(const std::string & username, const std::string & bucketname, DBConnRef conn) {
+  void createBucket(
+      const std::string& username, const std::string& bucketname, DBConnRef conn
+  ) {
     createUser(username, conn);
     SQLiteBuckets buckets(conn);
     DBOPBucketInfo bucket;
@@ -64,7 +64,7 @@ protected:
   }
 };
 
-void compareObjects(const DBOPObjectInfo & origin, const DBOPObjectInfo & dest) {
+void compareObjects(const DBOPObjectInfo& origin, const DBOPObjectInfo& dest) {
   ASSERT_EQ(origin.uuid, dest.uuid);
   ASSERT_EQ(origin.bucket_id, dest.bucket_id);
   ASSERT_EQ(origin.name, dest.name);
@@ -75,7 +75,10 @@ void compareObjects(const DBOPObjectInfo & origin, const DBOPObjectInfo & dest) 
   ASSERT_EQ(origin.delete_at, dest.delete_at);
 }
 
-DBOPObjectInfo createTestObject(const std::string & suffix, CephContext *context, const std::string & username="usertest") {
+DBOPObjectInfo createTestObject(
+    const std::string& suffix, CephContext* context,
+    const std::string& username = "usertest"
+) {
   DBOPObjectInfo object;
   object.uuid.generate_random();
   object.bucket_id = "test_bucket";
@@ -88,9 +91,8 @@ DBOPObjectInfo createTestObject(const std::string & suffix, CephContext *context
   return object;
 }
 
-bool uuidInVector(const uuid_d & uuid, const std::vector<uuid_d> & uuids)
-{
-  for (auto const & list_uuid : uuids) {
+bool uuidInVector(const uuid_d& uuid, const std::vector<uuid_d>& uuids) {
+  for (auto const& list_uuid : uuids) {
     if (list_uuid == uuid) return true;
   }
   return false;
@@ -116,7 +118,6 @@ TEST_F(TestSFSSQLiteObjects, CreateAndGet) {
   ASSERT_TRUE(ret_object.has_value());
   compareObjects(object, *ret_object);
 }
-
 
 TEST_F(TestSFSSQLiteObjects, ListObjectsIDs) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
@@ -184,7 +185,6 @@ TEST_F(TestSFSSQLiteObjects, ListBucketsIDsPerBucket) {
   ASSERT_EQ(objects_ids.size(), 1);
   EXPECT_EQ(objects_ids[0], test_object_3.uuid);
 }
-
 
 TEST_F(TestSFSSQLiteObjects, remove_object) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
@@ -316,14 +316,20 @@ TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
   db_object.object_id = "254ddc1a-06a6-11ed-b939-0242ac120002";
   db_object.name = "test";
 
-  EXPECT_THROW({
-    try {
-        storage.replace(db_object);;
-    } catch( const std::system_error & e ) {
-        EXPECT_STREQ( "FOREIGN KEY constraint failed: constraint failed", e.what() );
-        throw;
-    }
-  }, std::system_error );
+  EXPECT_THROW(
+      {
+        try {
+          storage.replace(db_object);
+          ;
+        } catch (const std::system_error& e) {
+          EXPECT_STREQ(
+              "FOREIGN KEY constraint failed: constraint failed", e.what()
+          );
+          throw;
+        }
+      },
+      std::system_error
+  );
 }
 
 TEST_F(TestSFSSQLiteObjects, GetObjectByBucketAndObjectName) {
@@ -341,20 +347,29 @@ TEST_F(TestSFSSQLiteObjects, GetObjectByBucketAndObjectName) {
   auto db_objects = std::make_shared<SQLiteObjects>(conn);
 
   // create objects with names "test1", "test2" and "test3"... in bucket "test_bucket"
-  auto object_1 = createTestObject("1", ceph_context.get()); // name is "test1", bucket is "test_bucket"
+  auto object_1 = createTestObject(
+      "1", ceph_context.get()
+  );  // name is "test1", bucket is "test_bucket"
   db_objects->store_object(object_1);
-  auto object_2 = createTestObject("2", ceph_context.get()); // name is "test2", bucket is "test_bucket"
+  auto object_2 = createTestObject(
+      "2", ceph_context.get()
+  );  // name is "test2", bucket is "test_bucket"
   db_objects->store_object(object_2);
-  auto object_3 = createTestObject("3", ceph_context.get()); // name is "test3", bucket is "test_bucket"
+  auto object_3 = createTestObject(
+      "3", ceph_context.get()
+  );  // name is "test3", bucket is "test_bucket"
   db_objects->store_object(object_3);
 
   // create object "test1" in bucket "test_bucket_2"
-  auto object_1_2 = createTestObject("1", ceph_context.get()); // name is "test3", bucket is "test_bucket"
+  auto object_1_2 = createTestObject(
+      "1", ceph_context.get()
+  );  // name is "test3", bucket is "test_bucket"
   object_1_2.bucket_id = "test_bucket_2";
   db_objects->store_object(object_1_2);
 
   // run a few queries
-  auto ret_object = db_objects->get_object("test_bucket", "this_object_does_not_exist");
+  auto ret_object =
+      db_objects->get_object("test_bucket", "this_object_does_not_exist");
   ASSERT_FALSE(ret_object.has_value());
 
   ret_object = db_objects->get_object("test_bucket", "test1");


### PR DESCRIPTION
Implements permanent deletion of objects that have a delete marker, plus permanent deletion of noncurrent versions.

Versions to be deleted (may imply deleting the whole object) are obtained from a query to the metadata to delete them by size in descending order.

In order to trigger GC on demand I think we can do it by simply calling: `store->gc->process()` as the garbage collection instance is public within the `SFStore`.

That will simply run the same process that it's executed by the garbage collector internal timer.

**Notes:**
ON DELETE CASCADE option was tested as an option for deleting the object and its versions but there are problems because other parts of the code are `replacing` instead to `updating` objects.
`replacing` calls internally delete which triggers the deletion of all the versions. 
So for now versions need to be iterated. Also... I guess it is safer to avoid cascade... and we won't have orphan versions because that breaks the foreign key constrain and sqlite throws an exception.


It implements basic error handling. 
For more complex and better error handling I propose to open an issue to be discussed and implemented.


Fixes: https://github.com/aquarist-labs/s3gw/issues/393
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

