### PR TITLE
Fix radosgw shutdown with telemetry disabled

### DIFF
--- a/src/rgw/rgw_s3gw_telemetry.cc
+++ b/src/rgw/rgw_s3gw_telemetry.cc
@@ -75,9 +75,11 @@ void S3GWTelemetry::wake_up() {
 }
 
 void S3GWTelemetry::stop() {
-  m_shutdown = true;
-  wake_up();
-  m_updater.join();
+  if (!m_shutdown) {
+    m_shutdown = true;
+    wake_up();
+    m_updater.join();
+  }
 }
 
 void S3GWTelemetry::update() {


### PR DESCRIPTION
Shutting down the radosgw process with telemetry
disabled (--rgw-s3gw-enable-telemetry 0) caused a system error /
Invalid Argument as the telemetry class tried to stop the updater
thead that wasn't actually running. Fix this by not doing a shutdown
if we are already shut down (or never ran in the first place).

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
