### PR TITLE
rgw/sfs: Allow multiple delete markers

### DIFF
--- a/src/rgw/driver/sfs/sqlite/sqlite_list.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_list.cc
@@ -111,7 +111,6 @@ bool SQLiteList::versions(
           &DBVersionedObject::size, &DBVersionedObject::version_type,
           is_equal(
               // IsLatest logic
-              // - delete markers are always on top
               // - Use the id as secondary condition if multiple version
               // with same max(commit_time) exists
               sqlite_orm::select(
@@ -126,7 +125,6 @@ bool SQLiteList::versions(
                       )
                   ),
                   multi_order_by(
-                      order_by(&DBVersionedObject::version_type).desc(),
                       order_by(&DBVersionedObject::commit_time).desc(),
                       order_by(&DBVersionedObject::id).desc()
                   ),
@@ -150,7 +148,6 @@ bool SQLiteList::versions(
       // newest to oldest version
       multi_order_by(
           order_by(&DBObject::name).asc(),
-          order_by(&DBVersionedObject::version_type).desc(),
           order_by(&DBVersionedObject::commit_time).desc(),
           order_by(&DBVersionedObject::id).desc()
       ),

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -312,7 +312,6 @@ SQLiteVersionedObjects::delete_version_and_get_previous_transact(
               )
           ),
           multi_order_by(
-              order_by(&DBVersionedObject::version_type).desc(),
               order_by(&DBVersionedObject::commit_time).desc(),
               order_by(&DBVersionedObject::id).desc()
           ),
@@ -345,7 +344,6 @@ uint SQLiteVersionedObjects::add_delete_marker_transact(
             is_not_equal(&DBVersionedObject::object_state, ObjectState::DELETED)
         ),
         multi_order_by(
-            order_by(&DBVersionedObject::version_type).desc(),
             order_by(&DBVersionedObject::commit_time).desc(),
             order_by(&DBVersionedObject::id).desc()
         ),
@@ -360,6 +358,7 @@ uint SQLiteVersionedObjects::add_delete_marker_transact(
         auto now = ceph::real_clock::now();
         last_version.version_type = VersionType::DELETE_MARKER;
         last_version.object_state = ObjectState::COMMITTED;
+        last_version.commit_time = now;
         last_version.delete_time = now;
         last_version.mtime = now;
         last_version.version_id = delete_marker_id;
@@ -429,7 +428,6 @@ SQLiteVersionedObjects::get_committed_versioned_object_last_version(
           is_equal(&DBVersionedObject::object_state, ObjectState::COMMITTED)
       ),
       multi_order_by(
-          order_by(&DBVersionedObject::version_type).desc(),
           order_by(&DBVersionedObject::commit_time).desc(),
           order_by(&DBVersionedObject::id).desc()
       ),


### PR DESCRIPTION
This PR changes how delete markers are stored and retrieved. As stated in [Amazon
docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManagingDelMarkers.html) multiple delete markers are allowed and are stacked as just another version.

Another possible reason why this is supported is to track the history of a version.

Fixes: https://github.com/aquarist-labs/s3gw/issues/718
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

