### PR TITLE
CI: Switch to S3 Test Excuses File

### DIFF
--- a/.github/workflows/test-s3gw.yml
+++ b/.github/workflows/test-s3gw.yml
@@ -128,6 +128,7 @@ jobs:
           docker run --rm \
             -v /run/docker.sock:/run/docker.sock \
             -v ${GITHUB_WORKSPACE}/s3tr-out:/out \
+            --pull=always \
             ghcr.io/aquarist-labs/s3tr:latest \
             run \
             --image s3gw:${IMAGE_TAG} \

--- a/.github/workflows/test-s3gw.yml
+++ b/.github/workflows/test-s3gw.yml
@@ -149,16 +149,6 @@ jobs:
             -v ${GITHUB_WORKSPACE}/s3tr-out:/out \
             -v ${GITHUB_WORKSPACE}/ceph:/ceph:ro \
             ghcr.io/aquarist-labs/s3tr:latest \
-            analyze new-successes \
-              --known-good-file \
-                /ceph/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt \
-              /out/s3tr.json
-
-          docker run --rm \
-            -v ${GITHUB_WORKSPACE}/s3tr-out:/out \
-            -v ${GITHUB_WORKSPACE}/ceph:/ceph:ro \
-            ghcr.io/aquarist-labs/s3tr:latest \
-            analyze new-failures \
-              --known-good-file \
-                /ceph/qa/rgw/store/sfs/tests/fixtures/s3-tests.txt \
-              /out/s3tr.json
+            analyze summary \
+              /out/s3tr.json \
+              /ceph/qa/rgw/store/sfs/tests/fixtures/s3tr_excuses.csv

