### PR TITLE
Change DM/version sort to fix test_lifecycle_expiration_versioned_tags2

### DIFF
--- a/src/rgw/driver/sfs/sqlite/sqlite_list.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_list.cc
@@ -60,7 +60,7 @@ bool SQLiteList::objects(
           greater_than(&DBObject::name, start_after_object_name) and
           like(&DBObject::name, prefix_to_like_expr(prefix))
       ),
-      group_by(&DBObject::name),
+      group_by(&DBVersionedObject::object_id),
       having(is_equal(
           sqlite_orm::max(&DBVersionedObject::version_type),
           VersionType::REGULAR

--- a/src/rgw/driver/sfs/sqlite/sqlite_list.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_list.cc
@@ -152,11 +152,11 @@ bool SQLiteList::versions(
       ),
       // Sort:
       // names a-Z
-      // first versions, then delete markers
+      // first delete markers, then versions - (See: LC CurrentExpiration)
       // newest to oldest version
       multi_order_by(
           order_by(&DBObject::name).asc(),
-          order_by(&DBVersionedObject::version_type).asc(),
+          order_by(&DBVersionedObject::version_type).desc(),
           order_by(&DBVersionedObject::commit_time).desc(),
           order_by(&DBVersionedObject::id).desc()
       ),

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
@@ -320,9 +320,9 @@ TEST_F(TestSFSList, versions__returns_versions_and_delete_markers) {
   ASSERT_EQ(results.size(), 2);
 
   EXPECT_TRUE(results[0].flags & rgw_bucket_dir_entry::FLAG_VER);
-  EXPECT_TRUE(results[0].is_valid());
+  EXPECT_TRUE(results[0].is_delete_marker());
   EXPECT_TRUE(results[1].flags & rgw_bucket_dir_entry::FLAG_VER);
-  EXPECT_TRUE(results[1].is_delete_marker());
+  EXPECT_TRUE(results[1].is_valid());
 }
 
 TEST_F(TestSFSList, versions__correctly_sorts_and_marks_latest_version) {
@@ -465,10 +465,10 @@ TEST_F(TestSFSList, versions__delete_marker_latest) {
 
   ASSERT_TRUE(uut.versions("testbucket", "", "", 1000, results));
   ASSERT_EQ(results.size(), 2);
-  EXPECT_FALSE(results[0].is_delete_marker());
-  EXPECT_FALSE(results[0].is_current());
-  EXPECT_TRUE(results[1].is_delete_marker());
-  EXPECT_TRUE(results[1].is_current());
+  EXPECT_TRUE(results[0].is_delete_marker());
+  EXPECT_TRUE(results[0].is_current());
+  EXPECT_FALSE(results[1].is_delete_marker());
+  EXPECT_FALSE(results[1].is_current());
 }
 
 TEST_F(TestSFSList, roll_up_example) {


### PR DESCRIPTION
Change list versions order to DM first.

DMs last made S3 test lifecycle_expiration_versioned_tags2 flaky.

Fixes: https://github.com/aquarist-labs/s3gw/issues/670

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
