### PR TITLE
rgw/s3gw: ensure s3gw_telemetry is non-null before stop

### DIFF
--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -645,5 +645,7 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 #endif
   rgw_perf_stop(g_ceph_context);
   ratelimiter.reset(); // deletes--ensure this happens before we destruct
-  env.s3gw_telemetry->stop();
+  if (env.s3gw_telemetry) {
+    env.s3gw_telemetry->stop();
+  }
 } /* AppMain::shutdown */


### PR DESCRIPTION
env.s3gw_telemetry is only valid when using the sfs store.  If you try to run the radosgw binary using, say, dbstore, it will segfault on exit due to a null pointer dereference.

Fixes: 9b02b73a9ea6cafa3d4151951d7c7917a1ba597d
