### PR TITLE
rgw/sfs: testing: destroy dbconn and store before removing db dir

### DIFF
--- a/src/test/rgw/sfs/test_rgw_sfs_concurrency.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_concurrency.cc
@@ -124,7 +124,11 @@ class TestSFSConcurrency
     cct->get_perfcounters_collection()->add(perfcounter_exec_time_sum);
   }
 
-  void TearDown() override { fs::remove_all(database_directory); }
+  void TearDown() override {
+    store.reset();
+    dbconn.reset();
+    fs::remove_all(database_directory);
+  }
 
   fs::path create_database_directory() const {
     const std::string rand = gen_rand_alphanumeric(cct.get(), 23);

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_list.cc
@@ -76,6 +76,8 @@ class TestSFSList : public ::testing::Test {
     if (::testing::Test::HasFailure()) {
       dump_db();
     }
+    store.reset();
+    dbconn.reset();
     fs::remove_all(database_directory);
   }
 


### PR DESCRIPTION
`TestSFSConcurrency` and `TestSFSList` both keep pointers to a `sqlite::DBConnRef` and a `rgw::sal::SFStore`.  The `TearDown()` method deletes the database directory while these objects still exist, and then later when they're automatically destroyed, we see the following output when running the unit tests:
```
[SQLITE] (28) file unlinked while open: /tmp/8kGFAz3iWQxhP9SR6oTflAF/s3gw.db
[SQLITE] (28) file unlinked while open: /tmp/8kGFAz3iWQxhP9SR6oTflAF/s3gw.db
```
This happens many times (twice for each test for each of those classes).  If we reset the pointers before removing the database directory, the objects are destroyed in advance and the errors go away.
