### PR TITLE
Default disable unused / unsupported APIs

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -265,7 +265,7 @@ options:
                 any ``radosgw`` instance that is meant to
                 participate in a `multi-site <../multisite>`_
                 configuration.
-  default: s3, s3website, swift, swift_auth, admin, sts, iam, notifications
+  default: s3, admin
   services:
   - rgw
   with_legacy: true


### PR DESCRIPTION
Disable s3website (future work), swift, swift_auth (not planned), STS,
IAM, notifications (future work) to limit API surface of undefined /
unimplemented features.

Fixes: https://github.com/aquarist-labs/s3gw/issues/527


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
