### PR TITLE
ci: Run build and push image in target repo

### DIFF
--- a/.github/workflows/build-image-on-pr-label.yaml
+++ b/.github/workflows/build-image-on-pr-label.yaml
@@ -1,11 +1,10 @@
 ---
 name: Build and Push S3GW Image
 on:
-
-  pull_request:
+  pull_request_target:
     branches:
       - "s3gw"
-    types: [ labeled ]
+    types: [labeled]
 
   workflow_dispatch:
 
@@ -14,7 +13,7 @@ env:
   IMAGE_TAG: pr-${{ github.workflow_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
-  tests:
+  build:
     if: github.event.label.name == 'ci/build-s3gw-image' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
@@ -30,12 +29,6 @@ jobs:
         with:
           path: s3gw/ceph
           submodules: recursive
-
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
To allow access to secrets, run PRs labeled with ci/build-s3gw-image in the target repository.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

