### PR TITLE
Escape SQL LIKE

### DIFF
--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
@@ -20,6 +20,7 @@
 #include "rgw/driver/sfs/multipart_types.h"
 #include "rgw/driver/sfs/sqlite/buckets/bucket_definitions.h"
 #include "rgw/driver/sfs/sqlite/buckets/multipart_conversions.h"
+#include "rgw/driver/sfs/sqlite/conversion_utils.h"
 
 using namespace sqlite_orm;
 
@@ -69,7 +70,7 @@ std::vector<DBOPMultipart> SQLiteMultipart::list_multiparts_by_bucket_id(
       where(
           is_equal(&DBMultipart::bucket_id, bucket_id) and cond and
           greater_or_equal(&DBMultipart::meta_str, marker) and
-          like(&DBMultipart::object_name, fmt::format("{}%", prefix))
+          prefix_to_like(&DBMultipart::object_name, prefix)
       ),
       order_by(&DBMultipart::meta_str), limit(max_uploads + 1)
   );

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
@@ -271,6 +271,22 @@ TEST_P(TestSFSListObjectsAndVersions, more_avail__max_zero_bucket_not_empty) {
   EXPECT_TRUE(more_avail);
 }
 
+TEST_P(TestSFSListObjectsAndVersions, wildcard_in_prefix_do_not_match) {
+  std::vector<rgw_bucket_dir_entry> results;
+  add_obj_single_ver("$");
+  ASSERT_TRUE(uut_list("testbucket", "%", "", 1000, results));
+  ASSERT_EQ(results.size(), 0);
+}
+
+TEST_P(TestSFSListObjectsAndVersions, prefix_matches_dont_interprete_wildcards) {
+  std::vector<rgw_bucket_dir_entry> results;
+  add_obj_single_ver("___$");
+  add_obj_single_ver("$__$");
+  ASSERT_TRUE(uut_list("testbucket", "___$", "", 1000, results));
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_TRUE(results[0].key.name.starts_with("___$"));
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ObjectsVersions, TestSFSListObjectsAndVersions,
     testing::Values("objects", "versions"),


### PR DESCRIPTION
Add utility to create LIKE ESCAPE expressions from prefixes. Use that
utility in our list queries.

Fixes: https://github.com/aquarist-labs/s3gw/issues/643

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