--- a/qa/rgw/store/sfs/tests/fixtures/s3tr_excuses.csv
+++ b/qa/rgw/store/sfs/tests/fixtures/s3tr_excuses.csv
@@ -1,0 +1,59 @@
+test_account_usage;https://github.com/aquarist-labs/s3gw/issues/359;Unsupported RGW Extension
+test_atomic_dual_conditional_write_1mb;https://github.com/aquarist-labs/s3gw/issues/674;Unsupported RGW Extension
+test_bucket_create_exists_nonowner;https://github.com/aquarist-labs/s3gw/issues/617;BUG
+test_bucket_create_special_key_names;https://github.com/aquarist-labs/s3gw/issues/516;BUG
+test_bucket_get_location;https://github.com/aquarist-labs/s3gw/issues/676;BUG
+test_bucket_head_extended;https://github.com/aquarist-labs/s3gw/issues/196;WIP, RGW Extension
+test_bucket_list_delimiter_not_skip_special;https://github.com/aquarist-labs/s3gw/issues/691;BUG
+test_bucket_list_delimiter_prefix_underscore;https://github.com/aquarist-labs/s3gw/issues/691;BUG
+test_bucket_listv2_delimiter_prefix_underscore;https://github.com/aquarist-labs/s3gw/issues/691;BUG
+test_bucket_policy_different_tenant;https://github.com/ceph/s3-tests/issues;Broken test, marked fails_on_rgw
+test_bucket_policy_get_obj_acl_existing_tag;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_get_obj_existing_tag;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_get_obj_tagging_existing_tag;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_put_obj_copy_source;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_put_obj_copy_source_meta;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_put_obj_request_obj_tag;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_put_obj_s3_noenc;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_object_copy_canned_acl;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_bucket_policy_put_obj_tagging_existing_tag;https://github.com/aquarist-labs/s3gw/issues/698;BUG
+test_bucket_policy_set_condition_operator_end_with_IfExists;https://github.com/ceph/s3-tests/issues;Broken test, marked fails_on_rgw
+test_bucket_recreate_new_acl;https://github.com/aquarist-labs/s3gw/issues/617;BUG
+test_bucket_recreate_overwrite_acl;https://github.com/aquarist-labs/s3gw/issues/617;BUG
+test_delete_tags_obj_public;https://github.com/aquarist-labs/s3gw/issues/675;BUG
+test_get_tags_acl_public;https://github.com/aquarist-labs/s3gw/issues/675;BUG
+test_head_bucket_usage;https://github.com/aquarist-labs/s3gw/issues/92;Unsupported RGW Extension
+test_lifecycle_expiration_header_head;https://github.com/aquarist-labs/s3gw/issues/695;BUG
+test_lifecycle_expiration_header_tags_head;https://github.com/aquarist-labs/s3gw/issues/695;BUG
+test_logging_toggle;https://tracker.ceph.com/issues/984;Not supported by RGW
+test_object_copy_replacing_metadata;https://github.com/aquarist-labs/s3gw/issues/525;BUG
+test_object_copy_to_itself_with_metadata;https://github.com/aquarist-labs/s3gw/issues/525;BUG
+test_object_lock_delete_object_with_retention_and_marker;https://github.com/aquarist-labs/s3gw/issues/690;BUG
+test_object_read_unreadable;https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html;Broken test, Object names are UTF-8
+test_object_requestid_matches_header_on_error;https://github.com/aquarist-labs/s3gw/issues/689;BUG
+test_object_set_get_unicode_metadata;https://github.com/aquarist-labs/s3gw/issues/688;BUG, maybe upstream
+test_object_write_with_chunked_transfer_encoding;https://github.com/ceph/ceph/pull/50235;BUG, fixed upstream, remove after rebase
+test_put_object_ifmatch_failed;https://github.com/aquarist-labs/s3gw/issues/674;Unsupported RGW Extension
+test_put_object_ifmatch_nonexisted_failed;https://github.com/aquarist-labs/s3gw/issues/674;Unsupported RGW Extension
+test_put_object_ifnonmatch_failed;https://github.com/aquarist-labs/s3gw/issues/674;Unsupported RGW Extension
+test_put_object_ifnonmatch_overwrite_existed_failed;https://github.com/aquarist-labs/s3gw/issues/674;Unsupported RGW Extension
+test_put_tags_acl_public;https://github.com/aquarist-labs/s3gw/issues/675;BUG
+test_sse_s3_default_method_head;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_default_multipart_upload;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_default_post_object_authenticated_request;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_default_upload_1b;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_default_upload_1kb;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_default_upload_1mb;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_default_upload_8mb;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_encrypted_upload_1b;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_encrypted_upload_1kb;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_encrypted_upload_1mb;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_sse_s3_encrypted_upload_8mb;https://github.com/aquarist-labs/s3gw/issues/686;No external keystore support in s3tr
+test_versioning_bucket_atomic_upload_return_version_id;https://github.com/aquarist-labs/s3gw/blob/main/docs/decisions/0010-sfs-versioning.md;Versionin Suspended Buckets are unsupported and not planned
+test_versioning_bucket_create_suspend;https://github.com/aquarist-labs/s3gw/blob/main/docs/decisions/0010-sfs-versioning.md;Versioning Suspended Buckets ar unsupported and not planned
+test_versioning_bucket_multipart_upload_return_version_id;https://github.com/aquarist-labs/s3gw/blob/main/docs/decisions/0010-sfs-versioning.md;Versionin Suspended Buckets are unsupported and not planned
+test_versioning_obj_plain_null_version_overwrite;https://github.com/aquarist-labs/s3gw/issues/687;SFS does not support null versions
+test_versioning_obj_plain_null_version_overwrite_suspended;https://github.com/aquarist-labs/s3gw/blob/main/docs/decisions/0010-sfs-versioning.md;Versionin Suspended Buckets are unsupported and not planned
+test_versioning_obj_plain_null_version_removal;https://github.com/aquarist-labs/s3gw/issues/687;SFS does not support null versions
+test_versioning_obj_suspend_versions;https://github.com/aquarist-labs/s3gw/blob/main/docs/decisions/0010-sfs-versioning.md;Versioning Suspended Buckets ar unsupported and not planned
+test_multipart_copy_special_names;https://github.com/aquarist-labs/s3gw/issues/699;BUG


### PR DESCRIPTION
Switches S3 Test CI step to the new s3tr excuses.csv feature.

Requires s3tr update: https://github.com/aquarist-labs/s3gw/pull/700

Fixes: https://github.com/aquarist-labs/s3gw/issues/665

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
