### PR TITLE
Custom Metrics Support

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.cc
+++ b/src/rgw/driver/sfs/sqlite/dbconn.cc
@@ -247,7 +247,7 @@ void DBConn::maybe_upgrade_metadata() {
     storage.pragma.user_version(SFS_METADATA_VERSION);
   } else if (db_version < SFS_METADATA_VERSION && db_version >= SFS_METADATA_MIN_VERSION) {
     // perform schema update
-    upgrade_metadata(cct, storage, sqlite_db);
+    upgrade_metadata(cct, storage, first_sqlite_conn);
   } else if (db_version < SFS_METADATA_MIN_VERSION) {
     throw sqlite_sync_exception(
         "Existing metadata too far behind! Unable to upgrade schema!"

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -308,17 +308,20 @@ class DBConn {
   Storage storage;
 
  public:
-  sqlite3* sqlite_db;
+  sqlite3* first_sqlite_conn;
   CephContext* const cct;
   const bool profile_enabled;
 
   DBConn(CephContext* _cct)
       : storage(_make_storage(getDBPath(_cct))),
+        first_sqlite_conn(nullptr),
         cct(_cct),
         profile_enabled(_cct->_conf.get_val<bool>("rgw_sfs_sqlite_profile")) {
     sqlite3_config(SQLITE_CONFIG_LOG, &sqlite_error_callback, cct);
     storage.on_open = [this](sqlite3* db) {
-      sqlite_db = db;
+      if (first_sqlite_conn == nullptr) {
+        first_sqlite_conn = db;
+      }
 
       sqlite3_extended_result_codes(db, 1);
       sqlite3_busy_timeout(db, 10000);

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -399,7 +399,7 @@ http::status SFSStatusPage::render(std::ostream& os) {
   os << "</ul>\n";
 
   auto db = sfs->db_conn->get_storage();
-  sqlite3* sqlite_db = sfs->db_conn->sqlite_db;
+  sqlite3* sqlite_db = sfs->db_conn->first_sqlite_conn;
 
   os << "<h2>SQLite</h2>\n"
      << "<ul>\n"

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -574,6 +574,20 @@ SFStore::custom_metric_fns() {
             perfcounter_type_d::PERFCOUNTER_U64, "sfs_filesystem_avail_bytes",
             static_cast<double>(filesystem_stats_avail_bytes)
         );
+      },
+      [&]() {
+        const auto sqlite_fds = std::ranges::count_if(
+            std::filesystem::directory_iterator{"/proc/self/fd"},
+            [&](const auto& dentry) {
+              std::error_code ec;
+              const auto target = std::filesystem::read_symlink(dentry, ec);
+              return !ec && (target == db_conn->get_storage().filename());
+            }
+        );
+        return std::make_tuple(
+            perfcounter_type_d::PERFCOUNTER_U64, "sfs_sqlite_connection_count",
+            static_cast<double>(sqlite_fds)
+        );
       }};
   return fns;
 }

--- a/src/rgw/rgw_sal_sfs.h
+++ b/src/rgw/rgw_sal_sfs.h
@@ -149,6 +149,9 @@ class SFStore : public StoreDriver {
     return std::make_unique<SFSStatusPage>(this);
   }
 
+  std::vector<std::function<MetricsStatusPage::ScalarMetricFunction>>
+  custom_metric_fns();
+
   void filesystem_stats_updater_main(std::chrono::milliseconds update_interval);
 
   virtual const std::string get_name() const override { return "sfs"; }


### PR DESCRIPTION
Add custom metrics support. Add simple registry of functions that
return metric 3-tuples to metric status pages.

Add custom metrics from sqlite, filesystem and database file size sources.

Issue: https://github.com/aquarist-labs/s3gw/issues/681

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
