### PR TITLE
Add unique index to object (bucket_id, name)

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -65,6 +65,9 @@ inline auto _make_storage(const std::string& path) {
           "versioned_object_objid_vid_unique", &DBVersionedObject::object_id,
           &DBVersionedObject::version_id
       ),
+      sqlite_orm::make_unique_index(
+          "object_bucketid_name", &DBObject::bucket_id, &DBObject::name
+      ),
       sqlite_orm::make_index("bucket_ownerid_idx", &DBBucket::owner_id),
       sqlite_orm::make_index("bucket_name_idx", &DBBucket::bucket_name),
       sqlite_orm::make_index("objects_bucketid_idx", &DBObject::bucket_id),

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -32,9 +32,9 @@
 namespace rgw::sal::sfs::sqlite {
 
 /// current db version.
-constexpr int SFS_METADATA_VERSION = 3;
+constexpr int SFS_METADATA_VERSION = 4;
 /// minimum required version to upgrade db.
-constexpr int SFS_METADATA_MIN_VERSION = 1;
+constexpr int SFS_METADATA_MIN_VERSION = 4;
 
 constexpr std::string_view SCHEMA_DB_NAME = "s3gw.db";
 

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -484,17 +484,10 @@ SQLiteVersionedObjects::create_new_versioned_object_transact(
     auto transaction = storage.transaction_guard();
     auto objs = storage.select(
         columns(&DBObject::uuid),
-        inner_join<DBVersionedObject>(
-            on(is_equal(&DBObject::uuid, &DBVersionedObject::object_id))
-        ),
         where(
-            is_not_equal(
-                &DBVersionedObject::object_state, ObjectState::DELETED
-            ) and
             is_equal(&DBObject::bucket_id, bucket_id) and
             is_equal(&DBObject::name, object_name)
-        ),
-        group_by(&DBObject::uuid)
+        )
     );
     // should return none or 1
     // TODO revisit this ceph_assert after error handling is defined

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -88,7 +88,7 @@ class TestSFSSQLiteVersionedObjects : public ::testing::Test {
     DBObject object;
     object.uuid.parse(object_id.c_str());
     object.bucket_id = bucketname;
-    object.name = "test_name";
+    object.name = object_id;
     objects.store_object(object);
   }
 };
@@ -957,10 +957,10 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   object.commit_time = ceph::real_clock::now();
   EXPECT_EQ(3, db_versioned_objects->insert_versioned_object(object));
 
-  // try to get version (TEST_BUCKET, "test_name", "test_version_id_2")
+  // try to get version (TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_2")
   // corresponding to the second version
   auto version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", "test_version_id_2"
+      TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_2"
   );
   ASSERT_TRUE(version.has_value());
   EXPECT_EQ("test_version_id_2", version->version_id);
@@ -968,7 +968,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // don't pass any version. Should return the last one
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", ""
+      TEST_BUCKET, TEST_OBJECT_ID, ""
   );
   ASSERT_TRUE(version.has_value());
   EXPECT_EQ("test_version_id_3", version->version_id);
@@ -976,7 +976,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // pass a non existing version_id
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", "this_version_does_not_exist"
+      TEST_BUCKET, TEST_OBJECT_ID, "this_version_does_not_exist"
   );
   ASSERT_FALSE(version.has_value());
 
@@ -998,16 +998,16 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // don't pass any version. Should return the last one
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", ""
+      TEST_BUCKET, TEST_OBJECT_ID, ""
   );
   ASSERT_TRUE(version.has_value());
   EXPECT_EQ("test_version_id_3", version->version_id);
   EXPECT_EQ(3, version->id);
 
-  // try to get a deleted version (TEST_BUCKET, "test_name", "test_version_id_5")
+  // try to get a deleted version (TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_5")
   // corresponding to the second version
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", "test_version_id_5"
+      TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_5"
   );
   // should not return that object
   // (it is deleted waiting for the garbage collector)
@@ -1015,7 +1015,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // still return valid version
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", "test_version_id_3"
+      TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_3"
   );
   ASSERT_TRUE(version.has_value());
   EXPECT_EQ("test_version_id_3", version->version_id);
@@ -1032,7 +1032,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // still return valid version for 1st object
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", "test_version_id_3"
+      TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_3"
   );
   ASSERT_TRUE(version.has_value());
   EXPECT_EQ("test_version_id_3", version->version_id);
@@ -1040,7 +1040,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // and also valid for the object in the second bucket
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET_2, "test_name", "test_version_id_6"
+      TEST_BUCKET_2, TEST_OBJECT_ID_3, "test_version_id_6"
   );
   ASSERT_TRUE(version.has_value());
   EXPECT_EQ("test_version_id_6", version->version_id);
@@ -1048,7 +1048,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 
   // but version 6 is not on first bucket
   version = db_versioned_objects->get_committed_versioned_object(
-      TEST_BUCKET, "test_name", "test_version_id_6"
+      TEST_BUCKET, TEST_OBJECT_ID, "test_version_id_6"
   );
   ASSERT_FALSE(version.has_value());
 }


### PR DESCRIPTION
A bucket cannot have the same object key twice. Use unique index to
enforce this. Adapt create version path to use existing objects having deleted versions only.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

