### PR TITLE
Better SQLite Profiling

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3826,6 +3826,17 @@ options:
   level: advanced
   default: false
   desc:
-    Set up SQL query profiling using RGW logger.
+    Enable SFS SQLite profiling.
+    Logs with debug level prefixed "[SQLITE PROFILE]".
+    Logs slow queries with high level prefixed "[SQLITE SLOW QUERY]".
+    Makes data available in sfs_sqlite_profile Prometheus-style performane counter.
+  service:
+    - rgw
+- name: rgw_sfs_sqlite_profile_slowlog_time
+  type: millisecs
+  level: advanced
+  default: 20
+  desc:
+    Threshold to log slow queries with high log level.
   service:
     - rgw

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -10,6 +10,8 @@ extern PerfCounters *perfcounter;
 extern PerfCounters *perfcounter_ops;
 extern PerfCounters *perfcounter_ops_svc_time_hist;
 extern PerfCounters *perfcounter_ops_svc_time_sum;
+extern PerfCounters *perfcounter_prom_time_hist;
+extern PerfCounters *perfcounter_prom_time_sum;
 extern PerfHistogramCommon::axis_config_d perfcounter_op_hist_x_axis_config;
 extern PerfHistogramCommon::axis_config_d perfcounter_op_hist_y_axis_config;
 
@@ -67,4 +69,10 @@ enum {
   l_rgw_sfs_sqlite_retry_failed_count,
 
   l_rgw_last,
+};
+
+enum {
+  l_rgw_prom_first = 25000,
+  l_rgw_prom_sfs_sqlite_profile,
+  l_rgw_prom_last,
 };


### PR DESCRIPTION
Improve SQLite profiling by adding a slowlog functionality and making
data available via a Prometheus histogram

New output:
```
2023-08-25T14:03:58.408+0200 7f4928ec36c0  1 [SQLITE SLOW QUERY] 0x5622ac7bdc00 95ms REPLACE INTO 'objects' ("uuid", "bucket_id", "name") VALUES ('05762332-c83c-4fad-91e2-239337c49630', 'warp-benchmark-bucket.1692965029654959143', 'QJXOppkd/2.kAISpEgHGZSa96Rb.rnd')
2023-08-25T14:03:58.421+0200 7f49c17f46c0  1 [SQLITE SLOW QUERY] 0x5622ad3db880 78ms UPDATE  'multiparts' SET "state" = 4  , "state_change_time" = 1692965038346003234  WHERE ( (("multiparts"."upload_id" = '20230825T120355.528163237Z') AND ("multiparts"."state" = 3)))
2023-08-25T14:03:58.421+0200 7f490ce8b6c0  1 [SQLITE SLOW QUERY] 0x5622ae56c000 41ms UPDATE  'multiparts_parts' SET "etag" = '912470dc1223199aa0bc5cd78f075e3d'  , "mtime" = 1692965038383949171  , "size" = 16777216  WHERE ( ((("multiparts_parts"."upload_id" = '20230825T120357.334730068Z') AND ("multiparts_parts"."part_num" = 1)) AND "multiparts_parts"."etag" IS NULL))
2023-08-25T14:03:58.448+0200 7f49cc0096c0  1 [SQLITE SLOW QUERY] 0x5622ace92380 103ms UPDATE  'multiparts_parts' SET "etag" = 'b7aded250cf56d72580a63d09b4ced52'  , "mtime" = 1692965038346030473  , "size" = 15222784  WHERE ( ((("multiparts_parts"."upload_id" = '20230825T120355.484865040Z') AND ("multiparts_parts"."part_num" = 2)) AND "multiparts_parts"."etag" IS NULL))
2023-08-25T14:03:58.451+0200 7f49a97c46c0  1 [SQLITE SLOW QUERY] 0x5622abd08700 85ms UPDATE  'multiparts_parts' SET "etag" = 'aebe738f6592dbd606f996739acf6785'  , "mtime" = 1692965038369552437  , "size" = 15222784  WHERE ( ((("multiparts_parts"."upload_id" = '20230825T120356.248568735Z') AND ("multiparts_parts"."part_num" = 2)) AND "multiparts_parts"."etag" IS NULL))
2023-08-25T14:03:58.458+0200 7f496573c6c0  1 [SQLITE SLOW QUERY] 0x5622ae5fee00 105ms UPDATE  'multiparts' SET "state" = 4  , "state_change_time" = 1692965038354953859  WHERE ( (("multiparts"."upload_id" = '20230825T120355.511122568Z') AND ("multiparts"."state" = 3)))
2023-08-25T14:03:58.488+0200 7f49c17f46c0  1 [SQLITE SLOW QUERY] 0x5622ad3db500 30ms SELECT "objects"."uuid" FROM 'objects' WHERE ( (("objects"."bucket_id" = 'warp-benchmark-bucket.1692965029654959143') AND ("objects"."name" = 'UBzD6gOn/2.7AoRriIBRT72be4w.rnd')))
2023-08-25T14:03:58.488+0200 7f49466fe6c0  1 [SQLITE SLOW QUERY] 0x5622abccae00 30ms COMMIT
```

Prometheus:
```
# HELP rgw_prom_hist_sfs_sqlite_profile Histogram of SQLite Query time in µs (histogram int)
# TYPE rgw_prom_hist_sfs_sqlite_profile histogram
rgw_prom_hist_sfs_sqlite_profile_bucket{le="99"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="999"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="1899"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="3699"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="7299"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="14499"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="28899"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="57699"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="115299"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="230499"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="460899"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="921699"} 98041
rgw_prom_hist_sfs_sqlite_profile_bucket{le="1843299"} 103130
rgw_prom_hist_sfs_sqlite_profile_bucket{le="3686499"} 103331
rgw_prom_hist_sfs_sqlite_profile_bucket{le="7372899"} 103970
rgw_prom_hist_sfs_sqlite_profile_bucket{le="14745699"} 104223
rgw_prom_hist_sfs_sqlite_profile_bucket{le="29491299"} 104236
rgw_prom_hist_sfs_sqlite_profile_bucket{le="+Inf"} 104241
rgw_prom_hist_sfs_sqlite_profile_sum 66000
```


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

