### PR TITLE
rgw/sfs: testing: always call _log->start() on CephContext

### DIFF
--- a/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
@@ -66,6 +66,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
   }
 
   void TearDown() override {
+    store.reset();
     fs::current_path(fs::temp_directory_path());
     fs::remove_all(TEST_DIR);
   }

--- a/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_object_state_machine.cc
@@ -41,6 +41,7 @@ class TestSFSObjectStateMachine : public ::testing::Test {
   void SetUp() override {
     cct = (new CephContext(CEPH_ENTITY_TYPE_ANY))->get();
     cct->_conf.set_val("rgw_sfs_data_path", getTestDir());
+    cct->_log->start();
     fs::current_path(fs::temp_directory_path());
     fs::create_directory(TEST_DIR);
     store.reset(new rgw::sal::SFStore(cct, getTestDir()));

--- a/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sfs_bucket.cc
@@ -149,6 +149,7 @@ void compareListEntry(
 TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -230,6 +231,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromCreate) {
 TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromStore) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -310,6 +312,7 @@ TEST_F(TestSFSBucket, UserCreateBucketCheckGotFromStore) {
 TEST_F(TestSFSBucket, BucketSetAcl) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -392,6 +395,7 @@ TEST_F(TestSFSBucket, BucketSetAcl) {
 TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -484,6 +488,7 @@ TEST_F(TestSFSBucket, BucketMergeAndStoreAttrs) {
 TEST_F(TestSFSBucket, DeleteBucket) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -621,6 +626,7 @@ TEST_F(TestSFSBucket, DeleteBucket) {
 TEST_F(TestSFSBucket, TestListObjectsAndVersions) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -837,6 +843,7 @@ TEST_F(TestSFSBucket, TestListObjectsAndVersions) {
 TEST_F(TestSFSBucket, TestListObjectsDelimiter) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -1058,6 +1065,7 @@ TEST_F(TestSFSBucket, TestListObjectsDelimiter) {
 TEST_F(TestSFSBucket, TestListObjectVersionsDelimiter) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -1283,6 +1291,7 @@ TEST_F(TestSFSBucket, TestListObjectVersionsDelimiter) {
 TEST_F(TestSFSBucket, UserCreateBucketObjectLockEnabled) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -1356,6 +1365,7 @@ TEST_F(TestSFSBucket, UserCreateBucketObjectLockEnabled) {
 TEST_F(TestSFSBucket, ListNamespaceMultipartsBasics) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);

--- a/src/test/rgw/sfs/test_rgw_sfs_sfs_user.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sfs_user.cc
@@ -160,6 +160,7 @@ void compareUsers(
 TEST_F(TestSFSUser, ListBuckets) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -273,6 +274,7 @@ TEST_F(TestSFSUser, ListBuckets) {
 TEST_F(TestSFSUser, LoadUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -298,6 +300,7 @@ TEST_F(TestSFSUser, LoadUser) {
 TEST_F(TestSFSUser, LoadUserDoesNotExist) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -311,6 +314,7 @@ TEST_F(TestSFSUser, LoadUserDoesNotExist) {
 TEST_F(TestSFSUser, StoreUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -355,6 +359,7 @@ TEST_F(TestSFSUser, StoreUser) {
 TEST_F(TestSFSUser, StoreUserVersionMismatch) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);
@@ -374,6 +379,7 @@ TEST_F(TestSFSUser, StoreUserVersionMismatch) {
 TEST_F(TestSFSUser, RemoveUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store = new rgw::sal::SFStore(ceph_context.get(), getTestDir());
 
   NoDoutPrefix ndp(ceph_context.get(), 1);

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_buckets.cc
@@ -213,6 +213,7 @@ void deleteDBBucketBasic(
 TEST_F(TestSFSSQLiteBuckets, CreateAndGet) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -233,6 +234,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateAndGet) {
 TEST_F(TestSFSSQLiteBuckets, ListBucketsIDs) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -257,6 +259,7 @@ TEST_F(TestSFSSQLiteBuckets, ListBucketsIDs) {
 TEST_F(TestSFSSQLiteBuckets, ListBuckets) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -285,6 +288,7 @@ TEST_F(TestSFSSQLiteBuckets, ListBuckets) {
 TEST_F(TestSFSSQLiteBuckets, ListBucketsByOwner) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -328,6 +332,7 @@ TEST_F(TestSFSSQLiteBuckets, ListBucketsByOwner) {
 TEST_F(TestSFSSQLiteBuckets, ListBucketsIDsPerUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -370,6 +375,7 @@ TEST_F(TestSFSSQLiteBuckets, ListBucketsIDsPerUser) {
 TEST_F(TestSFSSQLiteBuckets, remove_bucket) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -396,6 +402,7 @@ TEST_F(TestSFSSQLiteBuckets, remove_bucket) {
 TEST_F(TestSFSSQLiteBuckets, RemoveUserThatDoesNotExist) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -420,6 +427,7 @@ TEST_F(TestSFSSQLiteBuckets, RemoveUserThatDoesNotExist) {
 TEST_F(TestSFSSQLiteBuckets, CreateAndUpdate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -447,6 +455,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateAndUpdate) {
 TEST_F(TestSFSSQLiteBuckets, GetExisting) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -473,6 +482,7 @@ TEST_F(TestSFSSQLiteBuckets, GetExisting) {
 TEST_F(TestSFSSQLiteBuckets, UseStorage) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
 
@@ -519,6 +529,7 @@ TEST_F(TestSFSSQLiteBuckets, UseStorage) {
 TEST_F(TestSFSSQLiteBuckets, CreateBucketForNonExistingUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   // Create the user, we need it because OwnerID is a foreign key of User::UserID
@@ -550,6 +561,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketForNonExistingUser) {
 TEST_F(TestSFSSQLiteBuckets, CreateBucketOwnerNotSet) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   // Create the user, we need it because OwnerID is a foreign key of User::UserID
@@ -579,6 +591,7 @@ TEST_F(TestSFSSQLiteBuckets, CreateBucketOwnerNotSet) {
 TEST_F(TestSFSSQLiteBuckets, GetDeletedBucketsIds) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   // Create the user, we need it because OwnerID is a foreign key of User::UserID
@@ -619,6 +632,7 @@ TEST_F(TestSFSSQLiteBuckets, GetDeletedBucketsIds) {
 TEST_F(TestSFSSQLiteBuckets, TestBucketEmpty) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   // Create the user, we need it because OwnerID is a foreign key of User::UserID

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_lifecycle.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_lifecycle.cc
@@ -52,6 +52,7 @@ std::string getLCBucketName(const rgw::sal::sfs::sqlite::DBOPBucketInfo& bucket
 TEST_F(TestSFSSQLiteLifecycle, GetHeadFirstTime) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -67,6 +68,7 @@ TEST_F(TestSFSSQLiteLifecycle, GetHeadFirstTime) {
 TEST_F(TestSFSSQLiteLifecycle, StoreHead) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -84,6 +86,7 @@ TEST_F(TestSFSSQLiteLifecycle, StoreHead) {
 TEST_F(TestSFSSQLiteLifecycle, StoreDeleteHead) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -108,6 +111,7 @@ TEST_F(TestSFSSQLiteLifecycle, StoreDeleteHead) {
 TEST_F(TestSFSSQLiteLifecycle, StoreGetEntry) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -132,6 +136,7 @@ TEST_F(TestSFSSQLiteLifecycle, StoreGetEntry) {
 TEST_F(TestSFSSQLiteLifecycle, GetNextEntry) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -201,6 +206,7 @@ TEST_F(TestSFSSQLiteLifecycle, GetNextEntry) {
 TEST_F(TestSFSSQLiteLifecycle, ListEntries) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_objects.cc
@@ -120,6 +120,7 @@ DBVersionedObject createTestVersionedObject(
 TEST_F(TestSFSSQLiteObjects, CreateAndGet) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -141,6 +142,7 @@ TEST_F(TestSFSSQLiteObjects, CreateAndGet) {
 TEST_F(TestSFSSQLiteObjects, remove_object) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -165,6 +167,7 @@ TEST_F(TestSFSSQLiteObjects, remove_object) {
 TEST_F(TestSFSSQLiteObjects, remove_objectThatDoesNotExist) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -190,6 +193,7 @@ TEST_F(TestSFSSQLiteObjects, remove_objectThatDoesNotExist) {
 TEST_F(TestSFSSQLiteObjects, CreateAndUpdate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -217,6 +221,7 @@ TEST_F(TestSFSSQLiteObjects, CreateAndUpdate) {
 TEST_F(TestSFSSQLiteObjects, GetExisting) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -243,6 +248,7 @@ TEST_F(TestSFSSQLiteObjects, GetExisting) {
 TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
 
@@ -278,6 +284,7 @@ TEST_F(TestSFSSQLiteObjects, CreateObjectForNonExistingBucket) {
 TEST_F(TestSFSSQLiteObjects, GetObjectByBucketAndObjectName) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_users.cc
@@ -101,6 +101,7 @@ DBOPUserInfo createTestUser(const std::string& suffix) {
 TEST_F(TestSFSSQLiteUsers, CreateAndGet) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -118,6 +119,7 @@ TEST_F(TestSFSSQLiteUsers, CreateAndGet) {
 TEST_F(TestSFSSQLiteUsers, CreateAndGetByEmail) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -135,6 +137,7 @@ TEST_F(TestSFSSQLiteUsers, CreateAndGetByEmail) {
 TEST_F(TestSFSSQLiteUsers, CreateAndGetByAccessKey) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -152,6 +155,7 @@ TEST_F(TestSFSSQLiteUsers, CreateAndGetByAccessKey) {
 TEST_F(TestSFSSQLiteUsers, ListUserIDs) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -173,6 +177,7 @@ TEST_F(TestSFSSQLiteUsers, ListUserIDs) {
 TEST_F(TestSFSSQLiteUsers, RemoveUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -196,6 +201,7 @@ TEST_F(TestSFSSQLiteUsers, RemoveUser) {
 TEST_F(TestSFSSQLiteUsers, RemoveUserThatDoesNotExist) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -217,6 +223,7 @@ TEST_F(TestSFSSQLiteUsers, RemoveUserThatDoesNotExist) {
 TEST_F(TestSFSSQLiteUsers, CreateAndUpdate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -241,6 +248,7 @@ TEST_F(TestSFSSQLiteUsers, CreateAndUpdate) {
 TEST_F(TestSFSSQLiteUsers, GetExisting) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -264,6 +272,7 @@ TEST_F(TestSFSSQLiteUsers, GetExisting) {
 TEST_F(TestSFSSQLiteUsers, AddMoreThanOneUserWithSameEmail) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -288,6 +297,7 @@ TEST_F(TestSFSSQLiteUsers, AddMoreThanOneUserWithSameEmail) {
 TEST_F(TestSFSSQLiteUsers, AddMoreThanOneUserWithSameAccessKey) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -316,6 +326,7 @@ TEST_F(TestSFSSQLiteUsers, AddMoreThanOneUserWithSameAccessKey) {
 TEST_F(TestSFSSQLiteUsers, UseStorage) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
   SQLiteUsers db_users(conn);
@@ -356,6 +367,7 @@ TEST_F(TestSFSSQLiteUsers, UseStorage) {
 TEST_F(TestSFSSQLiteUsers, StoreListUsers) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -397,6 +409,7 @@ TEST_F(TestSFSSQLiteUsers, StoreListUsers) {
 TEST_F(TestSFSSQLiteUsers, StoreAddUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -429,6 +442,7 @@ TEST_F(TestSFSSQLiteUsers, StoreAddUser) {
 TEST_F(TestSFSSQLiteUsers, StoreLoadUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -454,6 +468,7 @@ TEST_F(TestSFSSQLiteUsers, StoreLoadUser) {
 TEST_F(TestSFSSQLiteUsers, StoreUpdateUserCheckOldInfo) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -503,6 +518,7 @@ TEST_F(TestSFSSQLiteUsers, StoreUpdateUserCheckOldInfo) {
 TEST_F(TestSFSSQLiteUsers, StoreUpdateUserCheckVersioning) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -555,6 +571,7 @@ TEST_F(TestSFSSQLiteUsers, StoreUpdateUserCheckVersioning) {
 TEST_F(TestSFSSQLiteUsers, StoreUpdateUserErrorVersioning) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -601,6 +618,7 @@ TEST_F(TestSFSSQLiteUsers, StoreUpdateUserErrorVersioning) {
 TEST_F(TestSFSSQLiteUsers, StoreRemoveUser) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto store =
       std::make_shared<rgw::sal::SFStore>(ceph_context.get(), getTestDir());
 
@@ -658,6 +676,7 @@ TEST_F(TestSFSSQLiteUsers, StoreRemoveUser) {
 TEST_F(TestSFSSQLiteUsers, GetByAccessKeyMultipleKeys) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());

--- a/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_sqlite_versioned_objects.cc
@@ -175,6 +175,7 @@ void compareVersionedObjects(
 TEST_F(TestSFSSQLiteVersionedObjects, CreateAndGet) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -205,6 +206,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateAndGet) {
 TEST_F(TestSFSSQLiteVersionedObjects, ListObjectsIDs) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -244,6 +246,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, ListObjectsIDs) {
 TEST_F(TestSFSSQLiteVersionedObjects, ListBucketsIDsPerObject) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -291,6 +294,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, ListBucketsIDsPerObject) {
 TEST_F(TestSFSSQLiteVersionedObjects, RemoveObject) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -323,6 +327,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, RemoveObject) {
 TEST_F(TestSFSSQLiteVersionedObjects, RemoveObjectThatDoesNotExist) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -356,6 +361,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, RemoveObjectThatDoesNotExist) {
 TEST_F(TestSFSSQLiteVersionedObjects, CreateAndUpdate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -411,6 +417,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateAndUpdate) {
 TEST_F(TestSFSSQLiteVersionedObjects, GetExisting) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -440,6 +447,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, GetExisting) {
 TEST_F(TestSFSSQLiteVersionedObjects, CreateObjectForNonExistingBucket) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
 
@@ -479,6 +487,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, CreateObjectForNonExistingBucket) {
 TEST_F(TestSFSSQLiteVersionedObjects, StoreCreatesNewVersions) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -538,6 +547,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreCreatesNewVersions) {
 TEST_F(TestSFSSQLiteVersionedObjects, GetLastVersion) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -582,6 +592,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, GetLastVersion) {
 TEST_F(TestSFSSQLiteVersionedObjects, GetLastVersionRepeatedCommitTime) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -644,6 +655,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, GetLastVersionRepeatedCommitTime) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestInsertIncreaseID) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -694,6 +706,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestInsertIncreaseID) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestUpdate) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -726,6 +739,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestUpdate) {
 TEST_F(TestSFSSQLiteVersionedObjects, StoreUnsupportedTimestamp) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
 
@@ -776,6 +790,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, StoreUnsupportedTimestamp) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestFilterDeleted) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -900,6 +915,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestFilterDeleted) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestDeleteLastAndGetPrevious) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -946,6 +962,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestDeleteLastAndGetPrevious) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -1068,6 +1085,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestGetByBucketAndObjectName) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestUpdateAndDeleteRest) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -1137,6 +1155,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestUpdateAndDeleteRest) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestUpdateDeleteVersionDeletesObject) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -1262,6 +1281,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestUpdateDeleteVersionDeletesObject) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestAddDeleteMarker) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());
@@ -1381,6 +1401,7 @@ void insertNCommittedVersionsIncrementingSize(
 TEST_F(TestSFSSQLiteVersionedObjects, TestRemovedDeletedVersions) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   auto max_objects_per_iteration = ceph_context->_conf.get_val<uint64_t>(
       "rgw_sfs_gc_max_objects_per_iteration"
   );
@@ -1559,6 +1580,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestRemovedDeletedVersions) {
 TEST_F(TestSFSSQLiteVersionedObjects, TestRemovedDeletedVersionsLimitMax) {
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
   ceph_context->_conf.set_val("rgw_sfs_gc_max_objects_per_iteration", "2");
   auto max_objects_per_iteration = ceph_context->_conf.get_val<uint64_t>(
       "rgw_sfs_gc_max_objects_per_iteration"
@@ -1706,6 +1728,7 @@ TEST_F(TestSFSSQLiteVersionedObjects, TestDeleteMarkerAlwaysOnTop) {
   // in which a delete_marker had a lower commit time than an alive version
   auto ceph_context = std::make_shared<CephContext>(CEPH_ENTITY_TYPE_CLIENT);
   ceph_context->_conf.set_val("rgw_sfs_data_path", getTestDir());
+  ceph_context->_log->start();
 
   EXPECT_FALSE(fs::exists(getDBFullPath()));
   DBConnRef conn = std::make_shared<DBConn>(ceph_context.get());

--- a/src/test/rgw/sfs/test_rgw_sfs_wal_checkpoint.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_wal_checkpoint.cc
@@ -33,6 +33,7 @@ class TestSFSWALCheckpoint : public ::testing::Test {
         test_dir(fs::temp_directory_path() / TEST_DIR) {
     fs::create_directory(test_dir);
     cct->_conf.set_val("rgw_sfs_data_path", test_dir);
+    cct->_log->start();
     store.reset(new rgw::sal::SFStore(cct.get(), test_dir));
 
     sqlite::SQLiteUsers users(store->db_conn);


### PR DESCRIPTION
The first commit in this PR ensures that any low-level sqlite errors will be printed to STDERR when running unit tests.

The second commit here is to fix `TestSFSObjectStateMachine::TearDown()` so it destroys the store object before removing the database directory (same as #210).
