### PR TITLE
[experimental] rgw/sfs: don't use storage.open_forever()

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -319,7 +319,7 @@ class DBConn {
         );
       }
     };
-    storage.open_forever();
+    //storage.open_forever();
     storage.busy_timeout(5000);
     maybe_upgrade_metadata();
     check_metadata_is_compatible();


### PR DESCRIPTION
Given we have multiple threads which independently open the database, I'm not sure having the first connection open forever makes sense or does anything useful.  Let's see if it changes the benchmarks.