### PR TITLE
Make MP mark_complete a write transaction

### DIFF
--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
@@ -359,20 +359,6 @@ static int _mark_complete(
   return storage.changes();
 }
 
-bool SQLiteMultipart::mark_complete(const std::string& upload_id) const {
-  auto storage = conn->get_storage();
-  auto committed = storage.transaction([&]() mutable {
-    auto num_complete = _mark_complete(storage, upload_id);
-    if (num_complete == 0) {
-      return false;
-    }
-    ceph_assert(num_complete == 1);
-    return true;
-  });
-
-  return committed;
-}
-
 bool SQLiteMultipart::mark_complete(
     const std::string& upload_id, bool* duplicate
 ) const {

--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.h
@@ -180,15 +180,6 @@ class SQLiteMultipart {
    * @brief Mark an on-going Multipart Upload as being complete.
    *
    * @param upload_id The Multipart Upload's ID.
-   * @return true if a multipart upload was marked complete.
-   * @return false if no multipart upload was found.
-   */
-  bool mark_complete(const std::string& upload_id) const;
-
-  /**
-   * @brief Mark an on-going Multipart Upload as being complete.
-   *
-   * @param upload_id The Multipart Upload's ID.
    * @param duplicate Whether the Multipart Upload has previously been
    * completed.
    * @return true if a multipart upload was marked complete.


### PR DESCRIPTION
Make SQLiteMultipart::mark_complete a write transaction so that the
default retry timeout handler kicks in.

Fixes: https://github.com/aquarist-labs/s3gw/issues/710#issuecomment-1757011216

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

