### PR TITLE
Object State Transition Improvements

### DIFF
--- a/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt
+++ b/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt
@@ -302,13 +302,13 @@ test_cors_header_option
 test_atomic_read_1mb
 test_atomic_read_4mb
 test_atomic_read_8mb
-# test_atomic_write_1mb
-# test_atomic_write_4mb
-# test_atomic_write_8mb
-# test_atomic_dual_write_1mb
-# test_atomic_dual_write_4mb
-# test_atomic_dual_write_8mb
-# test_atomic_conditional_write_1mb
+test_atomic_write_1mb
+test_atomic_write_4mb
+test_atomic_write_8mb
+test_atomic_dual_write_1mb
+test_atomic_dual_write_4mb
+test_atomic_dual_write_8mb
+test_atomic_conditional_write_1mb
 # test_atomic_dual_conditional_write_1mb
 test_atomic_write_bucket_gone
 test_atomic_multipart_upload_write

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -369,10 +369,12 @@ uint SQLiteVersionedObjects::add_delete_marker_transact(
       auto last_version =
           storage.get_pointer<DBVersionedObject>(last_version_id);
       if (last_version &&
-          last_version->object_state == ObjectState::COMMITTED &&
+          (last_version->object_state == ObjectState::COMMITTED ||
+           last_version->object_state == ObjectState::OPEN) &&
           last_version->version_type == VersionType::REGULAR) {
         auto now = ceph::real_clock::now();
         last_version->version_type = VersionType::DELETE_MARKER;
+        last_version->object_state = ObjectState::COMMITTED;
         last_version->delete_time = now;
         last_version->mtime = now;
         last_version->version_id = delete_marker_id;

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
@@ -43,9 +43,15 @@ class SQLiteVersionedObjects {
 
   uint insert_versioned_object(const DBVersionedObject& object) const;
   void store_versioned_object(const DBVersionedObject& object) const;
+  bool store_versioned_object_if_state(
+      const DBVersionedObject& object, std::vector<ObjectState> allowed_states
+  ) const;
   void remove_versioned_object(uint id) const;
   void store_versioned_object_delete_rest_transact(
       const DBVersionedObject& object
+  ) const;
+  bool store_versioned_object_delete_rest_transact_if_state(
+      const DBVersionedObject& object, std::vector<ObjectState> allowed_states
   ) const;
 
   std::vector<uint> get_versioned_object_ids(bool filter_deleted = true) const;

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
@@ -50,7 +50,7 @@ class SQLiteVersionedObjects {
   void store_versioned_object_delete_rest_transact(
       const DBVersionedObject& object
   ) const;
-  bool store_versioned_object_delete_rest_transact_if_state(
+  bool store_versioned_object_delete_committed_transact_if_state(
       const DBVersionedObject& object, std::vector<ObjectState> allowed_states
   ) const;
 

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
@@ -34,7 +34,7 @@ class SQLiteVersionedObjects {
   std::optional<DBVersionedObject> get_versioned_object(
       const std::string& version_id, bool filter_deleted = true
   ) const;
-  std::optional<DBVersionedObject> get_non_deleted_versioned_object(
+  std::optional<DBVersionedObject> get_committed_versioned_object(
       const std::string& bucket_id, const std::string& object_name,
       const std::string& version_id
   ) const;
@@ -75,13 +75,12 @@ class SQLiteVersionedObjects {
 
  private:
   std::optional<DBVersionedObject>
-  get_non_deleted_versioned_object_specific_version(
+  get_committed_versioned_object_specific_version(
       const std::string& bucket_id, const std::string& object_name,
       const std::string& version_id
   ) const;
 
-  std::optional<DBVersionedObject>
-  get_non_deleted_versioned_object_last_version(
+  std::optional<DBVersionedObject> get_committed_versioned_object_last_version(
       const std::string& bucket_id, const std::string& object_name
   ) const;
 };

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -131,7 +131,7 @@ Object* Object::try_fetch_from_database(
   }
   sqlite::SQLiteVersionedObjects objs_versions(store->db_conn);
   // if version_id is empty it will get the last version for that object
-  auto version = objs_versions.get_non_deleted_versioned_object(
+  auto version = objs_versions.get_committed_versioned_object(
       bucket_id, name, version_id_query
   );
   if (!version.has_value()) {

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -231,7 +231,7 @@ bool Object::metadata_finish(SFStore* store, bool versioning_enabled) {
 
   } else {
     return db_versioned_objs
-        .store_versioned_object_delete_rest_transact_if_state(
+        .store_versioned_object_delete_committed_transact_if_state(
             *db_versioned_object, {ObjectState::OPEN}
         );
   }

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -110,7 +110,7 @@ class Object {
   // Including meta and attrs
   // Sets obj version state to COMMITTED
   // For unversioned buckets it set the other versions state to DELETED
-  void metadata_finish(SFStore* store, bool versioning_enabled);
+  bool metadata_finish(SFStore* store, bool versioning_enabled);
 
   /// Commit attrs to database
   void metadata_flush_attrs(SFStore* store);
@@ -308,12 +308,12 @@ class Bucket {
       sqlite::DBVersionedObject& last_version
   );
 
-  void _delete_object_non_versioned(
+  bool _delete_object_non_versioned(
       ObjectRef objref, const rgw_obj_key& key,
       sqlite::SQLiteVersionedObjects& sqlite_versioned_objects
   );
 
-  void _delete_object_version(
+  bool _delete_object_version(
       ObjectRef objref, const rgw_obj_key& key,
       sqlite::SQLiteVersionedObjects& sqlite_versioned_objects,
       sqlite::DBVersionedObject& version
@@ -372,8 +372,8 @@ class Bucket {
 
   /// S3 delete object operation: delete version or create tombstone.
   /// If a delete marker was added, it returns the new version id generated for
-  /// it
-  void delete_object(
+  /// it. Return indicates if operation succeeded
+  bool delete_object(
       ObjectRef objref, const rgw_obj_key& key, bool versioned_bucket,
       std::string& delete_marker_version_id
   );

--- a/src/test/rgw/sfs/CMakeLists.txt
+++ b/src/test/rgw/sfs/CMakeLists.txt
@@ -16,3 +16,4 @@ add_s3gw_test(unittest_rgw_sfs_sqlite_lifecycle test_rgw_sfs_sqlite_lifecycle.cc
 add_s3gw_test(unittest_rgw_sfs_sfs_bucket test_rgw_sfs_sfs_bucket.cc)
 add_s3gw_test(unittest_rgw_sfs_sfs_user test_rgw_sfs_sfs_user.cc)
 add_s3gw_test(unittest_rgw_sfs_gc test_rgw_sfs_gc.cc)
+add_s3gw_test(unittest_rgw_sfs_object_state_machine test_rgw_sfs_object_state_machine.cc)

--- a/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
@@ -1,0 +1,412 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <random>
+#include <stdexcept>
+
+#include "common/ceph_context.h"
+#include "driver/sfs/object_state.h"
+#include "driver/sfs/sqlite/sqlite_versioned_objects.h"
+#include "driver/sfs/sqlite/versioned_object/versioned_object_definitions.h"
+#include "driver/sfs/version_type.h"
+#include "rgw/driver/sfs/sqlite/buckets/bucket_conversions.h"
+#include "rgw/driver/sfs/sqlite/dbconn.h"
+#include "rgw/driver/sfs/sqlite/sqlite_buckets.h"
+#include "rgw/driver/sfs/sqlite/sqlite_users.h"
+#include "rgw/driver/sfs/types.h"
+#include "rgw/rgw_sal_sfs.h"
+#include "rgw_common.h"
+#include "rgw_placement_types.h"
+
+using namespace rgw::sal::sfs;
+
+namespace fs = std::filesystem;
+const static std::string TEST_DIR = "rgw_sfs_tests";
+
+class TestSFSObjectStateMachine : public ::testing::Test {
+ protected:
+  CephContext* cct;
+
+  std::unique_ptr<rgw::sal::SFStore> store;
+  sqlite::DBOPBucketInfo db_binfo;
+  RGWUserInfo bucket_owner;
+  BucketRef bucket;
+
+  void SetUp() override {
+    cct = (new CephContext(CEPH_ENTITY_TYPE_ANY))->get();
+    cct->_conf.set_val("rgw_sfs_data_path", getTestDir());
+    fs::current_path(fs::temp_directory_path());
+    fs::create_directory(TEST_DIR);
+    store.reset(new rgw::sal::SFStore(cct, getTestDir()));
+    sqlite::SQLiteUsers users(dbconn());
+    sqlite::DBOPUserInfo user;
+    user.uinfo.user_id.id = "testuser";
+    user.uinfo.display_name = "display_name";
+    users.store_user(user);
+
+    sqlite::SQLiteBuckets db_buckets(dbconn());
+    db_binfo.binfo.bucket = rgw_bucket("", "testbucket", "1234");
+    db_binfo.binfo.owner = rgw_user("testuser");
+    db_binfo.binfo.creation_time = ceph::real_clock::now();
+    db_binfo.binfo.placement_rule = rgw_placement_rule();
+    db_binfo.binfo.zonegroup = "zone";
+    db_binfo.deleted = false;
+    db_buckets.store_bucket(db_binfo);
+
+    bucket = std::make_shared<Bucket>(
+        cct, store.get(), db_binfo.binfo, bucket_owner, db_binfo.battrs
+    );
+  }
+
+  void TearDown() override {
+    fs::current_path(fs::temp_directory_path());
+    fs::remove_all(TEST_DIR);
+  }
+
+  std::string getTestDir() const {
+    auto test_dir = fs::temp_directory_path() / TEST_DIR;
+    return test_dir.string();
+  }
+
+  fs::path getDBFullPath(const std::string& base_dir) const {
+    auto db_full_name = "s3gw.db";
+    auto db_full_path = fs::path(base_dir) / db_full_name;
+    return db_full_path;
+  }
+
+  fs::path getDBFullPath() const { return getDBFullPath(getTestDir()); }
+  sqlite::DBConnRef dbconn() { return std::make_shared<sqlite::DBConn>(cct); }
+  sqlite::Storage storage() { return dbconn()->get_storage(); }
+  ObjectState database_object_state(ObjectRef obj) {
+    return storage()
+        .select(
+            &sqlite::DBVersionedObject::object_state,
+            sqlite_orm::where(sqlite_orm::is_equal(
+                &sqlite::DBVersionedObject::id, obj->version_id
+            ))
+        )
+        .back();
+  }
+  VersionType database_version_type(ObjectRef obj) {
+    return storage()
+        .select(
+            &sqlite::DBVersionedObject::version_type,
+            sqlite_orm::where(sqlite_orm::is_equal(
+                &sqlite::DBVersionedObject::id, obj->version_id
+            ))
+        )
+        .back();
+  }
+  int database_number_of_versions(ObjectRef obj) {
+    return storage()
+        .select(
+            sqlite_orm::count(),
+            sqlite_orm::where(sqlite_orm::is_equal(
+                &sqlite::DBVersionedObject::object_id, obj->path.get_uuid()
+            ))
+        )
+        .back();
+  }
+  auto database_get_versions_as_id_type_state(ObjectRef obj) {
+    return storage().select(
+        sqlite_orm::columns(
+            &sqlite::DBVersionedObject::version_id,
+            &sqlite::DBVersionedObject::version_type,
+            &sqlite::DBVersionedObject::object_state
+        ),
+        sqlite_orm::where(sqlite_orm::is_equal(
+            &sqlite::DBVersionedObject::object_id, obj->path.get_uuid()
+        )),
+        sqlite_orm::order_by(&sqlite::DBVersionedObject::id).asc()
+    );
+  }
+};
+
+TEST_F(TestSFSObjectStateMachine, object_start_in_open) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  EXPECT_EQ(database_object_state(object), ObjectState::OPEN);
+  EXPECT_EQ(database_version_type(object), VersionType::REGULAR);
+  EXPECT_EQ(database_number_of_versions(object), 1);
+}
+
+TEST_F(TestSFSObjectStateMachine, multiple_open_versions_are_ok) {
+  const int max_obj = 42;
+  for (int i = 0; i < max_obj; i++) {
+    const auto object = bucket->create_version(
+        rgw_obj_key("name", fmt::format("instance_{}", i))
+    );
+    ASSERT_EQ(database_object_state(object), ObjectState::OPEN);
+    ASSERT_EQ(database_number_of_versions(object), i + 1);
+  }
+}
+
+TEST_F(TestSFSObjectStateMachine, non_committed_objects_are_invisible_to_get) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  EXPECT_THROW(bucket->get(rgw_obj_key("foo", "bar")), UnknownObjectException);
+  EXPECT_EQ(database_number_of_versions(object), 1);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    unversioned__delete_object_soft_deletes_latest_open_version
+) {
+  const auto object = bucket->create_version(rgw_obj_key("foo"));
+  std::string unused;
+  ASSERT_TRUE(bucket->delete_object(object, rgw_obj_key("foo"), false, unused));
+  EXPECT_EQ(database_object_state(object), ObjectState::DELETED);
+  EXPECT_EQ(database_version_type(object), VersionType::REGULAR);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    unversioned__a_deleted_version_cannot_be_committed
+) {
+  const auto object = bucket->create_version(rgw_obj_key("foo"));
+  std::string unused;
+  ASSERT_TRUE(bucket->delete_object(object, rgw_obj_key("foo"), false, unused));
+  ASSERT_EQ(database_object_state(object), ObjectState::DELETED);
+  EXPECT_FALSE(object->metadata_finish(store.get(), false));
+  EXPECT_EQ(database_object_state(object), ObjectState::DELETED);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine, versioned__a_deleted_version_cannot_be_committed
+) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  std::string unused;
+  ASSERT_TRUE(
+      bucket->delete_object(object, rgw_obj_key("foo", "bar"), false, unused)
+  );
+  ASSERT_EQ(database_object_state(object), ObjectState::DELETED);
+  EXPECT_FALSE(object->metadata_finish(store.get(), true));
+  EXPECT_EQ(database_object_state(object), ObjectState::DELETED);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine, unversioned__commit_deletes_all_committed_versions
+) {
+  const std::array<ObjectRef, 3> objects = {
+      bucket->create_version(rgw_obj_key("foo", "version1")),
+      bucket->create_version(rgw_obj_key("foo", "version2")),
+      bucket->create_version(rgw_obj_key("foo", "version3")),
+  };
+  ASSERT_EQ(database_object_state(objects[0]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[0]->metadata_finish(store.get(), false));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine, unversioned__last_committer_wins
+) {
+  const std::array<ObjectRef, 3> objects = {
+      bucket->create_version(rgw_obj_key("foo", "version1")),
+      bucket->create_version(rgw_obj_key("foo", "version2")),
+      bucket->create_version(rgw_obj_key("foo", "version3")),
+  };
+  ASSERT_EQ(database_object_state(objects[0]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[0]->metadata_finish(store.get(), false));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[1]->metadata_finish(store.get(), false));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[2]->metadata_finish(store.get(), false));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::COMMITTED);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    unversioned__commit_on_deleted_by_another_commit_fails
+) {
+  const std::array<ObjectRef, 3> objects = {
+      bucket->create_version(rgw_obj_key("foo", "version1")),
+      bucket->create_version(rgw_obj_key("foo", "version2")),
+      bucket->create_version(rgw_obj_key("foo", "version3")),
+  };
+  ASSERT_TRUE(objects[0]->metadata_finish(store.get(), false));
+  ASSERT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  ASSERT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[1]->metadata_finish(store.get(), false));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_FALSE(objects[0]->metadata_finish(store.get(), false));
+  ASSERT_EQ(database_object_state(objects[0]), ObjectState::DELETED);
+  ASSERT_EQ(database_object_state(objects[1]), ObjectState::COMMITTED);
+  ASSERT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    versioned__commit_does_not_change_any_other_version_state
+) {
+  const std::array<ObjectRef, 3> objects = {
+      bucket->create_version(rgw_obj_key("foo", "version1")),
+      bucket->create_version(rgw_obj_key("foo", "version2")),
+      bucket->create_version(rgw_obj_key("foo", "version3"))};
+  ASSERT_EQ(database_object_state(objects[0]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[0]->metadata_finish(store.get(), true));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(objects[2]->metadata_finish(store.get(), true));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::COMMITTED);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    versioned__delete_does_not_change_any_other_version_state
+) {
+  std::string unused;
+  const std::array<ObjectRef, 3> objects = {
+      bucket->create_version(rgw_obj_key("foo", "version1")),
+      bucket->create_version(rgw_obj_key("foo", "version2")),
+      bucket->create_version(rgw_obj_key("foo", "version3"))};
+  ASSERT_TRUE(objects[0]->metadata_finish(store.get(), true));
+  ASSERT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  ASSERT_EQ(database_object_state(objects[1]), ObjectState::OPEN);
+  ASSERT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(bucket->delete_object(
+      objects[1], rgw_obj_key("foo", "version2"), true, unused
+  ));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::COMMITTED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+
+  EXPECT_TRUE(bucket->delete_object(
+      objects[0], rgw_obj_key("foo", "version1"), true, unused
+  ));
+  EXPECT_EQ(database_object_state(objects[0]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[1]), ObjectState::DELETED);
+  EXPECT_EQ(database_object_state(objects[2]), ObjectState::OPEN);
+}
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    unversioned__delete_soft_deletes_latest_committed_version
+) {
+  const auto object = bucket->create_version(rgw_obj_key("foo"));
+  object->metadata_finish(store.get(), false);
+  std::string unused;
+  EXPECT_TRUE(bucket->delete_object(object, rgw_obj_key("foo"), false, unused));
+  EXPECT_EQ(database_object_state(object), ObjectState::DELETED);
+  EXPECT_EQ(database_version_type(object), VersionType::REGULAR);
+  EXPECT_EQ(database_number_of_versions(object), 1);
+}
+
+
+class TestSFSVersionedDeleteMarkerTests : public TestSFSObjectStateMachine,
+					  public testing::WithParamInterface<ObjectState> {
+};
+
+TEST_P(
+    TestSFSVersionedDeleteMarkerTests,
+    deleting_object_creates_delete_marker
+) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "VERSION"));
+  const ObjectState initial_state = GetParam();
+  switch (initial_state) {
+    case ObjectState::COMMITTED:
+      object->metadata_finish(store.get(), true);
+      break;
+    default:
+      break;
+  }
+  ASSERT_EQ(database_object_state(object), initial_state);
+  ASSERT_EQ(database_version_type(object), VersionType::REGULAR);
+
+  std::string delete_marker_id;
+  ASSERT_TRUE(bucket->delete_object(object, rgw_obj_key("foo"), true, delete_marker_id));
+  const auto versions = database_get_versions_as_id_type_state(object);
+  EXPECT_FALSE(delete_marker_id.empty());
+  ASSERT_EQ(versions.size(), 2);
+  EXPECT_EQ(std::get<0>(versions[0]), "VERSION");
+  EXPECT_EQ(std::get<1>(versions[0]), VersionType::REGULAR);
+  EXPECT_EQ(std::get<2>(versions[0]), initial_state);
+  EXPECT_EQ(std::get<0>(versions[1]), delete_marker_id);
+  EXPECT_EQ(std::get<1>(versions[1]), VersionType::DELETE_MARKER);
+  EXPECT_EQ(std::get<2>(versions[1]), ObjectState::COMMITTED);
+}
+
+INSTANTIATE_TEST_SUITE_P(OpenAndCommitted,
+			 TestSFSVersionedDeleteMarkerTests,
+			testing::Values(ObjectState::OPEN, ObjectState::COMMITTED));
+
+TEST_F(
+    TestSFSObjectStateMachine,
+    versioned__deleting_version_does_not_create_delete_marker
+) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "VERSION"));
+  object->metadata_finish(store.get(), false);
+  ASSERT_EQ(database_object_state(object), ObjectState::COMMITTED);
+  ASSERT_EQ(database_version_type(object), VersionType::REGULAR);
+
+  std::string delete_marker_id;
+  EXPECT_TRUE(bucket->delete_object(
+      object, rgw_obj_key("foo", "VERSION"), true, delete_marker_id
+  ));
+  EXPECT_TRUE(object->deleted);
+  EXPECT_EQ(database_object_state(object), ObjectState::DELETED);
+  EXPECT_EQ(database_version_type(object), VersionType::REGULAR);
+  EXPECT_NE(delete_marker_id, object->instance);
+  EXPECT_EQ("", delete_marker_id);
+  EXPECT_EQ(database_number_of_versions(object), 1);
+}
+
+TEST_F(TestSFSObjectStateMachine, non_committed_are_invisible_to_get_all) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  const auto all = bucket->get_all();
+  ASSERT_EQ(all.size(), 0);
+}
+
+TEST_F(TestSFSObjectStateMachine, metadata_finish_makes_visible_to_get) {
+  auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  object->metadata_finish(store.get(), false);
+  auto obj_gotten = bucket->get(rgw_obj_key("foo", "bar"));
+  EXPECT_EQ(object->name, obj_gotten->name);
+  EXPECT_EQ(object->instance, obj_gotten->instance);
+}
+
+TEST_F(TestSFSObjectStateMachine, metadata_finish_makes_visible_to_get_all) {
+  auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  object->metadata_finish(store.get(), false);
+  const auto all = bucket->get_all();
+  EXPECT_EQ(all.size(), 1);
+  EXPECT_EQ(all.front()->name, "foo");
+}
+
+TEST_F(TestSFSObjectStateMachine, flush_attrs_does_not_commit) {
+  const auto object = bucket->create_version(rgw_obj_key("foo", "bar"));
+  object->metadata_flush_attrs(store.get());
+  ASSERT_EQ(database_object_state(object), ObjectState::OPEN);
+}

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -196,6 +196,7 @@ void createDBBucketBasic(
   db_bucket.bucket_name = name;
   db_bucket.bucket_id = bucket_id;
   db_bucket.owner_id = user;
+  db_bucket.deleted = false;
   storage.replace(db_bucket);
 }
 

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -958,7 +958,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // try to get version (TEST_BUCKET, "test_name", "test_version_id_2")
   // corresponding to the second version
-  auto version = db_versioned_objects->get_non_deleted_versioned_object(
+  auto version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", "test_version_id_2"
   );
   ASSERT_TRUE(version.has_value());
@@ -966,7 +966,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   EXPECT_EQ(2, version->id);
 
   // don't pass any version. Should return the last one
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", ""
   );
   ASSERT_TRUE(version.has_value());
@@ -974,7 +974,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   EXPECT_EQ(3, version->id);
 
   // pass a non existing version_id
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", "this_version_does_not_exist"
   );
   ASSERT_FALSE(version.has_value());
@@ -996,7 +996,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   // first object it should still return versions from the first object
 
   // don't pass any version. Should return the last one
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", ""
   );
   ASSERT_TRUE(version.has_value());
@@ -1005,7 +1005,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // try to get a deleted version (TEST_BUCKET, "test_name", "test_version_id_5")
   // corresponding to the second version
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", "test_version_id_5"
   );
   // should not return that object
@@ -1013,7 +1013,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   ASSERT_FALSE(version.has_value());
 
   // still return valid version
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", "test_version_id_3"
   );
   ASSERT_TRUE(version.has_value());
@@ -1030,7 +1030,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   EXPECT_EQ(6, db_versioned_objects->insert_versioned_object(object));
 
   // still return valid version for 1st object
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", "test_version_id_3"
   );
   ASSERT_TRUE(version.has_value());
