### PR TITLE
rgw/sfs: Add pedantic and other warnings

### DIFF
--- a/src/rgw/driver/sfs/CMakeLists.txt
+++ b/src/rgw/driver/sfs/CMakeLists.txt
@@ -40,22 +40,18 @@ set(sfs_srcs
 
 add_library(sfs STATIC ${sfs_srcs})
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  target_compile_options(sfs PRIVATE
-    -Werror -Wextra
-    -Wunused-function
-    -Wunused-result
-    -Wshadow
-    -Wno-error=unused-parameter)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-  target_compile_options(sfs PRIVATE
-    -Werror -Wextra
-    -Wunused-function
-    -Wunused-result
-    -Wshadow
-    -Wno-error=unused-parameter
-    -Wno-error=unqualified-std-cast-call)
-endif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+target_compile_options(sfs PRIVATE
+  -Wall
+  -Werror
+  -Wextra
+  -Wpedantic
+  -pedantic-errors
+  -Wold-style-cast
+  -Wcast-align
+  -Wcast-qual
+  -Wformat
+  -Wredundant-decls
+  -Wswitch-default)
 
 # Mark ceph includes system to not see "our" warnings there
 target_include_directories(sfs


### PR DESCRIPTION
Using pedantic, pedantic-errors and other warnings.
Using same set of warnings for gcc and clang.

Opened also to discuss about other possible extra warnings that we think are good to have. 

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

