### PR TITLE
Retry Util -> Busy Retry Util

### DIFF
--- a/src/rgw/driver/sfs/sqlite/errors.cc
+++ b/src/rgw/driver/sfs/sqlite/errors.cc
@@ -42,4 +42,16 @@ bool critical_error(int ec) {
   }
 }
 
+bool busy_error(int ec) {
+  switch (ec) {
+    case SQLITE_BUSY:
+    case SQLITE_BUSY_RECOVERY:
+    case SQLITE_BUSY_SNAPSHOT:
+    case SQLITE_LOCKED:
+      return true;
+    default:
+      return false;
+  }
+}
+
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/errors.h
+++ b/src/rgw/driver/sfs/sqlite/errors.h
@@ -16,5 +16,6 @@
 namespace rgw::sal::sfs::sqlite {
 
 bool critical_error(int ec);
+bool busy_error(int ec);
 
-}
+}  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.cc
@@ -139,7 +139,7 @@ std::optional<DBDeletedObjectItems> SQLiteBuckets::delete_bucket_transact(
     const std::string& bucket_id, uint max_objects, bool& bucket_deleted
 ) const {
   auto storage = conn->get_storage();
-  RetrySQLite<DBDeletedObjectItems> retry([&]() {
+  RetrySQLiteBusy<DBDeletedObjectItems> retry([&]() {
     bucket_deleted = false;
     DBDeletedObjectItems ret_values;
     storage.begin_transaction();

--- a/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_multipart.cc
@@ -222,7 +222,7 @@ std::optional<DBMultipartPart> SQLiteMultipart::create_or_reset_part(
 ) const {
   auto storage = conn->get_storage();
 
-  RetrySQLite<std::optional<DBMultipartPart>> retry([&]() {
+  RetrySQLiteBusy<std::optional<DBMultipartPart>> retry([&]() {
     auto transaction = storage.transaction_guard();
     std::optional<DBMultipartPart> entry = std::nullopt;
     auto cnt = storage.count<DBMultipart>(where(
@@ -466,7 +466,7 @@ SQLiteMultipart::remove_multiparts_by_bucket_id_transact(
 ) const {
   DBDeletedMultipartItems ret_parts;
   auto storage = conn->get_storage();
-  RetrySQLite<DBDeletedMultipartItems> retry([&]() {
+  RetrySQLiteBusy<DBDeletedMultipartItems> retry([&]() {
     auto transaction = storage.transaction_guard();
     // get first the list of parts to be deleted up to max_items
     ret_parts = storage.select(
@@ -532,7 +532,7 @@ SQLiteMultipart::remove_done_or_aborted_multiparts_transact(uint max_items
 ) const {
   DBDeletedMultipartItems ret_parts;
   auto storage = conn->get_storage();
-  RetrySQLite<DBDeletedMultipartItems> retry([&]() {
+  RetrySQLiteBusy<DBDeletedMultipartItems> retry([&]() {
     auto transaction = storage.transaction_guard();
     // get first the list of parts to be deleted up to max_items
     ret_parts = storage.select(

--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.cc
@@ -147,7 +147,7 @@ bool SQLiteVersionedObjects::
         const DBVersionedObject& object, std::vector<ObjectState> allowed_states
     ) const {
   auto storage = conn->get_storage();
-  RetrySQLite<bool> retry([&]() {
+  RetrySQLiteBusy<bool> retry([&]() {
     auto transaction = storage.transaction_guard();
     storage.update_all(
         set(c(&DBVersionedObject::object_id) = object.object_id,
@@ -449,7 +449,7 @@ SQLiteVersionedObjects::create_new_versioned_object_transact(
     const std::string& version_id
 ) const {
   auto storage = conn->get_storage();
-  RetrySQLite<DBVersionedObject> retry([&]() {
+  RetrySQLiteBusy<DBVersionedObject> retry([&]() {
     auto transaction = storage.transaction_guard();
     auto objs = storage.select(
         columns(&DBObject::uuid),
@@ -491,7 +491,7 @@ SQLiteVersionedObjects::remove_deleted_versions_transact(uint max_objects
 ) const {
   DBDeletedObjectItems ret_objs;
   auto storage = conn->get_storage();
-  RetrySQLite<DBDeletedObjectItems> retry([&]() {
+  RetrySQLiteBusy<DBDeletedObjectItems> retry([&]() {
     auto transaction = storage.transaction_guard();
     // get first the list of objects to be deleted up to max_objects
     // order by size so when we delete the versions data we are more efficient


### PR DESCRIPTION
Change SQLite transaction retry util into a busy retry util that only
retries database busy conditions not constraint errors

Related issue: https://github.com/aquarist-labs/s3gw/issues/645

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