@@ -1038,7 +1038,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   EXPECT_EQ(3, version->id);
 
   // and also valid for the object in the second bucket
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET_2, "test_name", "test_version_id_6"
   );
   ASSERT_TRUE(version.has_value());
@@ -1046,7 +1046,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   EXPECT_EQ(6, version->id);
 
   // but version 6 is not on first bucket
-  version = db_versioned_objects->get_non_deleted_versioned_object(
+  version = db_versioned_objects->get_committed_versioned_object(
       TEST_BUCKET, "test_name", "test_version_id_6"
   );
   ASSERT_FALSE(version.has_value());

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -1021,12 +1021,12 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   EXPECT_EQ(3, version->id);
 
   // SCENARIO 3. 2 Objects with the same name in different buckets.
-  // in this case the object in bucket TEST_BUCKET_2 is in open state
-  // (still writing to it), but that's still an alive object
+  // in this case the object in bucket TEST_BUCKET_2 is in committed state
   createObject(
       TEST_USERNAME, TEST_BUCKET_2, TEST_OBJECT_ID_3, ceph_context.get(), conn
   );
   object = createTestVersionedObject(6, TEST_OBJECT_ID_3, "6");
+  object.object_state = rgw::sal::sfs::ObjectState::COMMITTED;
   EXPECT_EQ(6, db_versioned_objects->insert_versioned_object(object));
 
   // still return valid version for 1st object


### PR DESCRIPTION
Improve and restrict object states:
- Open is treated as an intermediary state and no readily accessible by getters in the types.h abstraction
- Delete and commit transition functions get variants that allow pre conditions (if_state)
- Unversioned commit no longer deletes open versions to get last writer wins sematics (see commit for details)
- Objects with only open versions can be delete markered

Adds a unit test suite around types.h and the object state machine. The relevant modification functions now return a transaction successful boolean and bubble up to the types.h layer. Currently only the unit test suite checks this value. A follow up will tie this in with the SAL layer.

Fixes the dirty read problem for unversioned objects and adds the relevant s3 tests to our allowlist.

Fixes: https://github.com/aquarist-labs/s3gw/issues/462

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

