### PR TITLE
File Extensions

### DIFF
--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -335,7 +335,7 @@ int SFSMultipartUploadV2::complete(
   size_t accounted_bytes = 0;
 
   for (const auto& [part_num, part] : to_complete) {
-    MultipartPartPath partpath(mp->object_uuid, part_num);
+    MultipartPartPath partpath(mp->object_uuid, part.id);
     std::filesystem::path path = store->get_data_path() / partpath.to_path();
 
     ceph_assert(std::filesystem::exists(path));

--- a/src/rgw/driver/sfs/multipart_types.h
+++ b/src/rgw/driver/sfs/multipart_types.h
@@ -18,8 +18,6 @@
 #include "rgw/driver/sfs/uuid_path.h"
 #include "rgw/rgw_common.h"
 
-#define MULTIPART_PART_SUFFIX_LEN (6 + 1)  // '-' + len(10000) + '\0'
-
 namespace rgw::sal::sfs {
 
 using TOPNSPC::crypto::MD5;
@@ -40,9 +38,10 @@ class MultipartPartPath : public UUIDPath {
 
  public:
   MultipartPartPath(const uuid_d& uuid, int32_t num) : UUIDPath(uuid) {
-    char suffix[MULTIPART_PART_SUFFIX_LEN];
-    std::snprintf(suffix, sizeof(suffix), "-%d", num);
-    partpath = UUIDPath::to_path().concat(suffix);
+    ceph_assert(num >= 0);
+    std::string filename = std::to_string(num);
+    filename.append(".p");
+    partpath = UUIDPath::to_path() / filename;
   }
 
   virtual std::filesystem::path to_path() const override { return partpath; }

--- a/src/rgw/driver/sfs/sfs_gc.cc
+++ b/src/rgw/driver/sfs/sfs_gc.cc
@@ -176,7 +176,7 @@ bool SFSGC::delete_pending_multiparts_data() {
     for (auto it = (*pending_multiparts_to_delete).begin();
          it != (*pending_multiparts_to_delete).end();) {
       MultipartPartPath pp(
-          sqlite::get_object_uuid((*it)), sqlite::get_part_num((*it))
+          sqlite::get_object_uuid((*it)), sqlite::get_part_id((*it))
       );
       auto p = store->get_data_path() / pp.to_path();
       if (std::filesystem::exists(p)) {

--- a/src/rgw/driver/sfs/sqlite/buckets/multipart_definitions.h
+++ b/src/rgw/driver/sfs/sqlite/buckets/multipart_definitions.h
@@ -69,7 +69,7 @@ struct DBOPMultipart {
 
 using DBDeletedMultipartItem = std::tuple<
     decltype(DBMultipart::upload_id), decltype(DBMultipart::object_uuid),
-    decltype(DBMultipartPart::part_num)>;
+    decltype(DBMultipartPart::id)>;
 
 using DBDeletedMultipartItems = std::vector<DBDeletedMultipartItem>;
 
@@ -86,7 +86,7 @@ inline decltype(DBMultipart::object_uuid) get_object_uuid(
   return std::get<1>(item);
 }
 
-inline decltype(DBMultipartPart::part_num) get_part_num(
+inline decltype(DBMultipartPart::part_num) get_part_id(
     const DBDeletedMultipartItem& item
 ) {
   return std::get<2>(item);

--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
@@ -214,7 +214,7 @@ std::optional<DBMultipartPart> SQLiteMultipart::create_or_reset_part(
     const std::string& upload_id, uint32_t part_num, std::string* error_str
 ) const {
   auto storage = conn->get_storage();
-  std::optional<DBMultipartPart> entry;
+  std::optional<DBMultipartPart> entry = std::nullopt;
 
   storage.transaction([&]() mutable {
     auto cnt = storage.count<DBMultipart>(where(
@@ -271,7 +271,7 @@ std::optional<DBMultipartPart> SQLiteMultipart::create_or_reset_part(
           .mtime = std::nullopt,
       };
       try {
-        storage.insert(part);
+        part.id = storage.insert(part);
       } catch (const std::system_error& e) {
         if (error_str) {
           *error_str = e.what();

--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
@@ -462,7 +462,7 @@ SQLiteMultipart::remove_multiparts_by_bucket_id_transact(
     ret_parts = storage.select(
         columns(
             &DBMultipart::upload_id, &DBMultipart::object_uuid,
-            &DBMultipartPart::part_num
+            &DBMultipartPart::id
         ),
         inner_join<DBMultipart>(
             on(is_equal(&DBMultipart::upload_id, &DBMultipartPart::upload_id))

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -164,7 +164,9 @@ Object* Object::try_fetch_from_database(
 }
 
 std::filesystem::path Object::get_storage_path() const {
-  return path.to_path() / std::to_string(version_id);
+  std::string filename = std::to_string(version_id);
+  filename.append(".v");
+  return path.to_path() / filename;
 }
 
 const Object::Meta Object::get_meta() const {

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -438,7 +438,7 @@ int SFSMultipartWriterV2::prepare(optional_yield /* y */) {
     return -ERR_NO_SUCH_UPLOAD;
   }
 
-  MultipartPartPath partpath(mp->object_uuid, part_num);
+  MultipartPartPath partpath(mp->object_uuid, entry->id);
   std::filesystem::path path = store->get_data_path() / partpath.to_path();
 
   std::error_code ec;

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -101,8 +101,8 @@ class TestSFSGC : public ::testing::Test {
     ofs.close();
   }
 
-  void storeRandomPart(const uuid_d& uuid, int part_num) {
-    rgw::sal::sfs::MultipartPartPath pp(uuid, part_num);
+  void storeRandomPart(const uuid_d& uuid, int id) {
+    rgw::sal::sfs::MultipartPartPath pp(uuid, id);
     auto part_path = getTestDir() / pp.to_path();
     storeRandomFile(part_path);
   }
@@ -158,8 +158,8 @@ class TestSFSGC : public ::testing::Test {
     mp.upload_id = upload_id;
     mp.part_num = part_num;
     mp.size = 123;
-    storage.insert(mp);
-    storeRandomPart(uuid, part_num);
+    const int id = storage.insert(mp);
+    storeRandomPart(uuid, id);
     return mp;
   }
 


### PR DESCRIPTION
Add file extensions, use global / random ids as filenames

Extensions:
- '.v': object version
- '.p': multipart part
- '.m': multipart assemble tmporary (moved to ".v" after assembly complete)

Path changes:
MP: $multipart_id-$partnum -> $multipart_id/$partnum

Filenames:
- '.v': global versioned object id (int)
- '.p': global multipart part id (int)
- '.m': 16 byte random alphanumeric string

Renders data stores incompatible. Doesn't increment store version,
because we already incremented it for
https://github.com/aquarist-labs/ceph/pull/185 in this release cycle.

Fixes: https://github.com/aquarist-labs/s3gw/issues/668

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
