### PR TITLE
[experimental] rgw/sfs: use only one sqlite database connection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,4 +74,4 @@
 	url = https://github.com/open-telemetry/opentelemetry-cpp.git
 [submodule "src/rgw/driver/sfs/sqlite/sqlite_orm"]
 	path = src/rgw/driver/sfs/sqlite/sqlite_orm
-	url = https://github.com/fnc12/sqlite_orm.git
+	url = https://github.com/aquarist-labs/sqlite_orm.git

--- a/src/rgw/driver/sfs/sqlite/dbconn.cc
+++ b/src/rgw/driver/sfs/sqlite/dbconn.cc
@@ -113,7 +113,7 @@ static int sqlite_profile_callback(
 }
 
 DBConn::DBConn(CephContext* _cct)
-    : main_thread(pthread_self()),
+    : main_thread(std::this_thread::get_id()),
       first_sqlite_conn(nullptr),
       cct(_cct),
       profile_enabled(_cct->_conf.get_val<bool>("rgw_sfs_sqlite_profile")) {

--- a/src/rgw/driver/sfs/sqlite/dbconn.cc
+++ b/src/rgw/driver/sfs/sqlite/dbconn.cc
@@ -113,7 +113,7 @@ static int sqlite_profile_callback(
 }
 
 DBConn::DBConn(CephContext* _cct)
-    : storage(std::make_shared<StorageImpl>(_make_storage(getDBPath(_cct)))),
+    : storage(_make_storage(getDBPath(_cct))),
       first_sqlite_conn(nullptr),
       cct(_cct),
       profile_enabled(_cct->_conf.get_val<bool>("rgw_sfs_sqlite_profile")) {

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -279,6 +279,10 @@ class DBConn {
         storage_pool.try_emplace(t, storage_pool.at(main_thread));
     StorageRef s = &(*i).second;
     if (was_inserted) {
+      // A copy of the main thread's StorageImpl won't have an open DB
+      // connection yet, so we'd better make it have one (otherwise we're
+      // back to a gadzillion sqlite3_open()/sqlite3_close() calls again)
+      s->open_forever();
       // FIXME: get rid of this (or reduce it to a debug log)
       lderr(cct) << "Added new Storage object " << s << " to pool for thread "
                  << std::hex << t << dendl;

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -284,9 +284,6 @@ class DBConn {
       // connection yet, so we'd better make it have one (otherwise we're
       // back to a gadzillion sqlite3_open()/sqlite3_close() calls again)
       s->open_forever();
-      // FIXME: get rid of this (or reduce it to a debug log)
-      lderr(cct) << "Added new Storage object " << s << " to pool for thread "
-                 << std::hex << t << dendl;
     }
     return s;
   }

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -151,8 +151,8 @@ inline auto _make_storage(const std::string& path) {
       sqlite_orm::make_table(
           std::string(VERSIONED_OBJECTS_TABLE),
           sqlite_orm::make_column(
-              "id", &DBVersionedObject::id, sqlite_orm::autoincrement(),
-              sqlite_orm::primary_key()
+              "id", &DBVersionedObject::id,
+              sqlite_orm::primary_key().autoincrement()
           ),
           sqlite_orm::make_column("object_id", &DBVersionedObject::object_id),
           sqlite_orm::make_column("checksum", &DBVersionedObject::checksum),
@@ -182,8 +182,7 @@ inline auto _make_storage(const std::string& path) {
       sqlite_orm::make_table(
           std::string(ACCESS_KEYS),
           sqlite_orm::make_column(
-              "id", &DBAccessKey::id, sqlite_orm::autoincrement(),
-              sqlite_orm::primary_key()
+              "id", &DBAccessKey::id, sqlite_orm::primary_key().autoincrement()
           ),
           sqlite_orm::make_column("access_key", &DBAccessKey::access_key),
           sqlite_orm::make_column("user_id", &DBAccessKey::user_id),
@@ -211,8 +210,7 @@ inline auto _make_storage(const std::string& path) {
       sqlite_orm::make_table(
           std::string(MULTIPARTS_TABLE),
           sqlite_orm::make_column(
-              "id", &DBMultipart::id, sqlite_orm::primary_key(),
-              sqlite_orm::autoincrement()
+              "id", &DBMultipart::id, sqlite_orm::primary_key().autoincrement()
           ),
           sqlite_orm::make_column("bucket_id", &DBMultipart::bucket_id),
           sqlite_orm::make_column("upload_id", &DBMultipart::upload_id),
@@ -236,8 +234,8 @@ inline auto _make_storage(const std::string& path) {
       sqlite_orm::make_table(
           std::string(MULTIPARTS_PARTS_TABLE),
           sqlite_orm::make_column(
-              "id", &DBMultipartPart::id, sqlite_orm::primary_key(),
-              sqlite_orm::autoincrement()
+              "id", &DBMultipartPart::id,
+              sqlite_orm::primary_key().autoincrement()
           ),
           sqlite_orm::make_column("upload_id", &DBMultipartPart::upload_id),
           sqlite_orm::make_column("part_num", &DBMultipartPart::part_num),

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -263,6 +263,7 @@ class DBConn {
   sqlite3* first_sqlite_conn;
   CephContext* const cct;
   const bool profile_enabled;
+  ceph::mutex lock = ceph::make_mutex("sfs_db_lock");
 
   DBConn(CephContext* _cct);
   virtual ~DBConn() = default;

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -252,11 +252,11 @@ inline auto _make_storage(const std::string& path) {
 }
 
 using StorageImpl = decltype(_make_storage(""));
-using StorageRef = std::shared_ptr<StorageImpl>;
+using StorageRef = StorageImpl*;
 
 class DBConn {
  private:
-  StorageRef storage;
+  StorageImpl storage;
 
  public:
   sqlite3* first_sqlite_conn;
@@ -270,7 +270,7 @@ class DBConn {
   DBConn(const DBConn&) = delete;
   DBConn& operator=(const DBConn&) = delete;
 
-  inline auto get_storage() { return storage; }
+  inline auto get_storage() { return &storage; }
 
   static std::string getDBPath(CephContext* cct) {
     auto rgw_sfs_path = cct->_conf.get_val<std::string>("rgw_sfs_data_path");

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -270,7 +270,7 @@ class DBConn {
   DBConn(const DBConn&) = delete;
   DBConn& operator=(const DBConn&) = delete;
 
-  inline auto get_storage() const { return storage; }
+  inline auto& get_storage() { return storage; }
 
   static std::string getDBPath(CephContext* cct) {
     auto rgw_sfs_path = cct->_conf.get_val<std::string>("rgw_sfs_data_path");

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -264,7 +264,8 @@ class DBConn {
   sqlite3* first_sqlite_conn;
   CephContext* const cct;
   const bool profile_enabled;
-  ceph::mutex lock = ceph::make_mutex("sfs_db_lock");
+  // This probably isn't actually needed with multiple connections
+  ceph::mutex sfs_db_lock = ceph::make_mutex("sfs_db_lock");
 
   DBConn(CephContext* _cct);
   virtual ~DBConn() = default;

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -251,11 +251,12 @@ inline auto _make_storage(const std::string& path) {
   );
 }
 
-using Storage = decltype(_make_storage(""));
+using StorageImpl = decltype(_make_storage(""));
+using StorageRef = std::shared_ptr<StorageImpl>;
 
 class DBConn {
  private:
-  Storage storage;
+  StorageRef storage;
 
  public:
   sqlite3* first_sqlite_conn;
@@ -269,7 +270,7 @@ class DBConn {
   DBConn(const DBConn&) = delete;
   DBConn& operator=(const DBConn&) = delete;
 
-  inline auto& get_storage() { return storage; }
+  inline auto get_storage() { return storage; }
 
   static std::string getDBPath(CephContext* cct) {
     auto rgw_sfs_path = cct->_conf.get_val<std::string>("rgw_sfs_data_path");

--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -256,8 +256,8 @@ using StorageRef = StorageImpl*;
 
 class DBConn {
  private:
-  std::map<pthread_t, StorageImpl> storage_pool;
-  pthread_t main_thread;
+  std::map<std::thread::id, StorageImpl> storage_pool;
+  std::thread::id main_thread;
   ceph::mutex storage_pool_lock = ceph::make_mutex("sfs_storage_pool_lock");
 
  public:
@@ -275,7 +275,7 @@ class DBConn {
 
   inline StorageRef get_storage() {
     std::lock_guard l(storage_pool_lock);  // TODO: is this necessary or not?
-    pthread_t t = pthread_self();
+    std::thread::id t = std::this_thread::get_id();
     auto [i, was_inserted] =
         storage_pool.try_emplace(t, storage_pool.at(main_thread));
     StorageRef s = &(*i).second;

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -142,7 +142,7 @@ std::optional<DBDeletedObjectItems> SQLiteBuckets::delete_bucket_transact(
   RetrySQLite<DBDeletedObjectItems> retry([&]() {
     bucket_deleted = false;
     DBDeletedObjectItems ret_values;
-    std::lock_guard l(conn->lock);
+    // std::lock_guard l(conn->sfs_db_lock);
     auto transaction = storage->transaction_guard();
     // first get all the objects and versions for that bucket
     ret_values = storage->select(

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -142,6 +142,9 @@ std::optional<DBDeletedObjectItems> SQLiteBuckets::delete_bucket_transact(
   RetrySQLite<DBDeletedObjectItems> retry([&]() {
     bucket_deleted = false;
     DBDeletedObjectItems ret_values;
+    std::lock_guard l(conn->lock);
+    // FIXME: looks like this transaction will never rollback/commit if anything below throws.
+    // FIXME: I assume this wants to be storage.transaction_guard()?
     storage.begin_transaction();
     // first get all the objects and versions for that bucket
     ret_values = storage.select(

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -40,7 +40,7 @@ std::vector<DBOPBucketInfo> get_rgw_buckets(
 std::optional<DBOPBucketInfo> SQLiteBuckets::get_bucket(
     const std::string& bucket_id
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto bucket = storage.get_pointer<DBBucket>(bucket_id);
   std::optional<DBOPBucketInfo> ret_value;
   if (bucket) {
@@ -52,7 +52,7 @@ std::optional<DBOPBucketInfo> SQLiteBuckets::get_bucket(
 std::optional<std::pair<std::string, std::string>> SQLiteBuckets::get_owner(
     const std::string& bucket_id
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   const auto rows = storage.select(
       columns(&DBUser::user_id, &DBUser::display_name),
       inner_join<DBUser>(on(is_equal(&DBBucket::owner_id, &DBUser::user_id))),
@@ -68,60 +68,60 @@ std::optional<std::pair<std::string, std::string>> SQLiteBuckets::get_owner(
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_bucket_by_name(
     const std::string& bucket_name
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return get_rgw_buckets(
       storage.get_all<DBBucket>(where(c(&DBBucket::bucket_name) = bucket_name))
   );
 }
 
 void SQLiteBuckets::store_bucket(const DBOPBucketInfo& bucket) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto db_bucket = get_db_bucket(bucket);
   storage.replace(db_bucket);
 }
 
 void SQLiteBuckets::remove_bucket(const std::string& bucket_name) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.remove<DBBucket>(bucket_name);
 }
 
 std::vector<std::string> SQLiteBuckets::get_bucket_ids() const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return storage.select(&DBBucket::bucket_name);
 }
 
 std::vector<std::string> SQLiteBuckets::get_bucket_ids(
     const std::string& user_id
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return storage.select(
       &DBBucket::bucket_name, where(c(&DBBucket::owner_id) = user_id)
   );
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets() const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return get_rgw_buckets(storage.get_all<DBBucket>());
 }
 
 std::vector<DBOPBucketInfo> SQLiteBuckets::get_buckets(
     const std::string& user_id
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return get_rgw_buckets(
       storage.get_all<DBBucket>(where(c(&DBBucket::owner_id) = user_id))
   );
 }
 
 std::vector<std::string> SQLiteBuckets::get_deleted_buckets_ids() const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return storage.select(
       &DBBucket::bucket_id, where(c(&DBBucket::deleted) = true)
   );
 }
 
 bool SQLiteBuckets::bucket_empty(const std::string& bucket_id) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto num_ids = storage.count<DBVersionedObject>(
       inner_join<DBObject>(
           on(is_equal(&DBObject::uuid, &DBVersionedObject::object_id))
@@ -138,7 +138,7 @@ bool SQLiteBuckets::bucket_empty(const std::string& bucket_id) const {
 std::optional<DBDeletedObjectItems> SQLiteBuckets::delete_bucket_transact(
     const std::string& bucket_id, uint max_objects, bool& bucket_deleted
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   RetrySQLite<DBDeletedObjectItems> retry([&]() {
     bucket_deleted = false;
     DBDeletedObjectItems ret_values;

--- a/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
@@ -19,7 +19,7 @@ namespace rgw::sal::sfs::sqlite {
 SQLiteLifecycle::SQLiteLifecycle(DBConnRef _conn) : conn(_conn) {}
 
 DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto head = storage.get_pointer<DBOPLCHead>(oid);
   DBOPLCHead ret_value;
   if (head) {
@@ -36,19 +36,19 @@ DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
 }
 
 void SQLiteLifecycle::store_head(const DBOPLCHead& head) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.replace(head);
 }
 
 void SQLiteLifecycle::remove_head(const std::string& oid) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.remove<DBOPLCHead>(oid);
 }
 
 std::optional<DBOPLCEntry> SQLiteLifecycle::get_entry(
     const std::string& oid, const std::string& marker
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto db_entry = storage.get_pointer<DBOPLCEntry>(oid, marker);
   std::optional<DBOPLCEntry> ret_value;
   if (db_entry) {
@@ -60,7 +60,7 @@ std::optional<DBOPLCEntry> SQLiteLifecycle::get_entry(
 std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
     const std::string& oid, const std::string& marker
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto db_entries = storage.get_all<DBOPLCEntry>(
       where(
           is_equal(&DBOPLCEntry::lc_index, oid) and
@@ -77,21 +77,21 @@ std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
 }
 
 void SQLiteLifecycle::store_entry(const DBOPLCEntry& entry) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.replace(entry);
 }
 
 void SQLiteLifecycle::remove_entry(
     const std::string& oid, const std::string& marker
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.remove<DBOPLCEntry>(oid, marker);
 }
 
 std::vector<DBOPLCEntry> SQLiteLifecycle::list_entries(
     const std::string& oid, const std::string& marker, uint32_t max_entries
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return storage.get_all<DBOPLCEntry>(
       where(
           is_equal(&DBOPLCEntry::lc_index, oid) and

--- a/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_lifecycle.cc
@@ -19,8 +19,8 @@ namespace rgw::sal::sfs::sqlite {
 SQLiteLifecycle::SQLiteLifecycle(DBConnRef _conn) : conn(_conn) {}
 
 DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
-  auto& storage = conn->get_storage();
-  auto head = storage.get_pointer<DBOPLCHead>(oid);
+  auto storage = conn->get_storage();
+  auto head = storage->get_pointer<DBOPLCHead>(oid);
   DBOPLCHead ret_value;
   if (head) {
     ret_value = *head;
@@ -29,27 +29,27 @@ DBOPLCHead SQLiteLifecycle::get_head(const std::string& oid) const {
     // LC was not executed yet.
     // create an empty entry
     DBOPLCHead new_head{oid, "", 0};
-    storage.replace(new_head);
+    storage->replace(new_head);
     ret_value = new_head;
   }
   return ret_value;
 }
 
 void SQLiteLifecycle::store_head(const DBOPLCHead& head) const {
-  auto& storage = conn->get_storage();
-  storage.replace(head);
+  auto storage = conn->get_storage();
+  storage->replace(head);
 }
 
 void SQLiteLifecycle::remove_head(const std::string& oid) const {
-  auto& storage = conn->get_storage();
-  storage.remove<DBOPLCHead>(oid);
+  auto storage = conn->get_storage();
+  storage->remove<DBOPLCHead>(oid);
 }
 
 std::optional<DBOPLCEntry> SQLiteLifecycle::get_entry(
     const std::string& oid, const std::string& marker
 ) const {
-  auto& storage = conn->get_storage();
-  auto db_entry = storage.get_pointer<DBOPLCEntry>(oid, marker);
+  auto storage = conn->get_storage();
+  auto db_entry = storage->get_pointer<DBOPLCEntry>(oid, marker);
   std::optional<DBOPLCEntry> ret_value;
   if (db_entry) {
     ret_value = *db_entry;
@@ -60,8 +60,8 @@ std::optional<DBOPLCEntry> SQLiteLifecycle::get_entry(
 std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
     const std::string& oid, const std::string& marker
 ) const {
-  auto& storage = conn->get_storage();
-  auto db_entries = storage.get_all<DBOPLCEntry>(
+  auto storage = conn->get_storage();
+  auto db_entries = storage->get_all<DBOPLCEntry>(
       where(
           is_equal(&DBOPLCEntry::lc_index, oid) and
           greater_than(&DBOPLCEntry::bucket_name, marker)
@@ -77,22 +77,22 @@ std::optional<DBOPLCEntry> SQLiteLifecycle::get_next_entry(
 }
 
 void SQLiteLifecycle::store_entry(const DBOPLCEntry& entry) const {
-  auto& storage = conn->get_storage();
-  storage.replace(entry);
+  auto storage = conn->get_storage();
+  storage->replace(entry);
 }
 
 void SQLiteLifecycle::remove_entry(
     const std::string& oid, const std::string& marker
 ) const {
-  auto& storage = conn->get_storage();
-  storage.remove<DBOPLCEntry>(oid, marker);
+  auto storage = conn->get_storage();
+  storage->remove<DBOPLCEntry>(oid, marker);
 }
 
 std::vector<DBOPLCEntry> SQLiteLifecycle::list_entries(
     const std::string& oid, const std::string& marker, uint32_t max_entries
 ) const {
-  auto& storage = conn->get_storage();
-  return storage.get_all<DBOPLCEntry>(
+  auto storage = conn->get_storage();
+  return storage->get_all<DBOPLCEntry>(
       where(
           is_equal(&DBOPLCEntry::lc_index, oid) and
           greater_than(&DBOPLCEntry::bucket_name, marker)

--- a/src/rgw/driver/sfs/sqlite/sqlite_list.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_list.cc
@@ -39,8 +39,8 @@ bool SQLiteList::objects(
 
   // ListBucket does not care about versions/instances. don't populate
   // key.instance
-  auto& storage = conn->get_storage();
-  auto rows = storage.select(
+  auto storage = conn->get_storage();
+  auto rows = storage->select(
       columns(
           &DBObject::name, &DBVersionedObject::mtime, &DBVersionedObject::etag,
           sum(&DBVersionedObject::size)
@@ -103,8 +103,8 @@ bool SQLiteList::versions(
   ceph_assert(max < std::numeric_limits<size_t>::max());
   const size_t query_limit = max + 1;
 
-  auto& storage = conn->get_storage();
-  auto rows = storage.select(
+  auto storage = conn->get_storage();
+  auto rows = storage->select(
       columns(
           &DBObject::name, &DBVersionedObject::version_id,
           &DBVersionedObject::mtime, &DBVersionedObject::etag,

--- a/src/rgw/driver/sfs/sqlite/sqlite_list.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_list.cc
@@ -54,11 +54,11 @@ bool SQLiteList::objects(
           greater_than(&DBObject::name, start_after_object_name) and
           prefix_to_like(&DBObject::name, prefix)
       ),
-      group_by(&DBVersionedObject::object_id),
-      having(is_equal(
-          sqlite_orm::max(&DBVersionedObject::version_type),
-          VersionType::REGULAR
-      )),
+      group_by(&DBVersionedObject::object_id)
+          .having(is_equal(
+              sqlite_orm::max(&DBVersionedObject::version_type),
+              VersionType::REGULAR
+          )),
       order_by(&DBObject::name), limit(query_limit)
   );
   ceph_assert(rows.size() <= static_cast<size_t>(query_limit));

--- a/src/rgw/driver/sfs/sqlite/sqlite_list.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_list.cc
@@ -39,7 +39,7 @@ bool SQLiteList::objects(
 
   // ListBucket does not care about versions/instances. don't populate
   // key.instance
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto rows = storage.select(
       columns(
           &DBObject::name, &DBVersionedObject::mtime, &DBVersionedObject::etag,
@@ -103,7 +103,7 @@ bool SQLiteList::versions(
   ceph_assert(max < std::numeric_limits<size_t>::max());
   const size_t query_limit = max + 1;
 
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto rows = storage.select(
       columns(
           &DBObject::name, &DBVersionedObject::version_id,

--- a/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
@@ -23,15 +23,15 @@ SQLiteObjects::SQLiteObjects(DBConnRef _conn) : conn(_conn) {}
 
 std::vector<DBObject> SQLiteObjects::get_objects(const std::string& bucket_id
 ) const {
-  auto& storage = conn->get_storage();
-  return storage.get_all<DBObject>(
+  auto storage = conn->get_storage();
+  return storage->get_all<DBObject>(
       where(is_equal(&DBObject::bucket_id, bucket_id))
   );
 }
 
 std::optional<DBObject> SQLiteObjects::get_object(const uuid_d& uuid) const {
-  auto& storage = conn->get_storage();
-  auto object = storage.get_pointer<DBObject>(uuid.to_string());
+  auto storage = conn->get_storage();
+  auto object = storage->get_pointer<DBObject>(uuid.to_string());
   std::optional<DBObject> ret_value;
   if (object) {
     ret_value = *object;
@@ -42,8 +42,8 @@ std::optional<DBObject> SQLiteObjects::get_object(const uuid_d& uuid) const {
 std::optional<DBObject> SQLiteObjects::get_object(
     const std::string& bucket_id, const std::string& object_name
 ) const {
-  auto& storage = conn->get_storage();
-  auto objects = storage.get_all<DBObject>(where(
+  auto storage = conn->get_storage();
+  auto objects = storage->get_all<DBObject>(where(
       is_equal(&DBObject::bucket_id, bucket_id) and
       is_equal(&DBObject::name, object_name)
   ));
@@ -57,13 +57,13 @@ std::optional<DBObject> SQLiteObjects::get_object(
 }
 
 void SQLiteObjects::store_object(const DBObject& object) const {
-  auto& storage = conn->get_storage();
-  storage.replace(object);
+  auto storage = conn->get_storage();
+  storage->replace(object);
 }
 
 void SQLiteObjects::remove_object(const uuid_d& uuid) const {
-  auto& storage = conn->get_storage();
-  storage.remove<DBObject>(uuid);
+  auto storage = conn->get_storage();
+  storage->remove<DBObject>(uuid);
 }
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_objects.cc
@@ -23,14 +23,14 @@ SQLiteObjects::SQLiteObjects(DBConnRef _conn) : conn(_conn) {}
 
 std::vector<DBObject> SQLiteObjects::get_objects(const std::string& bucket_id
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   return storage.get_all<DBObject>(
       where(is_equal(&DBObject::bucket_id, bucket_id))
   );
 }
 
 std::optional<DBObject> SQLiteObjects::get_object(const uuid_d& uuid) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto object = storage.get_pointer<DBObject>(uuid.to_string());
   std::optional<DBObject> ret_value;
   if (object) {
@@ -42,7 +42,7 @@ std::optional<DBObject> SQLiteObjects::get_object(const uuid_d& uuid) const {
 std::optional<DBObject> SQLiteObjects::get_object(
     const std::string& bucket_id, const std::string& object_name
 ) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto objects = storage.get_all<DBObject>(where(
       is_equal(&DBObject::bucket_id, bucket_id) and
       is_equal(&DBObject::name, object_name)
@@ -57,12 +57,12 @@ std::optional<DBObject> SQLiteObjects::get_object(
 }
 
 void SQLiteObjects::store_object(const DBObject& object) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.replace(object);
 }
 
 void SQLiteObjects::remove_object(const uuid_d& uuid) const {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   storage.remove<DBObject>(uuid);
 }
 

--- a/src/rgw/driver/sfs/sqlite/sqlite_users.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_users.cc
@@ -26,8 +26,8 @@ SQLiteUsers::SQLiteUsers(DBConnRef _conn) : conn(_conn) {}
 
 std::optional<DBOPUserInfo> SQLiteUsers::get_user(const std::string& userid
 ) const {
-  auto& storage = conn->get_storage();
-  auto user = storage.get_pointer<DBUser>(userid);
+  auto storage = conn->get_storage();
+  auto user = storage->get_pointer<DBUser>(userid);
   std::optional<DBOPUserInfo> ret_value;
   if (user) {
     ret_value = get_rgw_user(*user);
@@ -49,11 +49,11 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_email(
 std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(
     const std::string& key
 ) const {
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
   auto user_id = _get_user_id_by_access_key(storage, key);
   std::optional<DBOPUserInfo> ret_value;
   if (user_id.has_value()) {
-    auto user = storage.get_pointer<DBUser>(user_id);
+    auto user = storage->get_pointer<DBUser>(user_id);
     if (user) {
       ret_value = get_rgw_user(*user);
     }
@@ -62,28 +62,28 @@ std::optional<DBOPUserInfo> SQLiteUsers::get_user_by_access_key(
 }
 
 std::vector<std::string> SQLiteUsers::get_user_ids() const {
-  auto& storage = conn->get_storage();
-  return storage.select(&DBUser::user_id);
+  auto storage = conn->get_storage();
+  return storage->select(&DBUser::user_id);
 }
 
 void SQLiteUsers::store_user(const DBOPUserInfo& user) const {
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
   auto db_user = get_db_user(user);
-  storage.replace(db_user);
+  storage->replace(db_user);
   _store_access_keys(storage, user);
 }
 
 void SQLiteUsers::remove_user(const std::string& userid) const {
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
   _remove_access_keys(storage, userid);
-  storage.remove<DBUser>(userid);
+  storage->remove<DBUser>(userid);
 }
 
 template <class... Args>
 std::vector<DBOPUserInfo> SQLiteUsers::get_users_by(Args... args) const {
   std::vector<DBOPUserInfo> users_return;
-  auto& storage = conn->get_storage();
-  auto users = storage.get_all<DBUser>(args...);
+  auto storage = conn->get_storage();
+  auto users = storage->get_all<DBUser>(args...);
   for (auto& user : users) {
     users_return.push_back(get_rgw_user(user));
   }
@@ -91,7 +91,7 @@ std::vector<DBOPUserInfo> SQLiteUsers::get_users_by(Args... args) const {
 }
 
 void SQLiteUsers::_store_access_keys(
-    rgw::sal::sfs::sqlite::Storage& storage, const DBOPUserInfo& user
+    StorageRef storage, const DBOPUserInfo& user
 ) const {
   // remove existing keys for the user (in case any of them had changed)
   _remove_access_keys(storage, user.uinfo.user_id.id);
@@ -99,21 +99,21 @@ void SQLiteUsers::_store_access_keys(
     DBAccessKey db_key;
     db_key.access_key = key.first;
     db_key.user_id = user.uinfo.user_id.id;
-    storage.insert(db_key);
+    storage->insert(db_key);
   }
 }
 
 void SQLiteUsers::_remove_access_keys(
-    rgw::sal::sfs::sqlite::Storage& storage, const std::string& userid
+    StorageRef storage, const std::string& userid
 ) const {
-  storage.remove_all<DBAccessKey>(where(c(&DBAccessKey::user_id) = userid));
+  storage->remove_all<DBAccessKey>(where(c(&DBAccessKey::user_id) = userid));
 }
 
 std::optional<std::string> SQLiteUsers::_get_user_id_by_access_key(
-    rgw::sal::sfs::sqlite::Storage& storage, const std::string& key
+    StorageRef storage, const std::string& key
 ) const {
   auto keys =
-      storage.get_all<DBAccessKey>(where(c(&DBAccessKey::access_key) = key));
+      storage->get_all<DBAccessKey>(where(c(&DBAccessKey::access_key) = key));
   std::optional<std::string> ret_value;
   if (keys.size() > 0) {
     // in case we have 2 keys that are equal in different users we return

--- a/src/rgw/driver/sfs/sqlite/sqlite_users.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_users.h
@@ -40,14 +40,10 @@ class SQLiteUsers {
   template <class... Args>
   std::vector<DBOPUserInfo> get_users_by(Args... args) const;
 
-  void _store_access_keys(
-      rgw::sal::sfs::sqlite::Storage& storage, const DBOPUserInfo& user
-  ) const;
-  void _remove_access_keys(
-      rgw::sal::sfs::sqlite::Storage& storage, const std::string& userid
-  ) const;
+  void _store_access_keys(StorageRef storage, const DBOPUserInfo& user) const;
+  void _remove_access_keys(StorageRef storage, const std::string& userid) const;
   std::optional<std::string> _get_user_id_by_access_key(
-      rgw::sal::sfs::sqlite::Storage& storage, const std::string& key
+      StorageRef storage, const std::string& key
   ) const;
 };
 

--- a/src/rgw/driver/sfs/sqlite/sqlite_users.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_users.h
@@ -41,13 +41,13 @@ class SQLiteUsers {
   std::vector<DBOPUserInfo> get_users_by(Args... args) const;
 
   void _store_access_keys(
-      rgw::sal::sfs::sqlite::Storage storage, const DBOPUserInfo& user
+      rgw::sal::sfs::sqlite::Storage& storage, const DBOPUserInfo& user
   ) const;
   void _remove_access_keys(
-      rgw::sal::sfs::sqlite::Storage storage, const std::string& userid
+      rgw::sal::sfs::sqlite::Storage& storage, const std::string& userid
   ) const;
   std::optional<std::string> _get_user_id_by_access_key(
-      rgw::sal::sfs::sqlite::Storage storage, const std::string& key
+      rgw::sal::sfs::sqlite::Storage& storage, const std::string& key
   ) const;
 };
 

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -119,7 +119,7 @@ bool SQLiteVersionedObjects::store_versioned_object_if_state(
     const DBVersionedObject& object, std::vector<ObjectState> allowed_states
 ) const {
   auto storage = conn->get_storage();
-  std::lock_guard l(conn->lock);
+  // std::lock_guard l(conn->sfs_db_lock);
   auto transaction = storage->transaction_guard();
   transaction.commit_on_destroy = true;
   storage->update_all(
@@ -149,7 +149,7 @@ bool SQLiteVersionedObjects::
     ) const {
   auto storage = conn->get_storage();
   RetrySQLite<bool> retry([&]() {
-    std::lock_guard l(conn->lock);
+    // std::lock_guard l(conn->sfs_db_lock);
     auto transaction = storage->transaction_guard();
     storage->update_all(
         set(c(&DBVersionedObject::object_id) = object.object_id,
@@ -302,7 +302,7 @@ SQLiteVersionedObjects::delete_version_and_get_previous_transact(
 ) const {
   try {
     auto storage = conn->get_storage();
-    std::lock_guard l(conn->lock);
+    // std::lock_guard l(conn->sfs_db_lock);
     auto transaction = storage->transaction_guard();
     std::optional<DBVersionedObject> ret_value = std::nullopt;
     storage->remove<DBVersionedObject>(id);
@@ -342,7 +342,7 @@ uint SQLiteVersionedObjects::add_delete_marker_transact(
   added = false;
   try {
     auto storage = conn->get_storage();
-    std::lock_guard l(conn->lock);
+    // std::lock_guard l(conn->sfs_db_lock);
     auto transaction = storage->transaction_guard();
     auto last_version_select = storage->get_all<DBVersionedObject>(
         where(
@@ -457,7 +457,7 @@ SQLiteVersionedObjects::create_new_versioned_object_transact(
 ) const {
   auto storage = conn->get_storage();
   RetrySQLite<DBVersionedObject> retry([&]() {
-    std::lock_guard l(conn->lock);
+    // std::lock_guard l(conn->sfs_db_lock);
     auto transaction = storage->transaction_guard();
     auto objs = storage->select(
         columns(&DBObject::uuid),
@@ -500,7 +500,7 @@ SQLiteVersionedObjects::remove_deleted_versions_transact(uint max_objects
   DBDeletedObjectItems ret_objs;
   auto storage = conn->get_storage();
   RetrySQLite<DBDeletedObjectItems> retry([&]() {
-    std::lock_guard l(conn->lock);
+    // std::lock_guard l(conn->sfs_db_lock);
     auto transaction = storage->transaction_guard();
     // get first the list of objects to be deleted up to max_objects
     // order by size so when we delete the versions data we are more efficient

--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -198,7 +198,7 @@ void SFSAtomicWriter::cleanup() noexcept {
     lsfs_dout(dpp, -1)
         << fmt::format(
                "failed to remove failed upload version from database {}: {}",
-               store->db_conn->get_storage().filename(), e.what()
+               store->db_conn->get_storage()->filename(), e.what()
            )
         << dendl;
   }
@@ -226,7 +226,7 @@ int SFSAtomicWriter::prepare(optional_yield /*y*/) {
                "failed to create new object version in bucket {} db:{}. "
                "failing operation.",
                bucketref->get_bucket_id(),
-               store->db_conn->get_storage().filename()
+               store->db_conn->get_storage()->filename()
            )
         << dendl;
     return -ERR_INTERNAL_ERROR;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1744,7 +1744,7 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
       if (!iter->is_delete_marker()) {
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
-        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
+        auto storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
         s->formatter->dump_string("StorageClass", storage_class.c_str());
       }
       dump_owner(s, rgw_user(iter->meta.owner), iter->meta.owner_display_name);
@@ -1851,7 +1851,7 @@ void RGWListBucket_ObjStore_S3::send_response()
       dump_time(s, "LastModified", iter->meta.mtime);
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
-      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
+      auto storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
       s->formatter->dump_string("StorageClass", storage_class.c_str());
       dump_owner(s, rgw_user(iter->meta.owner), iter->meta.owner_display_name);
       if (s->system_request) {
@@ -1933,7 +1933,7 @@ void RGWListBucket_ObjStore_S3v2::send_versioned_response()
       if (!iter->is_delete_marker()) {
         s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
         s->formatter->dump_int("Size", iter->meta.accounted_size);
-        auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
+        auto storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
         s->formatter->dump_string("StorageClass", storage_class.c_str());
       }
       if (fetchOwner == true) {
@@ -2013,7 +2013,7 @@ void RGWListBucket_ObjStore_S3v2::send_response()
       dump_time(s, "LastModified", iter->meta.mtime);
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
-      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
+      auto storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
       s->formatter->dump_string("StorageClass", storage_class.c_str());
       if (fetchOwner == true) {
         dump_owner(s, s->user->get_id(), s->user->get_display_name());

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -400,14 +400,14 @@ http::status SFSStatusPage::render(std::ostream& os) {
      << " locked=" << ceph_mutex_is_locked(sfs->buckets_map_lock) << "</li>\n";
   os << "</ul>\n";
 
-  auto& db = sfs->db_conn->get_storage();
+  auto db = sfs->db_conn->get_storage();
   sqlite3* sqlite_db = sfs->db_conn->first_sqlite_conn;
 
   os << "<h2>SQLite</h2>\n"
      << "<ul>\n"
-     << "<li> filename: " << db.filename() << "</li>\n"
-     << "<li> libversion: " << db.libversion() << "</li>\n"
-     << "<li> total_changes: " << db.total_changes() << "</li>\n";
+     << "<li> filename: " << db->filename() << "</li>\n"
+     << "<li> libversion: " << db->libversion() << "</li>\n"
+     << "<li> total_changes: " << db->total_changes() << "</li>\n";
 
   int current;
   int highwater;
@@ -547,14 +547,14 @@ SFStore::custom_metric_fns() {
       [&]() {
         std::error_code ec;
         const auto size =
-            std::filesystem::file_size(db_conn->get_storage().filename(), ec);
+            std::filesystem::file_size(db_conn->get_storage()->filename(), ec);
         return std::make_tuple(
             perfcounter_type_d::PERFCOUNTER_U64, "sfs_sqlite_db_bytes",
             ec ? std::nan("error") : static_cast<double>(size)
         );
       },
       [&]() {
-        std::filesystem::path path(db_conn->get_storage().filename());
+        std::filesystem::path path(db_conn->get_storage()->filename());
         path.replace_extension("db-wal");
         std::error_code ec;
         const auto size = std::filesystem::file_size(path, ec);
@@ -581,7 +581,7 @@ SFStore::custom_metric_fns() {
             [&](const auto& dentry) {
               std::error_code ec;
               const auto target = std::filesystem::read_symlink(dentry, ec);
-              return !ec && (target == db_conn->get_storage().filename());
+              return !ec && (target == db_conn->get_storage()->filename());
             }
         );
         return std::make_tuple(

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -400,7 +400,7 @@ http::status SFSStatusPage::render(std::ostream& os) {
      << " locked=" << ceph_mutex_is_locked(sfs->buckets_map_lock) << "</li>\n";
   os << "</ul>\n";
 
-  auto db = sfs->db_conn->get_storage();
+  auto& db = sfs->db_conn->get_storage();
   sqlite3* sqlite_db = sfs->db_conn->first_sqlite_conn;
 
   os << "<h2>SQLite</h2>\n"

--- a/src/test/rgw/sfs/test_rgw_sfs_concurrency.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_concurrency.cc
@@ -51,7 +51,7 @@ PerfHistogramCommon::axis_config_d perfcounter_exec_time_config{
 
 struct SFSConcurrencyFixture {
   CephContext* cct;
-  sqlite::Storage storage;
+  sqlite::Storage& storage;
   rgw::sal::SFStore* store;
   Bucket* predef_bucket;
   Object* predef_object;
@@ -192,7 +192,7 @@ class TestSFSConcurrency
     );
   }
 
-  sqlite::Storage storage() { return dbconn->get_storage(); }
+  sqlite::Storage& storage() { return dbconn->get_storage(); }
 };
 
 TEST_P(TestSFSConcurrency, parallel_executions_must_not_throw) {

--- a/src/test/rgw/sfs/test_rgw_sfs_concurrency.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_concurrency.cc
@@ -51,7 +51,7 @@ PerfHistogramCommon::axis_config_d perfcounter_exec_time_config{
 
 struct SFSConcurrencyFixture {
   CephContext* cct;
-  sqlite::Storage& storage;
+  sqlite::StorageRef storage;
   rgw::sal::SFStore* store;
   Bucket* predef_bucket;
   Object* predef_object;
@@ -189,7 +189,7 @@ class TestSFSConcurrency
     );
   }
 
-  sqlite::Storage& storage() { return store->db_conn->get_storage(); }
+  sqlite::StorageRef storage() { return store->db_conn->get_storage(); }
 };
 
 TEST_P(TestSFSConcurrency, parallel_executions_must_not_throw) {

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -182,11 +182,11 @@ class TestSFSGC : public ::testing::Test {
   ) {
     SQLiteMultipart db_multiparts(conn);
     rgw::sal::sfs::sqlite::DBMultipartPart mp;
-    auto& storage = conn->get_storage();
+    auto storage = conn->get_storage();
     mp.upload_id = upload_id;
     mp.part_num = part_num;
     mp.size = 123;
-    const int id = storage.insert(mp);
+    const int id = storage->insert(mp);
     storeRandomPart(uuid, id);
     return mp;
   }

--- a/src/test/rgw/sfs/test_rgw_sfs_gc.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_gc.cc
@@ -182,7 +182,7 @@ class TestSFSGC : public ::testing::Test {
   ) {
     SQLiteMultipart db_multiparts(conn);
     rgw::sal::sfs::sqlite::DBMultipartPart mp;
-    auto storage = conn->get_storage();
+    auto& storage = conn->get_storage();
     mp.upload_id = upload_id;
     mp.part_num = part_num;
     mp.size = 123;

--- a/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
@@ -84,10 +84,10 @@ class TestSFSObjectStateMachine : public ::testing::Test {
 
   fs::path getDBFullPath() const { return getDBFullPath(getTestDir()); }
   sqlite::DBConnRef dbconn() { return store->db_conn; }
-  sqlite::Storage& storage() { return dbconn()->get_storage(); }
+  sqlite::StorageRef storage() { return dbconn()->get_storage(); }
   ObjectState database_object_state(ObjectRef obj) {
     return storage()
-        .select(
+        ->select(
             &sqlite::DBVersionedObject::object_state,
             sqlite_orm::where(sqlite_orm::is_equal(
                 &sqlite::DBVersionedObject::id, obj->version_id
@@ -97,7 +97,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
   }
   VersionType database_version_type(ObjectRef obj) {
     return storage()
-        .select(
+        ->select(
             &sqlite::DBVersionedObject::version_type,
             sqlite_orm::where(sqlite_orm::is_equal(
                 &sqlite::DBVersionedObject::id, obj->version_id
@@ -107,7 +107,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
   }
   int database_number_of_versions(ObjectRef obj) {
     return storage()
-        .select(
+        ->select(
             sqlite_orm::count(),
             sqlite_orm::where(sqlite_orm::is_equal(
                 &sqlite::DBVersionedObject::object_id, obj->path.get_uuid()
@@ -116,7 +116,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
         .back();
   }
   auto database_get_versions_as_id_type_state(ObjectRef obj) {
-    return storage().select(
+    return storage()->select(
         sqlite_orm::columns(
             &sqlite::DBVersionedObject::version_id,
             &sqlite::DBVersionedObject::version_type,

--- a/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
@@ -84,7 +84,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
 
   fs::path getDBFullPath() const { return getDBFullPath(getTestDir()); }
   sqlite::DBConnRef dbconn() { return std::make_shared<sqlite::DBConn>(cct); }
-  sqlite::Storage storage() { return dbconn()->get_storage(); }
+  sqlite::Storage& storage() { return dbconn()->get_storage(); }
   ObjectState database_object_state(ObjectRef obj) {
     return storage()
         .select(

--- a/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
@@ -83,7 +83,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
   }
 
   fs::path getDBFullPath() const { return getDBFullPath(getTestDir()); }
-  sqlite::DBConnRef dbconn() { return std::make_shared<sqlite::DBConn>(cct); }
+  sqlite::DBConnRef dbconn() { return store->db_conn; }
   sqlite::Storage& storage() { return dbconn()->get_storage(); }
   ObjectState database_object_state(ObjectRef obj) {
     return storage()

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -191,23 +191,23 @@ void createDBBucketBasic(
     const std::string& user, const std::string& name,
     const std::string& bucket_id, const std::shared_ptr<DBConn>& conn
 ) {
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
   DBBucket db_bucket;
   db_bucket.bucket_name = name;
   db_bucket.bucket_id = bucket_id;
   db_bucket.owner_id = user;
   db_bucket.deleted = false;
-  storage.replace(db_bucket);
+  storage->replace(db_bucket);
 }
 
 void deleteDBBucketBasic(
     const std::string& bucket_id, const std::shared_ptr<DBConn>& conn
 ) {
-  auto& storage = conn->get_storage();
-  auto bucket = storage.get_pointer<DBBucket>(bucket_id);
+  auto storage = conn->get_storage();
+  auto bucket = storage->get_pointer<DBBucket>(bucket_id);
   ASSERT_TRUE(bucket != nullptr);
   bucket->deleted = true;
-  storage.replace(*bucket);
+  storage->replace(*bucket);
 }
 
 TEST_F(TestSFSSQLiteBuckets, CreateAndGet) {
@@ -490,7 +490,7 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   createUser("usertest", conn);
 
   SQLiteBuckets db_buckets(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBBucket db_bucket;
   db_bucket.bucket_name = "test_storage";
@@ -498,9 +498,9 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   db_bucket.bucket_id = "test_storage_id";
 
   // we have to use replace because the primary key of rgw_bucket is a string
-  storage.replace(db_bucket);
+  storage->replace(db_bucket);
 
-  auto bucket = storage.get_pointer<DBBucket>("test_storage_id");
+  auto bucket = storage->get_pointer<DBBucket>("test_storage_id");
 
   ASSERT_NE(bucket, nullptr);
   ASSERT_EQ(bucket->bucket_name, "test_storage");
@@ -518,7 +518,7 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   auto db_bucket_2 = get_db_bucket(rgw_bucket_2);
 
   // we have to use replace because the primary key of rgw_bucket is a string
-  storage.replace(db_bucket_2);
+  storage->replace(db_bucket_2);
 
   // now use the SqliteBuckets method, so user is already converted
   auto ret_bucket = db_buckets.get_bucket("BucketID1");
@@ -536,7 +536,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketForNonExistingUser) {
   createUser("usertest", conn);
 
   SQLiteBuckets db_buckets(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBBucket db_bucket;
   db_bucket.bucket_name = "test_storage";
@@ -545,7 +545,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketForNonExistingUser) {
   EXPECT_THROW(
       {
         try {
-          storage.replace(db_bucket);
+          storage->replace(db_bucket);
           ;
         } catch (const std::system_error& e) {
           EXPECT_STREQ(
@@ -568,7 +568,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketOwnerNotSet) {
   createUser("usertest", conn);
 
   SQLiteBuckets db_buckets(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBBucket db_bucket;
   db_bucket.bucket_name = "test_storage";
@@ -576,7 +576,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketOwnerNotSet) {
   EXPECT_THROW(
       {
         try {
-          storage.replace(db_bucket);
+          storage->replace(db_bucket);
         } catch (const std::system_error& e) {
           EXPECT_STREQ(
               "FOREIGN KEY constraint failed: constraint failed", e.what()

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -191,7 +191,7 @@ void createDBBucketBasic(
     const std::string& user, const std::string& name,
     const std::string& bucket_id, const std::shared_ptr<DBConn>& conn
 ) {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   DBBucket db_bucket;
   db_bucket.bucket_name = name;
   db_bucket.bucket_id = bucket_id;
@@ -203,7 +203,7 @@ void createDBBucketBasic(
 void deleteDBBucketBasic(
     const std::string& bucket_id, const std::shared_ptr<DBConn>& conn
 ) {
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
   auto bucket = storage.get_pointer<DBBucket>(bucket_id);
   ASSERT_TRUE(bucket != nullptr);
   bucket->deleted = true;
@@ -490,7 +490,7 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   createUser("usertest", conn);
 
   SQLiteBuckets db_buckets(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBBucket db_bucket;
   db_bucket.bucket_name = "test_storage";
@@ -536,7 +536,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketForNonExistingUser) {
   createUser("usertest", conn);
 
   SQLiteBuckets db_buckets(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBBucket db_bucket;
   db_bucket.bucket_name = "test_storage";
@@ -568,7 +568,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketOwnerNotSet) {
   createUser("usertest", conn);
 
   SQLiteBuckets db_buckets(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBBucket db_bucket;
   db_bucket.bucket_name = "test_storage";

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
@@ -105,7 +105,7 @@ class TestSFSList : public ::testing::Test {
   }
 
   void dump_db() {
-    auto storage = dbconn->get_storage();
+    auto& storage = dbconn->get_storage();
     lderr(cct.get()) << "Dumping objects:" << dendl;
     for (const auto& row : storage.get_all<DBObject>()) {
       lderr(cct.get()) << row << dendl;

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
@@ -40,7 +40,6 @@ class TestSFSList : public ::testing::Test {
   const fs::path database_directory;
 
   std::unique_ptr<rgw::sal::SFStore> store;
-  DBConnRef dbconn;
 
   TestSFSList()
       : cct(new CephContext(CEPH_ENTITY_TYPE_ANY)),
@@ -52,16 +51,15 @@ class TestSFSList : public ::testing::Test {
   }
   void SetUp() override {
     ASSERT_TRUE(fs::exists(database_directory)) << database_directory;
-    dbconn = std::make_shared<DBConn>(cct.get());
     store.reset(new rgw::sal::SFStore(cct.get(), database_directory));
 
-    SQLiteUsers users(dbconn);
+    SQLiteUsers users(store->db_conn);
     DBOPUserInfo user;
     user.uinfo.user_id.id = "testuser";
     user.uinfo.display_name = "display_name";
     users.store_user(user);
 
-    SQLiteBuckets db_buckets(dbconn);
+    SQLiteBuckets db_buckets(store->db_conn);
     DBOPBucketInfo db_binfo;
     db_binfo.binfo.bucket = rgw_bucket("", "testbucket", "testbucket");
     db_binfo.binfo.owner = rgw_user("testuser");
@@ -77,7 +75,6 @@ class TestSFSList : public ::testing::Test {
       dump_db();
     }
     store.reset();
-    dbconn.reset();
     fs::remove_all(database_directory);
   }
 
@@ -95,17 +92,17 @@ class TestSFSList : public ::testing::Test {
     std::string name(prefix);
     name.append(gen_rand_alphanumeric(cct.get(), 23));
     const auto obj = create_test_object("testbucket", name);
-    SQLiteObjects os(dbconn);
+    SQLiteObjects os(store->db_conn);
     os.store_object(obj);
     auto ver = create_test_versionedobject(obj.uuid, "testversion");
     ver.object_state = version_state;
-    SQLiteVersionedObjects vos(dbconn);
+    SQLiteVersionedObjects vos(store->db_conn);
     vos.insert_versioned_object(ver);
     return std::make_pair(obj, ver);
   }
 
   void dump_db() {
-    auto& storage = dbconn->get_storage();
+    auto& storage = store->db_conn->get_storage();
     lderr(cct.get()) << "Dumping objects:" << dendl;
     for (const auto& row : storage.get_all<DBObject>()) {
       lderr(cct.get()) << row << dendl;
@@ -122,7 +119,7 @@ class TestSFSList : public ::testing::Test {
     return e;
   }
 
-  SQLiteList make_uut() { return SQLiteList(dbconn); }
+  SQLiteList make_uut() { return SQLiteList(store->db_conn); }
 };
 
 class TestSFSListObjectsAndVersions
@@ -308,7 +305,7 @@ TEST_F(TestSFSList, objects__does_not_return_objects_with_delete_marker) {
   auto del = create_test_versionedobject(oov.first.uuid, "deletemarker");
   del.object_state = rgw::sal::sfs::ObjectState::COMMITTED;
   del.version_type = rgw::sal::sfs::VersionType::DELETE_MARKER;
-  SQLiteVersionedObjects vos(dbconn);
+  SQLiteVersionedObjects vos(store->db_conn);
   vos.insert_versioned_object(del);
 
   ASSERT_TRUE(uut.objects("testbucket", "", "", 1000, results));
@@ -333,7 +330,7 @@ TEST_F(TestSFSList, versions__returns_versions_and_delete_markers) {
   auto del = create_test_versionedobject(oov.first.uuid, "deletemarker");
   del.object_state = rgw::sal::sfs::ObjectState::COMMITTED;
   del.version_type = rgw::sal::sfs::VersionType::DELETE_MARKER;
-  SQLiteVersionedObjects vos(dbconn);
+  SQLiteVersionedObjects vos(store->db_conn);
   vos.insert_versioned_object(del);
 
   ASSERT_TRUE(uut.versions("testbucket", "", "", 1000, results));
@@ -350,8 +347,8 @@ TEST_F(TestSFSList, versions__correctly_sorts_and_marks_latest_version) {
   std::vector<rgw_bucket_dir_entry> results;
 
   const auto obj = create_test_object("testbucket", "obj");
-  SQLiteObjects os(dbconn);
-  SQLiteVersionedObjects vos(dbconn);
+  SQLiteObjects os(store->db_conn);
+  SQLiteVersionedObjects vos(store->db_conn);
   os.store_object(obj);
   auto latest = create_test_versionedobject(obj.uuid, "latest");
   latest.object_state = rgw::sal::sfs::ObjectState::COMMITTED;
@@ -385,8 +382,8 @@ TEST_F(TestSFSList, versions__there_is_latest_with_multiple_versions) {
 
   const auto obj1 = create_test_object("testbucket", "test1/a");
   const auto obj2 = create_test_object("testbucket", "test2/abc");
-  SQLiteObjects os(dbconn);
-  SQLiteVersionedObjects vos(dbconn);
+  SQLiteObjects os(store->db_conn);
+  SQLiteVersionedObjects vos(store->db_conn);
   os.store_object(obj1);
   os.store_object(obj2);
   std::array<rgw::sal::sfs::sqlite::DBVersionedObject, 3> vers_obj1 = {
@@ -434,8 +431,8 @@ TEST_F(TestSFSList, versions__only_one_latest) {
   std::vector<rgw_bucket_dir_entry> results;
 
   const auto obj = create_test_object("testbucket", "test1/a");
-  SQLiteObjects os(dbconn);
-  SQLiteVersionedObjects vos(dbconn);
+  SQLiteObjects os(store->db_conn);
+  SQLiteVersionedObjects vos(store->db_conn);
   os.store_object(obj);
   auto vo1 = create_test_versionedobject(
       obj.uuid, gen_rand_alphanumeric(cct.get(), 23)
@@ -464,8 +461,8 @@ TEST_F(TestSFSList, versions__delete_marker_latest) {
   std::vector<rgw_bucket_dir_entry> results;
 
   const auto obj = create_test_object("testbucket", "test1/a");
-  SQLiteObjects os(dbconn);
-  SQLiteVersionedObjects vos(dbconn);
+  SQLiteObjects os(store->db_conn);
+  SQLiteVersionedObjects vos(store->db_conn);
   os.store_object(obj);
   auto vo1 = create_test_versionedobject(
       obj.uuid, gen_rand_alphanumeric(cct.get(), 23)

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
@@ -102,13 +102,13 @@ class TestSFSList : public ::testing::Test {
   }
 
   void dump_db() {
-    auto& storage = store->db_conn->get_storage();
+    auto storage = store->db_conn->get_storage();
     lderr(cct.get()) << "Dumping objects:" << dendl;
-    for (const auto& row : storage.get_all<DBObject>()) {
+    for (const auto& row : storage->get_all<DBObject>()) {
       lderr(cct.get()) << row << dendl;
     }
     lderr(cct.get()) << "Dumping versioned objects:" << dendl;
-    for (const auto& row : storage.get_all<DBVersionedObject>()) {
+    for (const auto& row : storage->get_all<DBVersionedObject>()) {
       lderr(cct.get()) << row << dendl;
     }
   }

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
@@ -256,7 +256,7 @@ TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
   createBucket("usertest", "test_bucket", conn);
 
   SQLiteObjects db_objects(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBObject db_object;
 

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
@@ -256,7 +256,7 @@ TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
   createBucket("usertest", "test_bucket", conn);
 
   SQLiteObjects db_objects(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBObject db_object;
 
@@ -268,7 +268,7 @@ TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
   EXPECT_THROW(
       {
         try {
-          storage.replace(db_object);
+          storage->replace(db_object);
           ;
         } catch (const std::system_error& e) {
           EXPECT_STREQ(

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -330,7 +330,7 @@ TEST_F(TestSFSSQLiteUsers, UseStorage) {
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   SQLiteUsers db_users(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBUser db_user;
   db_user.user_id = "test_storage";

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -330,15 +330,15 @@ TEST_F(TestSFSSQLiteUsers, UseStorage) {
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   SQLiteUsers db_users(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBUser db_user;
   db_user.user_id = "test_storage";
 
   // we have to use replace because the primary key of rgw_user is a string
-  storage.replace(db_user);
+  storage->replace(db_user);
 
-  auto user = storage.get_pointer<DBUser>("test_storage");
+  auto user = storage->get_pointer<DBUser>("test_storage");
 
   ASSERT_NE(user, nullptr);
   ASSERT_EQ(user->user_id, "test_storage");
@@ -354,7 +354,7 @@ TEST_F(TestSFSSQLiteUsers, UseStorage) {
   auto db_user_2 = get_db_user(rgw_user_2);
 
   // we have to use replace because the primary key of rgw_user is a string
-  storage.replace(db_user_2);
+  storage->replace(db_user_2);
 
   // now use the SqliteUsers method, so user is already converted
   auto ret_user = db_users.get_user("test1");

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -457,7 +457,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateObjectForNonExistingBucket) {
   );
 
   SQLiteVersionedObjects db_objects(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBVersionedObject db_object;
 
@@ -749,7 +749,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreUnsupportedTimestamp) {
   );
 
   SQLiteVersionedObjects db_versions(conn);
-  auto storage = conn->get_storage();
+  auto& storage = conn->get_storage();
 
   DBVersionedObject db_version;
 

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -457,7 +457,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateObjectForNonExistingBucket) {
   );
 
   SQLiteVersionedObjects db_objects(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBVersionedObject db_object;
 
@@ -471,7 +471,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateObjectForNonExistingBucket) {
   EXPECT_THROW(
       {
         try {
-          storage.replace(db_object);
+          storage->replace(db_object);
           ;
         } catch (const std::system_error& e) {
           EXPECT_STREQ(
@@ -749,7 +749,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreUnsupportedTimestamp) {
   );
 
   SQLiteVersionedObjects db_versions(conn);
-  auto& storage = conn->get_storage();
+  auto storage = conn->get_storage();
 
   DBVersionedObject db_version;
 
@@ -769,7 +769,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreUnsupportedTimestamp) {
   EXPECT_THROW(
       {
         try {
-          storage.replace(db_version);
+          storage->replace(db_version);
           ;
         } catch (const std::system_error& e) {
           EXPECT_STREQ(

--- a/src/test/rgw/sfs/test_rgw_sfs_wal_checkpoint.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_wal_checkpoint.cc
@@ -103,61 +103,41 @@ class TestSFSWALCheckpoint : public ::testing::Test {
   }
 };
 
-// This test checks whether SQLite's default checkpoint
-// mechanism suffers from the WAL growth problem.
-TEST_F(TestSFSWALCheckpoint, test_default_wal_checkpoint) {
+// This test proves that we have a problem with WAL growth.
+// If this test ever *fails* it means the WAL growth problem
+// has been unexpectedly fixed by some other change that
+// doesn't involve our SFS checkpoint mechanism.
+TEST_F(TestSFSWALCheckpoint, confirm_wal_explosion) {
   cct->_conf.set_val("rgw_sfs_wal_checkpoint_use_sqlite_default", "true");
   cct->_conf.set_val("rgw_sfs_wal_size_limit", "-1");
   init_store();
 
-  // Prior to the change to use only a single DB connection,
-  // 10 concurrent writer threads would easily push us past
-  // 500MB.  Since using only a single connection the problem
-  // goes away and we should never go over about 4MB (we're
-  // allowing up to 5MB here for a bit of wiggle room).
+  // Using the SQLite default checkpointing mechanism with
+  // 10 concurrent writer threads will easily push us past
+  // 500MB quite quickly.
   std::uintmax_t max_wal_size = multithread_object_create(10, 1000);
-  EXPECT_LE(max_wal_size, SIZE_1MB * 5);
+  EXPECT_GT(max_wal_size, SIZE_1MB * 500);
 
   // The fact that we have no size limit set means the WAL
   // won't be truncated even when the last writer completes,
-  // so the file size now should be the same as the maximum
-  // size it reached during the above write operation.
+  // so it should *still* be huge now.
   EXPECT_EQ(fs::file_size(test_dir / "s3gw.db-wal"), max_wal_size);
 }
 
-// This test proves that our SFS checkpoint mechanism works
-// the same as the default checkpoint mechanism, but that the
-// WAL is truncated to 4MB by default.
-TEST_F(TestSFSWALCheckpoint, test_sfs_wal_checkpoint) {
+// This test proves the WAL growth problem has been fixed
+// by our SFS checkpoint mechanism.
+TEST_F(TestSFSWALCheckpoint, test_wal_checkpoint) {
   init_store();
 
-  // As with the default checkpoint mechanism, this can go
-  // over 4MB, but shouldn't go over by much (hence the 5MB
-  // limit)
+  // Using our SFS checkpoint mechanism, the WAL may exceed
+  // 16MB while writing, because the trunacte checkpoints
+  // don't always succeed, but it shouldn't go over by much.
+  // We're allowing 32MB here for some extra wiggle room
+  // just in case.
   std::uintmax_t max_wal_size = multithread_object_create(10, 1000);
-  EXPECT_LT(max_wal_size, SIZE_1MB * 5);
+  EXPECT_LT(max_wal_size, SIZE_1MB * 32);
 
   // Once the writes are all done, the WAL should be finally
-  // truncated to 4MB or less
-  EXPECT_LE(fs::file_size(test_dir / "s3gw.db-wal"), SIZE_1MB * 4);
-}
-
-// This test proves that our SFS checkpoint mechanism can let
-// the WAL get bigger than 4MB if configured to do so, but that
-// it's still ultimately truncated eventually.
-TEST_F(TestSFSWALCheckpoint, test_sfs_wal_checkpoint_16mb) {
-  cct->_conf.set_val("rgw_sfs_wal_checkpoint_passive_frames", "4000");
-  init_store();
-
-  // Given we're checkpointing at 4000 frames (16MB), the WAL will
-  // surely grow to at least somewhere near that size before being
-  // checkpointed.
-  std::uintmax_t max_wal_size = multithread_object_create(10, 1000);
-  EXPECT_GE(max_wal_size, SIZE_1MB * 12);
-
-  // Once the writes are all done, the WAL should be finally
-  // either truncated to to 4MB, or be less than 16MB (in case it
-  // truncated part way through the write operation, but didn't get
-  // up to the 16MB limit again yet before we finished).
+  // truncated to something less than 16MB.
   EXPECT_LT(fs::file_size(test_dir / "s3gw.db-wal"), SIZE_1MB * 16);
 }

--- a/src/test/rgw/sfs/test_rgw_sfs_wal_checkpoint.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_wal_checkpoint.cc
@@ -114,9 +114,9 @@ TEST_F(TestSFSWALCheckpoint, confirm_wal_explosion) {
 
   // Using the SQLite default checkpointing mechanism with
   // 10 concurrent writer threads will easily push us past
-  // 500MB quite quickly.
+  // a few hundred megabytes quite quickly.
   std::uintmax_t max_wal_size = multithread_object_create(10, 1000);
-  EXPECT_GT(max_wal_size, SIZE_1MB * 500);
+  EXPECT_GT(max_wal_size, SIZE_1MB * 300);
 
   // The fact that we have no size limit set means the WAL
   // won't be truncated even when the last writer completes,


### PR DESCRIPTION
Currently there is one long lived connection to the sqlite database, but also many other threads use their own connections (for some analysis of this, see https://github.com/aquarist-labs/ceph/pull/201).

This PR changes all the copies of the storage object to references, which means we're actually only using one db connection now.  It's a bit irritating to do this, because it's way too easy to accidentally make a copy if you leave the '&' off :-/  I'd really want to somehow disable copy construction of the Storage object, but I didn't figure out how to do that yet.

One interesting effect of this change is that, prior to this commit, the SFS status page only showed SQLite stats for the connection from the status thread, which is not overly helpful.  With this commit (all threads using the same connection), the figures from the SQLite stats will actually change over time while s3gw is being used.

Note that as we're building with -DSQLITE_THREADSAFE=1, i.e. we're using Serialized mode, it's totally cool to have one connection shared by multiple threads (see https://www.sqlite.org/threadsafe.html)
