### PR TITLE
Telemetry: Use interval from server

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3788,11 +3788,11 @@ options:
     Reserves space for metadata operations and SQLite updates.
   service:
     - rgw
-- name: rgw_s3gw_telemetry_update_interval
-  type: millisecs
+- name: rgw_s3gw_enable_telemetry
+  type: bool
   level: advanced
-  default: 3600000
-  desc: S3GW telemetry update inverval. Set to 0 to disable.
+  default: true
+  desc: Enable S3GW telemetry updates
   service:
     - rgw
 - name: rgw_s3gw_telemetry_upgrade_responder_url

--- a/src/rgw/rgw_s3gw_telemetry.h
+++ b/src/rgw/rgw_s3gw_telemetry.h
@@ -65,7 +65,7 @@ class S3GWTelemetry {
     State()
         : m_mutex(make_mutex("S3GWTelemetry::State")),
           m_versions(),
-	  m_update_interval(std::chrono::minutes(10)),
+          m_update_interval(std::chrono::minutes(10)),
           m_status({{}, {}}) {}
     Status status() const {
       std::lock_guard<std::mutex> lock(mutex);
@@ -103,7 +103,7 @@ class S3GWTelemetry {
   ceph::condition_variable m_updater_cvar;
   ceph::mutex m_updater_mutex;
 
-  void updater_main(std::chrono::milliseconds update_interval);
+  void updater_main();
   void append_sfs_telemetry(JSONFormatter* f) const;
 
   /// Make POST to upgrade responder URL. Stores the raw response body data in response
@@ -141,8 +141,8 @@ class S3GWTelemetry {
   /// (https://github.com/longhorn/upgrade-responder/blob/master/upgraderesponder/service.go)
   bool parse_upgrade_response(
       bufferlist& response,
-      std::chrono::milliseconds* out_request_interval_minutes,
-      std::vector<Version>* out_versions
+      std::chrono::milliseconds& out_request_interval_minutes,
+      std::vector<Version>& out_versions
   ) const;
 
   /// Create "CheckUpgradeRequest"


### PR DESCRIPTION
Record requestIntervalInMinutes sent back from the upgrade responder
to set the retry interval in the future. Initialize interval with 10
minutes, overwritten after the first successful response.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>Fixes https://github.com/aquarist-labs/s3gw/issues/529

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

