### PR TITLE
rgw/sfs: fix delete bucket when not empty

### DIFF
--- a/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt
+++ b/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt
@@ -86,7 +86,7 @@ test_bucket_listv2_objects_anonymous_fail
 test_bucket_notexist
 test_bucketv2_notexist
 test_bucket_delete_notexist
-# test_bucket_delete_nonempty
+test_bucket_delete_nonempty
 test_bucket_concurrent_set_canned_acl
 test_object_write_to_nonexist_bucket
 test_bucket_create_delete

--- a/src/rgw/driver/sfs/bucket.cc
+++ b/src/rgw/driver/sfs/bucket.cc
@@ -256,13 +256,10 @@ bool SFSBucket::is_owner(User* user) {
 int SFSBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y) {
   /** Check in the backing store if this bucket is empty */
   // check if there are still objects owned by the bucket
-  sfs::sqlite::SQLiteVersionedObjects db_ver_objects(store->db_conn);
-  auto objects = db_ver_objects.list_last_versioned_objects(get_name());
-  for (const auto& obj : objects) {
-    if (sfs::sqlite::get_version_type(obj) != sfs::VersionType::DELETE_MARKER) {
-      ldpp_dout(dpp, -1) << __func__ << ": Bucket Not Empty.." << dendl;
-      return -ENOTEMPTY;
-    }
+  sfs::sqlite::SQLiteBuckets db_buckets(store->db_conn);
+  if (!db_buckets.bucket_empty(get_bucket_id())) {
+    ldpp_dout(dpp, -1) << __func__ << ": Bucket Not Empty.." << dendl;
+    return -ENOTEMPTY;
   }
   return 0;
 }

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -97,4 +97,19 @@ std::vector<std::string> SQLiteBuckets::get_deleted_buckets_ids() const {
   );
 }
 
+bool SQLiteBuckets::bucket_empty(const std::string& bucket_id) const {
+  auto storage = conn->get_storage();
+  auto num_ids = storage.count<DBVersionedObject>(
+      inner_join<DBObject>(
+          on(is_equal(&DBObject::uuid, &DBVersionedObject::object_id))
+      ),
+      where(
+          is_equal(&DBVersionedObject::object_state, ObjectState::COMMITTED) and
+          is_equal(&DBObject::bucket_id, bucket_id) and
+          is_equal(&DBVersionedObject::version_type, VersionType::REGULAR)
+      )
+  );
+  return num_ids == 0;
+}
+
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.h
@@ -42,6 +42,8 @@ class SQLiteBuckets {
   std::vector<DBOPBucketInfo> get_buckets(const std::string& user_id) const;
 
   std::vector<std::string> get_deleted_buckets_ids() const;
+
+  bool bucket_empty(const std::string& bucket_id) const;
 };
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -91,7 +91,7 @@ class Object {
 
   static Object* try_fetch_from_database(
       SFStore* store, const std::string& name, const std::string& bucket_id,
-      const std::string& version_id
+      const std::string& version_id, bool versioning_enabled
   );
 
   const Meta get_meta() const;


### PR DESCRIPTION
Fixes deleting a bucket when it's not empty.
And also fixes being able to delete and get null versionId for unversioned buckets.
The later is needed for running `s3tests` after fixing the deleting bucket non empty bug, because buckets are deleted in the tearDown call. 
It lists the versions and for unversioned buckets it deletes objects passing `versionID=null`, so we need to support that.

Basically when a bucket is not versioned and `versionId` passed is `null` it is ignored (as if it was not specified)

Fixes: https://github.com/aquarist-labs/s3gw/issues/325
Fixes: https://github.com/aquarist-labs/s3gw/issues/577

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

