### PR TITLE
rgw/sfs: Fix multipart etag in response

### DIFF
--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -495,6 +495,9 @@ int SFSMultipartUploadV2::complete(
   }
 
   objref->update_attrs(mp->attrs);
+  bufferlist etag_bl;
+  etag_bl.append(etag.c_str(), etag.size());
+  objref->set_attr(RGW_ATTR_ETAG, etag_bl);
   objref->update_meta(
       {.size = accounted_bytes,
        .etag = etag,


### PR DESCRIPTION
This fixes the problem found when downloading a multipart object with s3cmd because the `etag` was not populated in the response.

It also happened with `aws cli` tool, but in that case the tool was not showing any error, just that the `ETag` field was not set in the response.

When creating the final object, the `etag` should be also set in the object's attributes, because when filling the response for `RGWGetObj` it iterates through the attributes to fill the response.

non-multipart uploads had the `etag` already in the attributes, that's why it was working fine in that case.

Fixes: https://github.com/aquarist-labs/s3gw/issues/658



## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

