### PR TITLE
ci: Build crypto plugins openssl and isal

### DIFF
--- a/qa/rgw/store/sfs/build-radosgw.sh
+++ b/qa/rgw/store/sfs/build-radosgw.sh
@@ -109,7 +109,7 @@ _configure() {
 _build() {
   pushd "${SFS_BUILD_DIR}"
 
-  ninja -j "${NPROC}" bin/radosgw
+  ninja -j "${NPROC}" bin/radosgw crypto_plugins
 
   if [ "${WITH_TESTS}" == "ON" ] ; then
     # discover tests from build.ninja so we don't need to update this after


### PR DESCRIPTION
Build openssl and isal ceph crypto plugins. Building creates files libceph_crypto_openssl.so and libceph_crypto_isal.so.1.0.0 that may be loaded at runtime (see --plugin_crypto_accelerator).

Issue: https://github.com/aquarist-labs/s3gw/issues/521

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

