### PR TITLE
rgw/sfs: GC: reorder SFSGC::process() so buckets are GC'd last

### DIFF
--- a/src/rgw/driver/sfs/sfs_gc.cc
+++ b/src/rgw/driver/sfs/sfs_gc.cc
@@ -60,6 +60,19 @@ int SFSGC::process() {
     );
     return 0;
   }
+
+  // process done or aborted multiparts
+  time_to_process_more = process_done_and_aborted_multiparts();
+  if (!time_to_process_more) {
+    perfcounter->set(
+        l_rgw_sfs_gc_process_exit,
+        static_cast<uint64_t>(
+            sfs_gc_process_exit_state::process_done_and_aborted_multiparts
+        )
+    );
+    return 0;
+  }
+
   // now delete possible pending multiparts data
   time_to_process_more = delete_pending_multiparts_data();
   if (!time_to_process_more) {
@@ -71,16 +84,7 @@ int SFSGC::process() {
     );
     return 0;
   }
-  // process deleted buckets
-  time_to_process_more = process_deleted_buckets();
-  if (!time_to_process_more) {
-    perfcounter->set(
-        l_rgw_sfs_gc_process_exit,
-        static_cast<uint64_t>(sfs_gc_process_exit_state::process_deleted_buckets
-        )
-    );
-    return 0;
-  }
+
   // process deleted objects
   time_to_process_more = process_deleted_objects();
   if (!time_to_process_more) {
@@ -92,8 +96,17 @@ int SFSGC::process() {
     return 0;
   }
 
-  // process done or aborted multiparts
-  time_to_process_more = process_done_and_aborted_multiparts();
+  // process deleted buckets
+  time_to_process_more = process_deleted_buckets();
+  if (!time_to_process_more) {
+    perfcounter->set(
+        l_rgw_sfs_gc_process_exit,
+        static_cast<uint64_t>(sfs_gc_process_exit_state::process_deleted_buckets
+        )
+    );
+    return 0;
+  }
+
   perfcounter->set(
       l_rgw_sfs_gc_process_exit,
       static_cast<uint64_t>(sfs_gc_process_exit_state::finished)

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -45,8 +45,8 @@ std::ostream& operator<<(std::ostream& os, sfs_gc_process_exit_state state) {
     case sfs_gc_process_exit_state::process_deleted_objects:
       os << "process_deleted_objects";
       break;
-    case sfs_gc_process_exit_state::finished:
-      os << "finished";
+    case sfs_gc_process_exit_state::process_done_and_aborted_multiparts:
+      os << "process_done_and_aborted_multiparts";
       break;
     default:
       os << "unknown";

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -92,6 +92,7 @@ enum class sfs_gc_process_exit_state : int {
   delete_pending_multiparts_data,
   process_deleted_buckets,
   process_deleted_objects,
+  process_done_and_aborted_multiparts,
   finished,
 };
 


### PR DESCRIPTION
This partially fixes https://github.com/aquarist-labs/s3gw/issues/719 by garbage collecting done and aborted multiparts, and objects, before trying to garbage collect buckets (if we do buckets earlier, we hit foreign key violations if there's still multiparts or objects hanging around).
