### PR TITLE
rgw/sfs: Delete markers on top

### DIFF
--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
@@ -64,7 +64,7 @@ class SQLiteVersionedObjects {
   ) const;
 
   std::optional<DBVersionedObject> delete_version_and_get_previous_transact(
-      uint id
+      const uuid_d& object_id, uint id
   ) const;
 
   std::optional<DBVersionedObject> create_new_versioned_object_transact(

--- a/src/rgw/driver/sfs/types.cc
+++ b/src/rgw/driver/sfs/types.cc
@@ -388,7 +388,7 @@ bool Bucket::_undelete_object(
     if (!key.instance.empty() && (key.instance == last_version.version_id)) {
       // remove the delete marker and get the previous version in a transaction
       sqlite_versioned_objects.delete_version_and_get_previous_transact(
-          last_version.id
+          last_version.object_id, last_version.id
       );
     }
   }


### PR DESCRIPTION
This PR changes how we query for last version, and how delete markers are obtained.

It sorts by version_type first, so commit time is only taken into account if a delete marker is not found.
It also selects with a limit(1).

It also refactors a few other version queries to make them simpler and to make them one of them not a READ-WRITE transaction.

Fixes: https://github.com/aquarist-labs/s3gw/issues/622
Fixes partially: https://github.com/aquarist-labs/s3gw/issues/645
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

