### PR TITLE
Disable Versioning Suspended Buckets

### DIFF
--- a/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt
+++ b/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt
@@ -319,7 +319,7 @@ test_ranged_request_skip_leading_bytes_response_code
 test_ranged_request_return_trailing_bytes_response_code
 test_ranged_request_invalid_range
 test_ranged_request_empty_object
-test_versioning_bucket_create_suspend
+# test_versioning_bucket_create_suspend (https://github.com/aquarist-labs/s3gw/issues/534)
 test_versioning_obj_create_read_remove
 test_versioning_obj_create_read_remove_head
 # test_versioning_obj_plain_null_version_removal
@@ -429,8 +429,8 @@ test_post_object_tags_authenticated_request
 # test_get_tags_acl_public
 # test_put_tags_acl_public
 # test_delete_tags_obj_public
-test_versioning_bucket_atomic_upload_return_version_id
-test_versioning_bucket_multipart_upload_return_version_id
+# test_versioning_bucket_atomic_upload_return_version_id (https://github.com/aquarist-labs/s3gw/issues/534)
+# test_versioning_bucket_multipart_upload_return_version_id (https://github.com/aquarist-labs/s3gw/issues/534)
 # test_bucket_policy_get_obj_existing_tag
 # test_bucket_policy_get_obj_tagging_existing_tag
 # test_bucket_policy_put_obj_tagging_existing_tag

--- a/qa/rgw/store/sfs/tests/test-sfs-unsupported.py
+++ b/qa/rgw/store/sfs/tests/test-sfs-unsupported.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 SUSE, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import string
+import unittest
+import boto3
+import botocore
+import random
+
+ACCESS_KEY = "test"
+SECRET_KEY = "test"
+URL = "http://127.0.0.1:7480"
+
+
+class UnsupportedFeaturesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.s3c = boto3.client(  # type: ignore
+            "s3",
+            endpoint_url=URL,
+            aws_access_key_id=ACCESS_KEY,
+            aws_secret_access_key=SECRET_KEY,
+        )
+
+    def tearDown(self) -> None:
+        self.s3c.close()
+
+    def test_cannot_suspend_versioning(self):
+        """
+        As we don't support versioning suspended buckets, enabling
+        it must raise an NotImplemented error
+        """
+        name = "".join(random.choice(string.ascii_lowercase) for _ in range(42))
+        resp = self.s3c.create_bucket(Bucket=name)
+        with self.assertRaises(botocore.exceptions.ClientError) as cm:
+            self.s3c.put_bucket_versioning(
+                Bucket=name,
+                VersioningConfiguration={
+                    "MFADelete": "Disabled",
+                    "Status": "Suspended",
+                },
+            )
+        self.assertEqual(cm.exception.response["Error"]["Code"], "NotImplemented")
+
+    def test_cannot_suspend_enabled_versioning(self):
+        """
+        As we don't support versioning suspended buckets, enabling
+        on a versioned bucket must raise an NotImplemented error
+        """
+        name = "".join(random.choice(string.ascii_lowercase) for _ in range(42))
+        self.s3c.create_bucket(Bucket=name)
+        self.s3c.put_bucket_versioning(
+            Bucket=name,
+            VersioningConfiguration={"MFADelete": "Disabled", "Status": "Enabled"},
+        )
+        with self.assertRaises(botocore.exceptions.ClientError) as cm:
+            self.s3c.put_bucket_versioning(
+                Bucket=name,
+                VersioningConfiguration={
+                    "MFADelete": "Disabled",
+                    "Status": "Suspended",
+                },
+            )
+        self.assertEqual(cm.exception.response["Error"]["Code"], "NotImplemented")

--- a/src/rgw/driver/sfs/bucket.cc
+++ b/src/rgw/driver/sfs/bucket.cc
@@ -19,6 +19,7 @@
 #include "driver/sfs/object.h"
 #include "driver/sfs/sqlite/sqlite_versioned_objects.h"
 #include "driver/sfs/types.h"
+#include "rgw_common.h"
 #include "rgw_sal_sfs.h"
 
 #define dout_subsys ceph_subsys_rgw
@@ -442,6 +443,10 @@ int SFSBucket::check_bucket_shards(const DoutPrefixProvider* dpp) {
 int SFSBucket::put_info(
     const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime
 ) {
+  if (get_info().flags & BUCKET_VERSIONS_SUSPENDED) {
+    return -ERR_NOT_IMPLEMENTED;
+  }
+
   sfs::get_meta_buckets(get_store().db_conn)
       ->store_bucket(sfs::sqlite::DBOPBucketInfo(get_info(), get_attrs()));
 


### PR DESCRIPTION
Disable suspending versioning on buckets, as we don't support that
mode.

Fixes https://github.com/aquarist-labs/s3gw/issues/534

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
