### PR TITLE
rgw/sfs: Fix unused parameter warnings.

### DIFF
--- a/src/rgw/driver/sfs/bucket.cc
+++ b/src/rgw/driver/sfs/bucket.cc
@@ -48,7 +48,7 @@ SFSBucket::SFSBucket(SFStore* _store, sfs::BucketRef _bucket)
   }
 }
 
-void SFSBucket::write_meta(const DoutPrefixProvider* dpp) {
+void SFSBucket::write_meta(const DoutPrefixProvider* /*dpp*/) {
   // TODO
 }
 
@@ -94,7 +94,7 @@ std::unique_ptr<Object> SFSBucket::get_object(const rgw_obj_key& key) {
  */
 int SFSBucket::list(
     const DoutPrefixProvider* dpp, ListParams& params, int max,
-    ListResults& results, optional_yield y
+    ListResults& results, optional_yield /*y*/
 ) {
   lsfs_dout(dpp, 10) << fmt::format(
                             "listing bucket {} {}: max:{} params:", get_name(),
@@ -257,8 +257,8 @@ int SFSBucket::list(
 }
 
 int SFSBucket::remove_bucket(
-    const DoutPrefixProvider* dpp, bool delete_children, bool forward_to_master,
-    req_info* req_info, optional_yield y
+    const DoutPrefixProvider* dpp, bool delete_children,
+    bool /*forward_to_master*/, req_info* /*req_info*/, optional_yield y
 ) {
   if (!delete_children) {
     if (check_empty(dpp, y)) {
@@ -294,8 +294,8 @@ int SFSBucket::remove_bucket(
 }
 
 int SFSBucket::remove_bucket_bypass_gc(
-    int concurrent_max, bool keep_index_consistent, optional_yield y,
-    const DoutPrefixProvider* dpp
+    int /*concurrent_max*/, bool /*keep_index_consistent*/,
+    optional_yield /*y*/, const DoutPrefixProvider* dpp
 ) {
   /** Remove this bucket, bypassing garbage collection.  May be removed */
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
@@ -303,14 +303,15 @@ int SFSBucket::remove_bucket_bypass_gc(
 }
 
 int SFSBucket::load_bucket(
-    const DoutPrefixProvider* dpp, optional_yield y, bool get_stats
+    const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/, bool /*get_stats*/
 ) {
   // TODO
   return 0;
 }
 
 int SFSBucket::set_acl(
-    const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl, optional_yield y
+    const DoutPrefixProvider* /*dpp*/, RGWAccessControlPolicy& acl,
+    optional_yield /*y*/
 ) {
   acls = acl;
 
@@ -326,18 +327,19 @@ int SFSBucket::set_acl(
 }
 
 int SFSBucket::chown(
-    const DoutPrefixProvider* dpp, User& new_user, optional_yield y
+    const DoutPrefixProvider* dpp, User& /*new_user*/, optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
-bool SFSBucket::is_owner(User* user) {
+bool SFSBucket::is_owner(User* /*user*/) {
   ldout(store->ceph_context(), 10) << __func__ << ": TODO" << dendl;
   return true;
 }
 
-int SFSBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y) {
+int SFSBucket::
+    check_empty(const DoutPrefixProvider* dpp, optional_yield /*y*/) {
   /** Check in the backing store if this bucket is empty */
   // check if there are still objects owned by the bucket
   sfs::sqlite::SQLiteBuckets db_buckets(store->db_conn);
@@ -349,7 +351,7 @@ int SFSBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y) {
 }
 
 int SFSBucket::merge_and_store_attrs(
-    const DoutPrefixProvider* dpp, Attrs& new_attrs, optional_yield y
+    const DoutPrefixProvider* /*dpp*/, Attrs& new_attrs, optional_yield /*y*/
 ) {
   for (auto& it : new_attrs) {
     attrs[it.first] = it.second;
@@ -429,7 +431,7 @@ int SFSBucket::list_multiparts(
 }
 
 int SFSBucket::abort_multiparts(
-    const DoutPrefixProvider* dpp, CephContext* cct
+    const DoutPrefixProvider* dpp, CephContext* /*cct*/
 ) {
   lsfs_dout(
       dpp, 10
@@ -439,22 +441,24 @@ int SFSBucket::abort_multiparts(
 }
 
 int SFSBucket::try_refresh_info(
-    const DoutPrefixProvider* dpp, ceph::real_time* pmtime
+    const DoutPrefixProvider* dpp, ceph::real_time* /*pmtime*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
 int SFSBucket::read_usage(
-    const DoutPrefixProvider* dpp, uint64_t start_epoch, uint64_t end_epoch,
-    uint32_t max_entries, bool* is_truncated, RGWUsageIter& usage_iter,
-    std::map<rgw_user_bucket, rgw_usage_log_entry>& usage
+    const DoutPrefixProvider* dpp, uint64_t /*start_epoch*/,
+    uint64_t /*end_epoch*/, uint32_t /*max_entries*/, bool* /*is_truncated*/,
+    RGWUsageIter& /*usage_iter*/,
+    std::map<rgw_user_bucket, rgw_usage_log_entry>& /*usage*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 int SFSBucket::trim_usage(
-    const DoutPrefixProvider* dpp, uint64_t start_epoch, uint64_t end_epoch
+    const DoutPrefixProvider* dpp, uint64_t /*start_epoch*/,
+    uint64_t /*end_epoch*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
@@ -467,7 +471,7 @@ int SFSBucket::rebuild_index(const DoutPrefixProvider* dpp) {
 
 int SFSBucket::check_quota(
     const DoutPrefixProvider* dpp, RGWQuota& quota, uint64_t obj_size,
-    optional_yield y, bool check_size_only
+    optional_yield /*y*/, bool /*check_size_only*/
 ) {
   ldpp_dout(dpp, 10) << __func__
                      << ": user(max size: " << quota.user_quota.max_size
@@ -480,28 +484,28 @@ int SFSBucket::check_quota(
 }
 
 int SFSBucket::read_stats(
-    const DoutPrefixProvider* dpp,
-    const bucket_index_layout_generation& idx_layout, int shard_id,
-    std::string* bucket_ver, std::string* master_ver,
-    std::map<RGWObjCategory, RGWStorageStats>& stats, std::string* max_marker,
-    bool* syncstopped
+    const DoutPrefixProvider* /*dpp*/,
+    const bucket_index_layout_generation& /*idx_layout*/, int /*shard_id*/,
+    std::string* /*bucket_ver*/, std::string* /*master_ver*/,
+    std::map<RGWObjCategory, RGWStorageStats>& /*stats*/,
+    std::string* /*max_marker*/, bool* /*syncstopped*/
 ) {
   return 0;
 }
 int SFSBucket::read_stats_async(
-    const DoutPrefixProvider* dpp,
-    const bucket_index_layout_generation& idx_layout, int shard_id,
-    RGWGetBucketStats_CB* ctx
+    const DoutPrefixProvider* /*dpp*/,
+    const bucket_index_layout_generation& /*idx_layout*/, int /*shard_id*/,
+    RGWGetBucketStats_CB* /*ctx*/
 ) {
   return 0;
 }
 
 int SFSBucket::sync_user_stats(
-    const DoutPrefixProvider* dpp, optional_yield y
+    const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/
 ) {
   return 0;
 }
-int SFSBucket::update_container_stats(const DoutPrefixProvider* dpp) {
+int SFSBucket::update_container_stats(const DoutPrefixProvider* /*dpp*/) {
   return 0;
 }
 int SFSBucket::check_bucket_shards(const DoutPrefixProvider* dpp) {
@@ -509,7 +513,8 @@ int SFSBucket::check_bucket_shards(const DoutPrefixProvider* dpp) {
   return -ENOTSUP;
 }
 int SFSBucket::put_info(
-    const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time set_mtime
+    const DoutPrefixProvider* /*dpp*/, bool /*exclusive*/,
+    ceph::real_time /*set_mtime*/
 ) {
   if (get_info().flags & BUCKET_VERSIONS_SUSPENDED) {
     return -ERR_NOT_IMPLEMENTED;

--- a/src/rgw/driver/sfs/bucket.h
+++ b/src/rgw/driver/sfs/bucket.h
@@ -163,23 +163,24 @@ class SFSBucket : public StoreBucket {
 
   // maybe removed from api..
   virtual int remove_objs_from_index(
-      const DoutPrefixProvider* dpp,
-      std::list<rgw_obj_index_key>& objs_to_unlink
+      const DoutPrefixProvider* /*dpp*/,
+      std::list<rgw_obj_index_key>& /*objs_to_unlink*/
   ) override {
     return -ENOTSUP;
   }
   virtual int check_index(
-      const DoutPrefixProvider* dpp,
-      std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
-      std::map<RGWObjCategory, RGWStorageStats>& calculated_stats
+      const DoutPrefixProvider* /*dpp*/,
+      std::map<RGWObjCategory, RGWStorageStats>& /*existing_stats*/,
+      std::map<RGWObjCategory, RGWStorageStats>& /*calculated_stats*/
   ) override {
     return -ENOTSUP;
   }
-  virtual int set_tag_timeout(const DoutPrefixProvider* dpp, uint64_t timeout)
-      override {
+  virtual int set_tag_timeout(
+      const DoutPrefixProvider* /*dpp*/, uint64_t /*timeout*/
+  ) override {
     return 0;
   }
-  virtual int purge_instance(const DoutPrefixProvider* dpp) override {
+  virtual int purge_instance(const DoutPrefixProvider* /*dpp*/) override {
     return -ENOTSUP;
   }
 

--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -70,7 +70,7 @@ std::unique_ptr<rgw::sal::Object> SFSMultipartUploadV2::get_meta_obj() {
 }
 
 int SFSMultipartUploadV2::init(
-    const DoutPrefixProvider* dpp, optional_yield y, ACLOwner& acl_owner,
+    const DoutPrefixProvider* dpp, optional_yield /*y*/, ACLOwner& acl_owner,
     rgw_placement_rule& dest_placement, rgw::sal::Attrs& attrs
 ) {
   lsfs_dout(dpp, 10) << "upload_id: " << upload_id << ", oid: " << get_key()
@@ -137,8 +137,8 @@ int SFSMultipartUploadV2::init(
 }
 
 int SFSMultipartUploadV2::list_parts(
-    const DoutPrefixProvider* dpp, CephContext* cct, int num_parts, int marker,
-    int* next_marker, bool* truncated, bool assume_unsorted
+    const DoutPrefixProvider* dpp, CephContext* /*cct*/, int num_parts,
+    int marker, int* next_marker, bool* truncated, bool /*assume_unsorted*/
 ) {
   lsfs_dout(dpp, 10) << "num_parts: " << num_parts << ", marker: " << marker
                      << dendl;
@@ -162,7 +162,7 @@ int SFSMultipartUploadV2::list_parts(
 }
 
 int SFSMultipartUploadV2::abort(
-    const DoutPrefixProvider* dpp, CephContext* cct
+    const DoutPrefixProvider* dpp, CephContext* /*cct*/
 ) {
   lsfs_dout(dpp, 10) << "upload_id: " << upload_id << dendl;
 
@@ -176,11 +176,12 @@ int SFSMultipartUploadV2::abort(
 }
 
 int SFSMultipartUploadV2::complete(
-    const DoutPrefixProvider* dpp, optional_yield y, CephContext* cct,
+    const DoutPrefixProvider* dpp, optional_yield /*y*/, CephContext* /*cct*/,
     std::map<int, std::string>& part_etags,
-    std::list<rgw_obj_index_key>& remove_objs, uint64_t& accounted_size,
-    bool& compressed, RGWCompressionInfo& cs_info, off_t& ofs, std::string& tag,
-    ACLOwner& acl_owner, uint64_t olh_epoch, rgw::sal::Object* target_obj
+    std::list<rgw_obj_index_key>& /*remove_objs*/, uint64_t& accounted_size,
+    bool& /*compressed*/, RGWCompressionInfo& /*cs_info*/, off_t& /*ofs*/,
+    std::string& tag, ACLOwner& acl_owner, uint64_t olh_epoch,
+    rgw::sal::Object* target_obj
 ) {
   lsfs_dout(dpp, 10) << fmt::format(
                             "upload_id: {}, accounted_size: {}, tag: {}, "
@@ -488,8 +489,8 @@ int SFSMultipartUploadV2::complete(
 }
 
 int SFSMultipartUploadV2::get_info(
-    const DoutPrefixProvider* dpp, optional_yield y, rgw_placement_rule** rule,
-    rgw::sal::Attrs* attrs
+    const DoutPrefixProvider* dpp, optional_yield /*y*/,
+    rgw_placement_rule** rule, rgw::sal::Attrs* attrs
 ) {
   lsfs_dout(dpp, 10) << fmt::format(
                             "upload_id: {}, obj: {}", upload_id, get_key()
@@ -533,8 +534,8 @@ int SFSMultipartUploadV2::get_info(
 std::unique_ptr<Writer> SFSMultipartUploadV2::get_writer(
     const DoutPrefixProvider* dpp, optional_yield y, rgw::sal::Object* head_obj,
     const rgw_user& writer_owner,
-    const rgw_placement_rule* ptail_placement_rule, uint64_t part_num,
-    const std::string& part_num_str
+    const rgw_placement_rule* /*ptail_placement_rule*/, uint64_t part_num,
+    const std::string& /*part_num_str*/
 ) {
   ceph_assert(part_num <= 10000);
   uint32_t pnum = static_cast<uint32_t>(part_num);
@@ -554,7 +555,7 @@ int SFSMultipartUploadV2::list_multiparts(
     rgw::sal::SFSBucket* bucket, BucketRef bucketref, const std::string& prefix,
     std::string& marker, const std::string& delim, const int& max_uploads,
     std::vector<std::unique_ptr<MultipartUpload>>& uploads,
-    std::map<std::string, bool>* common_prefixes, bool* is_truncated
+    std::map<std::string, bool>* /*common_prefixes*/, bool* is_truncated
 ) {
   auto cls = SFSMultipartUploadV2::get_cls_name();
   auto bucket_name = bucket->get_name();

--- a/src/rgw/driver/sfs/multipart.h
+++ b/src/rgw/driver/sfs/multipart.h
@@ -47,7 +47,8 @@ struct SFSMultipartMetaObject : public rgw::sal::SFSObject {
 
   struct SFSMetaObjDeleteOp : public DeleteOp {
     SFSMetaObjDeleteOp() = default;
-    virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y)
+    virtual int
+    delete_obj(const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/)
         override {
       return 0;
     }
@@ -64,7 +65,8 @@ struct SFSMultipartMetaObject : public rgw::sal::SFSObject {
   }
 
   virtual int delete_object(
-      const DoutPrefixProvider* dpp, optional_yield y, bool prevent_versioning
+      const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/,
+      bool /*prevent_versioning*/
   ) override {
     return 0;
   }
@@ -257,7 +259,7 @@ struct SFSMultipartSerializer : public StoreMPSerializer {
   SFSMultipartSerializer() = default;
 
   virtual int try_lock(
-      const DoutPrefixProvider* dpp, utime_t dur, optional_yield y
+      const DoutPrefixProvider* /*dpp*/, utime_t /*dur*/, optional_yield /*y*/
   ) override {
     return 0;
   }

--- a/src/rgw/driver/sfs/object.cc
+++ b/src/rgw/driver/sfs/object.cc
@@ -40,7 +40,7 @@ SFSObject::SFSReadOp::SFSReadOp(SFSObject* _source) : source(_source) {
 }
 
 int SFSObject::SFSReadOp::prepare(
-    optional_yield y, const DoutPrefixProvider* dpp
+    optional_yield /*y*/, const DoutPrefixProvider* dpp
 ) {
   if (!objref || objref->deleted) {
     // at this point, we don't have an objectref because
@@ -65,8 +65,8 @@ int SFSObject::SFSReadOp::prepare(
 }
 
 int SFSObject::SFSReadOp::get_attr(
-    const DoutPrefixProvider* dpp, const char* name, bufferlist& dest,
-    optional_yield y
+    const DoutPrefixProvider* /*dpp*/, const char* name, bufferlist& dest,
+    optional_yield /*y*/
 ) {
   if (!objref || objref->deleted) {
     return -ENOENT;
@@ -79,7 +79,7 @@ int SFSObject::SFSReadOp::get_attr(
 
 // sync read
 int SFSObject::SFSReadOp::read(
-    int64_t ofs, int64_t end, bufferlist& bl, optional_yield y,
+    int64_t ofs, int64_t end, bufferlist& bl, optional_yield /*y*/,
     const DoutPrefixProvider* dpp
 ) {
   // TODO bounds check, etc.
@@ -105,7 +105,7 @@ int SFSObject::SFSReadOp::read(
 // async read
 int SFSObject::SFSReadOp::iterate(
     const DoutPrefixProvider* dpp, int64_t ofs, int64_t end, RGWGetDataCB* cb,
-    optional_yield y
+    optional_yield /*y*/
 ) {
   // TODO bounds check, etc.
   const auto len = end + 1 - ofs;
@@ -150,7 +150,7 @@ SFSObject::SFSDeleteOp::SFSDeleteOp(
     : source(_source), bucketref(_bucketref) {}
 
 int SFSObject::SFSDeleteOp::delete_obj(
-    const DoutPrefixProvider* dpp, optional_yield y
+    const DoutPrefixProvider* dpp, optional_yield /*y*/
 ) {
   lsfs_dout(dpp, 10) << "bucket: " << source->bucket->get_name()
                      << " bucket versioning: "
@@ -204,17 +204,19 @@ int SFSObject::delete_object(
 }
 
 int SFSObject::copy_object(
-    User* user, req_info* info, const rgw_zone_id& source_zone,
+    User* /*user*/, req_info* /*info*/, const rgw_zone_id& /*source_zone*/,
     rgw::sal::Object* dst_object, rgw::sal::Bucket* dst_bucket,
-    rgw::sal::Bucket* src_bucket, const rgw_placement_rule& dest_placement,
-    ceph::real_time* src_mtime, ceph::real_time* mtime,
-    const ceph::real_time* mod_ptr, const ceph::real_time* unmod_ptr,
-    bool high_precision_time, const char* if_match, const char* if_nomatch,
-    AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
-    RGWObjCategory category, uint64_t olh_epoch,
-    boost::optional<ceph::real_time> delete_at, std::string* version_id,
-    std::string* tag, std::string* etag, void (*progress_cb)(off_t, void*),
-    void* progress_data, const DoutPrefixProvider* dpp, optional_yield y
+    rgw::sal::Bucket* src_bucket, const rgw_placement_rule& /*dest_placement*/,
+    ceph::real_time* /*src_mtime*/, ceph::real_time* /*mtime*/,
+    const ceph::real_time* /*mod_ptr*/, const ceph::real_time* /*unmod_ptr*/,
+    bool /*high_precision_time*/, const char* /*if_match*/,
+    const char* /*if_nomatch*/, AttrsMod /*attrs_mod*/, bool /*copy_if_newer*/,
+    Attrs& /*attrs*/, RGWObjCategory /*category*/, uint64_t /*olh_epoch*/,
+    boost::optional<ceph::real_time> /*delete_at*/, std::string* /*version_id*/,
+    std::string* /*tag*/, std::string* /*etag*/, void (*)(off_t, void*),
+    void* /*progress_data*/
+    ,
+    const DoutPrefixProvider* dpp, optional_yield /*y*/
 ) {
   lsfs_dout(dpp, 10) << "source(bucket: " << src_bucket->get_name()
                      << ", obj: " << get_name()
@@ -293,15 +295,16 @@ void SFSObject::gen_rand_obj_instance_name() {
   because target_obj is left empty, that fail will be explicit.
 */
 int SFSObject::get_obj_attrs(
-    optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj
+    optional_yield /*y*/, const DoutPrefixProvider* /*dpp*/,
+    rgw_obj* /*target_obj*/
 ) {
   refresh_meta();
   return 0;
 }
 
 int SFSObject::get_obj_state(
-    const DoutPrefixProvider* dpp, RGWObjState** _state, optional_yield y,
-    bool follow_olh
+    const DoutPrefixProvider* /*dpp*/, RGWObjState** _state,
+    optional_yield /*y*/, bool /*follow_olh*/
 ) {
   refresh_meta();
   *_state = &state;
@@ -309,8 +312,8 @@ int SFSObject::get_obj_state(
 }
 
 int SFSObject::set_obj_attrs(
-    const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs,
-    optional_yield y
+    const DoutPrefixProvider* /*dpp*/, Attrs* setattrs, Attrs* delattrs,
+    optional_yield /*y*/
 ) {
   ceph_assert(objref);
   map<string, bufferlist>::iterator iter;
@@ -339,8 +342,8 @@ bool SFSObject::get_attr(const std::string& name, bufferlist& dest) {
 }
 
 int SFSObject::modify_obj_attrs(
-    const char* attr_name, bufferlist& attr_val, optional_yield y,
-    const DoutPrefixProvider* dpp
+    const char* attr_name, bufferlist& attr_val, optional_yield /*y*/,
+    const DoutPrefixProvider* /*dpp*/
 ) {
   if (!attr_name) {
     return 0;
@@ -357,7 +360,8 @@ int SFSObject::modify_obj_attrs(
 }
 
 int SFSObject::delete_obj_attrs(
-    const DoutPrefixProvider* dpp, const char* attr_name, optional_yield y
+    const DoutPrefixProvider* /*dpp*/, const char* attr_name,
+    optional_yield /*y*/
 ) {
   if (!attr_name) {
     return 0;
@@ -398,21 +402,21 @@ int SFSObject::transition_to_cloud(
 }
 
 bool SFSObject::placement_rules_match(
-    rgw_placement_rule& r1, rgw_placement_rule& r2
+    rgw_placement_rule& /*r1*/, rgw_placement_rule& /*r2*/
 ) {
   ldout(store->ceph_context(), 10) << __func__ << ": TODO" << dendl;
   return true;
 }
 
 int SFSObject::dump_obj_layout(
-    const DoutPrefixProvider* dpp, optional_yield y, Formatter* f
+    const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/, Formatter* /*f*/
 ) {
   ldout(store->ceph_context(), 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
 int SFSObject::swift_versioning_restore(
-    bool& restored, /* out */
+    bool& /*restored*/, /* out */
     const DoutPrefixProvider* dpp
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": do nothing." << dendl;
@@ -420,30 +424,31 @@ int SFSObject::swift_versioning_restore(
 }
 
 int SFSObject::swift_versioning_copy(
-    const DoutPrefixProvider* dpp, optional_yield y
+    const DoutPrefixProvider* dpp, optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": do nothing." << dendl;
   return 0;
 }
 
 int SFSObject::omap_get_vals_by_keys(
-    const DoutPrefixProvider* dpp, const std::string& oid,
-    const std::set<std::string>& keys, Attrs* vals
+    const DoutPrefixProvider* dpp, const std::string& /*oid*/,
+    const std::set<std::string>& /*keys*/, Attrs* /*vals*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
 int SFSObject::omap_set_val_by_key(
-    const DoutPrefixProvider* dpp, const std::string& key, bufferlist& val,
-    bool must_exist, optional_yield y
+    const DoutPrefixProvider* dpp, const std::string& /*key*/,
+    bufferlist& /*val*/, bool /*must_exist*/, optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
 int SFSObject::chown(
-    rgw::sal::User& new_user, const DoutPrefixProvider* dpp, optional_yield y
+    rgw::sal::User& /*new_user*/, const DoutPrefixProvider* dpp,
+    optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;

--- a/src/rgw/driver/sfs/sfs_bucket.cc
+++ b/src/rgw/driver/sfs/sfs_bucket.cc
@@ -20,15 +20,17 @@ using namespace std;
 namespace rgw::sal {
 
 int SFStore::set_buckets_enabled(
-    const DoutPrefixProvider* dpp, std::vector<rgw_bucket>& buckets_to_enable,
-    bool enabled
+    const DoutPrefixProvider* dpp,
+    std::vector<rgw_bucket>& /*buckets_to_enable*/, bool /*enabled*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
 int SFStore::get_bucket(
-    User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* result
+    User* /*u*/
+    ,
+    const RGWBucketInfo& i, std::unique_ptr<Bucket>* result
 ) {
   std::lock_guard l(buckets_map_lock);
   auto it = buckets.find(i.bucket.name);
@@ -43,8 +45,8 @@ int SFStore::get_bucket(
 }
 
 int SFStore::get_bucket(
-    const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b,
-    std::unique_ptr<Bucket>* result, optional_yield y
+    const DoutPrefixProvider* dpp, User* /*u*/, const rgw_bucket& b,
+    std::unique_ptr<Bucket>* result, optional_yield /*y*/
 ) {
   std::lock_guard l(buckets_map_lock);
   auto it = buckets.find(b.name);
@@ -60,8 +62,9 @@ int SFStore::get_bucket(
 }
 
 int SFStore::get_bucket(
-    const DoutPrefixProvider* dpp, User* u, const std::string& tenant,
-    const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y
+    const DoutPrefixProvider* dpp, User* /*u*/, const std::string& /*tenant*/,
+    const std::string& name, std::unique_ptr<Bucket>* bucket,
+    optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": get_bucket by name: " << name << dendl;
   std::lock_guard l(buckets_map_lock);

--- a/src/rgw/driver/sfs/sfs_user.cc
+++ b/src/rgw/driver/sfs/sfs_user.cc
@@ -24,7 +24,7 @@ std::unique_ptr<User> SFStore::get_user(const rgw_user& u) {
   return std::make_unique<SFSUser>(u, this);
 }
 int SFStore::get_user_by_access_key(
-    const DoutPrefixProvider* dpp, const std::string& key, optional_yield y,
+    const DoutPrefixProvider* dpp, const std::string& key, optional_yield /*y*/,
     std::unique_ptr<User>* user
 ) {
   int err = 0;
@@ -40,8 +40,8 @@ int SFStore::get_user_by_access_key(
 }
 
 int SFStore::get_user_by_email(
-    const DoutPrefixProvider* dpp, const std::string& email, optional_yield y,
-    std::unique_ptr<User>* user
+    const DoutPrefixProvider* dpp, const std::string& email,
+    optional_yield /*y*/, std::unique_ptr<User>* user
 ) {
   int err = 0;
   rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(db_conn);
@@ -56,8 +56,8 @@ int SFStore::get_user_by_email(
 }
 
 int SFStore::get_user_by_swift(
-    const DoutPrefixProvider* dpp, const std::string& user_str,
-    optional_yield y, std::unique_ptr<User>* user
+    const DoutPrefixProvider* dpp, const std::string& /*user_str*/,
+    optional_yield /*y*/, std::unique_ptr<User>* /*user*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;

--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
@@ -50,8 +50,8 @@ std::optional<std::vector<DBOPMultipart>> SQLiteMultipart::list_multiparts(
 
 std::vector<DBOPMultipart> SQLiteMultipart::list_multiparts_by_bucket_id(
     const std::string& bucket_id, const std::string& prefix,
-    const std::string& marker, const std::string& delim, const int& max_uploads,
-    bool* is_truncated, bool get_all
+    const std::string& marker, const std::string& /*delim*/,
+    const int& max_uploads, bool* is_truncated, bool get_all
 ) const {
   std::vector<DBOPMultipart> entries;
   auto storage = conn->get_storage();

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -331,12 +331,10 @@ bool Bucket::delete_object(
           db_versioned_objs.get_versioned_object(key.instance);
       if (version_to_delete.has_value()) {
         if (version_to_delete->version_type == VersionType::DELETE_MARKER) {
-          _undelete_object(obj, key, db_versioned_objs, *version_to_delete);
+          _undelete_object(key, db_versioned_objs, *version_to_delete);
           return true;
         } else {
-          return _delete_object_version(
-              obj, key, db_versioned_objs, *version_to_delete
-          );
+          return _delete_object_version(db_versioned_objs, *version_to_delete);
         }
       }
       return false;
@@ -366,7 +364,7 @@ std::string Bucket::create_non_existing_object_delete_marker(
 }
 
 bool Bucket::_undelete_object(
-    const Object& obj, const rgw_obj_key& key,
+    const rgw_obj_key& key,
     const sqlite::SQLiteVersionedObjects& sqlite_versioned_objects,
     const sqlite::DBVersionedObject& last_version
 ) const {
@@ -384,18 +382,15 @@ bool Bucket::_undelete_object(
 }
 
 bool Bucket::_delete_object_non_versioned(
-    const Object& obj, const rgw_obj_key& key,
+    const Object& obj, const rgw_obj_key& /*key*/,
     const sqlite::SQLiteVersionedObjects& db_versioned_objs
 ) const {
   auto version_to_delete =
       db_versioned_objs.get_last_versioned_object(obj.path.get_uuid());
-  return _delete_object_version(
-      obj, key, db_versioned_objs, *version_to_delete
-  );
+  return _delete_object_version(db_versioned_objs, *version_to_delete);
 }
 
 bool Bucket::_delete_object_version(
-    const Object& obj, const rgw_obj_key& key,
     const sqlite::SQLiteVersionedObjects& db_versioned_objs,
     const sqlite::DBVersionedObject& version
 ) const {
@@ -411,7 +406,7 @@ bool Bucket::_delete_object_version(
 }
 
 std::string Bucket::_add_delete_marker(
-    const Object& obj, const rgw_obj_key& key,
+    const Object& obj, const rgw_obj_key& /*key*/,
     const sqlite::SQLiteVersionedObjects& db_versioned_objs
 ) const {
   std::string delete_marker_id = generate_new_version_id(store->ceph_context());

--- a/src/rgw/driver/sfs/types.h
+++ b/src/rgw/driver/sfs/types.h
@@ -142,7 +142,7 @@ class Bucket {
 
  private:
   bool _undelete_object(
-      const Object& obj, const rgw_obj_key& key,
+      const rgw_obj_key& key,
       const sqlite::SQLiteVersionedObjects& sqlite_versioned_objects,
       const sqlite::DBVersionedObject& last_version
   ) const;
@@ -153,7 +153,6 @@ class Bucket {
   ) const;
 
   bool _delete_object_version(
-      const Object& obj, const rgw_obj_key& key,
       const sqlite::SQLiteVersionedObjects& sqlite_versioned_objects,
       const sqlite::DBVersionedObject& version
   ) const;

--- a/src/rgw/driver/sfs/user.cc
+++ b/src/rgw/driver/sfs/user.cc
@@ -30,7 +30,7 @@ int SFSUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y) {
 }
 
 int SFSUser::merge_and_store_attrs(
-    const DoutPrefixProvider* dpp, Attrs& new_attrs, optional_yield y
+    const DoutPrefixProvider* dpp, Attrs& /*new_attrs*/, optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   /** Set the attributes in attrs, leaving any other existing attrs set, and
@@ -39,8 +39,9 @@ int SFSUser::merge_and_store_attrs(
 }
 
 int SFSUser::read_stats(
-    const DoutPrefixProvider* dpp, optional_yield y, RGWStorageStats* stats,
-    ceph::real_time* last_stats_sync, ceph::real_time* last_stats_update
+    const DoutPrefixProvider* dpp, optional_yield /*y*/,
+    RGWStorageStats* /*stats*/, ceph::real_time* /*last_stats_sync*/,
+    ceph::real_time* /*last_stats_update*/
 ) {
   /** Read the User stats from the backing Store, synchronous */
   ldpp_dout(dpp, 1) << __func__ << ": WARNING faked call" << dendl;
@@ -48,7 +49,7 @@ int SFSUser::read_stats(
 }
 
 int SFSUser::read_stats_async(
-    const DoutPrefixProvider* dpp, RGWGetUserStats_CB* cb
+    const DoutPrefixProvider* dpp, RGWGetUserStats_CB* /*cb*/
 ) {
   /** Read the User stats from the backing Store, asynchronous */
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
@@ -56,7 +57,7 @@ int SFSUser::read_stats_async(
 }
 
 int SFSUser::complete_flush_stats(
-    const DoutPrefixProvider* dpp, optional_yield y
+    const DoutPrefixProvider* dpp, optional_yield /*y*/
 ) {
   /** Flush accumulated stat changes for this User to the backing store */
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
@@ -64,9 +65,10 @@ int SFSUser::complete_flush_stats(
 }
 
 int SFSUser::read_usage(
-    const DoutPrefixProvider* dpp, uint64_t start_epoch, uint64_t end_epoch,
-    uint32_t max_entries, bool* is_truncated, RGWUsageIter& usage_iter,
-    std::map<rgw_user_bucket, rgw_usage_log_entry>& usage
+    const DoutPrefixProvider* dpp, uint64_t /*start_epoch*/,
+    uint64_t /*end_epoch*/, uint32_t /*max_entries*/, bool* /*is_truncated*/,
+    RGWUsageIter& /*usage_iter*/,
+    std::map<rgw_user_bucket, rgw_usage_log_entry>& /*usage*/
 ) {
   /** Read detailed usage stats for this User from the backing store */
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
@@ -74,13 +76,15 @@ int SFSUser::read_usage(
 }
 
 int SFSUser::trim_usage(
-    const DoutPrefixProvider* dpp, uint64_t start_epoch, uint64_t end_epoch
+    const DoutPrefixProvider* dpp, uint64_t /*start_epoch*/,
+    uint64_t /*end_epoch*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": TODO" << dendl;
   return -ENOTSUP;
 }
 
-int SFSUser::load_user(const DoutPrefixProvider* dpp, optional_yield y) {
+int SFSUser::
+    load_user(const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/) {
   rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(store->db_conn);
   auto db_user = sqlite_users.get_user(info.user_id.id);
   if (db_user) {
@@ -93,7 +97,7 @@ int SFSUser::load_user(const DoutPrefixProvider* dpp, optional_yield y) {
 }
 
 int SFSUser::store_user(
-    const DoutPrefixProvider* dpp, optional_yield y, bool exclusive,
+    const DoutPrefixProvider* dpp, optional_yield /*y*/, bool /*exclusive*/,
     RGWUserInfo* old_info
 ) {
   rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(store->db_conn);
@@ -117,7 +121,8 @@ int SFSUser::store_user(
   return 0;
 }
 
-int SFSUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y) {
+int SFSUser::
+    remove_user(const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/) {
   rgw::sal::sfs::sqlite::SQLiteUsers sqlite_users(store->db_conn);
   auto db_user = sqlite_users.get_user(info.user_id.id);
   if (!db_user) {
@@ -129,8 +134,8 @@ int SFSUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y) {
 
 int SFSUser::list_buckets(
     const DoutPrefixProvider* dpp, const std::string& marker,
-    const std::string& end_marker, uint64_t max, bool need_stats,
-    BucketList& buckets, optional_yield y
+    const std::string& end_marker, uint64_t max, bool /*need_stats*/,
+    BucketList& buckets, optional_yield /*y*/
 ) {
   ldpp_dout(dpp, 10) << __func__ << ": marker (" << marker << ", " << end_marker
                      << "), max=" << max << dendl;
@@ -151,9 +156,9 @@ int SFSUser::create_bucket(
     const DoutPrefixProvider* dpp, const rgw_bucket& b,
     const std::string& zonegroup_id, rgw_placement_rule& new_placement_rule,
     std::string& swift_ver_location, const RGWQuotaInfo* pquota_info,
-    const RGWAccessControlPolicy& policy, Attrs& new_attrs,
-    RGWBucketInfo& new_info, obj_version& ep_objv, bool exclusive,
-    bool obj_lock_enabled, bool* existed, req_info& req_info,
+    const RGWAccessControlPolicy& /*policy*/, Attrs& new_attrs,
+    RGWBucketInfo& new_info, obj_version& /*ep_objv*/, bool /*exclusive*/,
+    bool obj_lock_enabled, bool* existed, req_info& /*req_info*/,
     std::unique_ptr<Bucket>* bucket_out, optional_yield /* y */
 ) {
   ceph_assert(bucket_out != nullptr);
@@ -192,8 +197,8 @@ int SFSUser::create_bucket(
 }
 
 int SFSUser::verify_mfa(
-    const std::string& mfa_str, bool* verified, const DoutPrefixProvider* dpp,
-    optional_yield y
+    const std::string& /*mfa_str*/, bool* /*verified*/,
+    const DoutPrefixProvider* /*dpp*/, optional_yield /*y*/
 ) {
   return 0;
 }

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -203,7 +203,7 @@ void SFSAtomicWriter::cleanup() noexcept {
   }
 }
 
-int SFSAtomicWriter::prepare(optional_yield y) {
+int SFSAtomicWriter::prepare(optional_yield /*y*/) {
   if (store->filesystem_stats_avail_bytes.load() <
       store->min_space_left_for_data_write_ops_bytes) {
     lsfs_dout(dpp, 10) << fmt::format(
@@ -285,7 +285,8 @@ int SFSAtomicWriter::complete(
     size_t accounted_size, const std::string& etag, ceph::real_time* out_mtime,
     ceph::real_time set_mtime, std::map<std::string, bufferlist>& attrs,
     ceph::real_time delete_at, const char* if_match, const char* if_nomatch,
-    const std::string* user_data, rgw_zone_set*, bool* canceled, optional_yield
+    const std::string* /*user_data*/, rgw_zone_set*, bool* /*canceled*/,
+    optional_yield
 ) {
   lsfs_dout(dpp, 10)
       << fmt::format(
@@ -536,7 +537,8 @@ int SFSMultipartWriterV2::complete(
     size_t accounted_size, const std::string& etag, ceph::real_time* mtime,
     ceph::real_time set_mtime, std::map<std::string, bufferlist>& attrs,
     ceph::real_time delete_at, const char* if_match, const char* if_nomatch,
-    const std::string* user_data, rgw_zone_set*, bool* canceled, optional_yield
+    const std::string* /*user_data*/, rgw_zone_set*, bool* /*canceled*/,
+    optional_yield
 ) {
   // NOTE(jecluis): ignored parameters:
   //  * set_mtime

--- a/src/rgw/driver/sfs/zone.cc
+++ b/src/rgw/driver/sfs/zone.cc
@@ -37,11 +37,11 @@ bool SFSZone::is_writeable() {
   return true;
 }
 
-bool SFSZone::get_redirect_endpoint(std::string* endpoint) {
+bool SFSZone::get_redirect_endpoint(std::string* /*endpoint*/) {
   return false;
 }
 
-bool SFSZone::has_zonegroup_api(const std::string& api) const {
+bool SFSZone::has_zonegroup_api(const std::string& /*api*/) const {
   return false;
 }
 


### PR DESCRIPTION
After enabling a few compilation warnings on the `sfs` code there are too many annoying unused parameter warnings that could shadow other important warnings.

This PR deals with the warnings.


Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

