### PR TITLE
rgw/sfs: Add GC for done and aborted multiparts

### DIFF
--- a/src/rgw/driver/sfs/sfs_gc.h
+++ b/src/rgw/driver/sfs/sfs_gc.h
@@ -72,14 +72,17 @@ class SFSGC : public DoutPrefixProvider {
   // Return false if it was forced to exit because max process time was met
   // which means there are still objects to be deleted
   bool process_deleted_buckets();
-  bool process_deleted_objects(bool& more_objects);
-  bool delete_bucket(const std::string& bucket_id, bool& bucket_deleted);
+  bool process_deleted_objects();
   bool delete_pending_objects_data();
   bool delete_pending_multiparts_data();
+  bool process_done_and_aborted_multiparts();
   bool abort_bucket_multiparts(const std::string& bucket_id);
   bool delete_bucket_multiparts(
       const std::string& bucket_id, bool& all_parts_deleted
   );
+  bool process_deleted_objects_batch(bool& more_objects);
+  bool process_done_and_aborted_multiparts_batch(bool& all_parts_deleted);
+  bool delete_bucket(const std::string& bucket_id, bool& bucket_deleted);
   bool process_time_elapsed() const;
 
   std::optional<sqlite::DBDeletedObjectItems> pending_objects_to_delete;

--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.h
@@ -240,6 +240,14 @@ class SQLiteMultipart {
   remove_multiparts_by_bucket_id_transact(
       const std::string& bucket_id, uint max_items
   ) const;
+
+  /**
+  * @brief Removes multiparts that are done or aborted and returns the IDs that identify those parts in the filesystem
+  * @param max_items Max parts to be deleted in this call
+  * @return List of <object_uuid, part_id> that identifies the parts in the filesystem
+  */
+  std::optional<DBDeletedMultipartItems>
+  remove_done_or_aborted_multiparts_transact(uint max_items) const;
 };
 
 }  // namespace rgw::sal::sfs::sqlite


### PR DESCRIPTION
This PR adds the code for dealing with aborted and done multiparts and their parts.

It also adds a minimal refactoring to the main GC method so it lists the GC steps in a more clear way.

Fixes: https://github.com/aquarist-labs/s3gw/issues/657

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

