### PR TITLE
rgw/sfs: Calculate multipart etag based on its parts

### DIFF
--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -282,6 +282,7 @@ int SFSMultipartUploadV2::complete(
           << dendl;
       return -ERR_INVALID_PART;
     }
+    hash.update(etag);
 
     if ((part.size < 5 * 1024 * 1024) &&
         (std::distance(it, part_etags.cend()) > 1)) {


### PR DESCRIPTION
This fixes the issue with multipart etags by updating the multipart hash for every part.

Now etags for multiparts should be following the `md5-num_parts` format.

Fixes: https://github.com/aquarist-labs/s3gw/issues/721
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

