### PR TITLE
rgw/sfs: ensure all SFS and related code has WITH_RADOSGW_SFS guards

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -148,7 +148,6 @@ set(librgw_common_srcs
   rgw_bucket_encryption.cc
   rgw_tracer.cc
   rgw_lua_background.cc
-  rgw_s3gw_telemetry.cc
   driver/rados/cls_fifo_legacy.cc
   driver/rados/rgw_bucket.cc
   driver/rados/rgw_bucket_sync.cc
@@ -219,7 +218,7 @@ endif()
 if(WITH_RADOSGW_SFS)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rgw/driver/sfs/sqlite/sqlite_orm/include")
   add_subdirectory(driver/sfs)
-  list(APPEND librgw_common_srcs rgw_sal_sfs.cc)
+  list(APPEND librgw_common_srcs rgw_sal_sfs.cc rgw_s3gw_telemetry.cc)
 endif()
 if(WITH_RADOSGW_MOTR)
   list(APPEND librgw_common_srcs rgw_sal_motr.cc)
@@ -282,7 +281,6 @@ target_link_libraries(rgw_common
 target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/services"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/sfs"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${LUA_INCLUDE_DIR}")
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
@@ -324,6 +322,7 @@ if(WITH_RADOSGW_DBSTORE)
 endif()
 
 if(WITH_RADOSGW_SFS)
+  target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/sfs")
   target_link_libraries(rgw_common PRIVATE global sfs)
 endif()
 
@@ -369,15 +368,19 @@ set(rgw_a_srcs
   rgw_rest_swift.cc
   rgw_rest_usage.cc
   rgw_signal.cc
-  rgw_status_frontend.cc
-  rgw_status_page.cc
-  rgw_status_page_telemetry.cc
   rgw_swift_auth.cc
   rgw_usage.cc
   rgw_sts.cc
   driver/rados/rgw_rest_bucket.cc
   driver/rados/rgw_rest_log.cc
   driver/rados/rgw_rest_realm.cc)
+
+if(WITH_RADOSGW_SFS)
+list(APPEND rgw_a_srcs
+  rgw_status_frontend.cc
+  rgw_status_page.cc
+  rgw_status_page_telemetry.cc)
+endif()
 
 gperf_generate(${CMAKE_SOURCE_DIR}/src/rgw/rgw_iam_policy_keywords.gperf
   rgw_iam_policy_keywords.frag.cc)

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -29,7 +29,6 @@
 #include "include/stringify.h"
 #include "rgw_main.h"
 #include "rgw_common.h"
-#include "rgw_s3gw_telemetry.h"
 #include "rgw_sal_rados.h"
 #include "rgw_period_pusher.h"
 #include "rgw_realm_reloader.h"
@@ -45,8 +44,6 @@
 #include "rgw_rest_config.h"
 #include "rgw_rest_realm.h"
 #include "rgw_rest_ratelimit.h"
-#include "rgw_status_page.h"
-#include "rgw_status_page_telemetry.h"
 #include "rgw_swift_auth.h"
 #include "rgw_log.h"
 #include "rgw_lib.h"
@@ -78,8 +75,13 @@
 #endif
 #include "rgw_lua_background.h"
 #include "services/svc_zone.h"
+#ifdef WITH_RADOSGW_SFS
+#include "rgw_s3gw_telemetry.h"
+#include "rgw_status_page.h"
+#include "rgw_status_page_telemetry.h"
 #include "rgw_sal_sfs.h"
 #include "rgw_status_frontend.h"
+#endif // WITH_RADOSGW_SFS
 
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
@@ -454,6 +456,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       continue;
 #endif
     }
+#ifdef WITH_RADOSGW_SFS
     else if (framework == "status") {
       auto cct = dpp->get_cct();
       RGWStatusFrontend* stat = new RGWStatusFrontend(env, config, cct);
@@ -479,7 +482,7 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
       stat->register_status_page(std::move(prometheus));
       fe = stat;
     }
-
+#endif // WITH_RADOSGW_SFS
     service_map_meta["frontend_type#" + stringify(fe_count)] = framework;
     service_map_meta["frontend_config#" + stringify(fe_count)] = config->get_config();
 
@@ -588,6 +591,7 @@ void rgw::AppMain::init_lua()
   }
 } /* init_lua */
 
+#ifdef WITH_RADOSGW_SFS
 void rgw::AppMain::init_s3gw_telemetry()
 {
   rgw::sal::Driver* driver = env.driver;
@@ -597,7 +601,7 @@ void rgw::AppMain::init_s3gw_telemetry()
     env.s3gw_telemetry->start();
   }
 } /* init_s3gw_telemetry */
-
+#endif // WITH_RADOSGW_SFS
 
 void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 {
@@ -645,7 +649,9 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 #endif
   rgw_perf_stop(g_ceph_context);
   ratelimiter.reset(); // deletes--ensure this happens before we destruct
+#ifdef WITH_RADOSGW_SFS
   if (env.s3gw_telemetry) {
     env.s3gw_telemetry->stop();
   }
+#endif // WITH_RADOSGW_SFS
 } /* AppMain::shutdown */

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -146,7 +146,9 @@ int main(int argc, char *argv[])
     return EIO;
   }
 
+#ifdef WITH_RADOSGW_SFS
   main.init_s3gw_telemetry();
+#endif // WITH_RADOSGW_SFS
   main.cond_init_apis();
 
   mutex.lock();

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -107,7 +107,9 @@ public:
   void init_tracepoints();
   void init_notification_endpoints();
   void init_lua();
+#ifdef WITH_RADOSGW_SFS
   void init_s3gw_telemetry();
+#endif // WITH_RADOSGW_SFS
 
   bool have_http() {
     return have_http_frontend;

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <memory>
+#ifdef WITH_RADOSGW_SFS
 #include "rgw_s3gw_telemetry.h"
+#endif
 
 class ActiveRateLimiter;
 class OpsLogSink;
@@ -41,7 +43,9 @@ struct RGWProcessEnv {
   OpsLogSink *olog = nullptr;
   std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
+#ifdef WITH_RADOSGW_SFS
   std::unique_ptr<S3GWTelemetry> s3gw_telemetry = nullptr;
+#endif
 
 #ifdef WITH_ARROW_FLIGHT
   // managed by rgw:flight::FlightFrontend in rgw_flight_frontend.cc

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -336,7 +336,11 @@ rgw::sal::Driver* DriverManager::init_raw_storage_provider(const DoutPrefixProvi
       return nullptr;
     }
   } else if (cfg.store_name.compare("sfs") == 0) {
+#ifdef WITH_RADOSGW_SFS
     driver = newSFStore(cct);
+#else
+    driver = nullptr;
+#endif
   } else if (cfg.store_name.compare("dbstore") == 0) {
 #ifdef WITH_RADOSGW_DBSTORE
     driver = newDBStore(cct);

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -268,16 +268,6 @@ target_include_directories(unittest_log_backing
 target_link_libraries(unittest_log_backing radostest-cxx ${UNITTEST_LIBS}
   ${rgw_libs})
 
-# unittest_rgw_status_page
-add_executable(unittest_rgw_s3gw_telemetry test_rgw_s3gw_telemetry.cc)
-add_ceph_unittest(unittest_rgw_s3gw_telemetry)
-target_include_directories(unittest_rgw_s3gw_telemetry
-  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
-  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/store/rados")
-target_link_libraries(unittest_rgw_s3gw_telemetry ${rgw_libs})
-set_tests_properties(unittest_rgw_s3gw_telemetry
-  PROPERTIES LABELS "unittest;rgw;s3gw;telemetry")
-
 add_executable(unittest_rgw_lua test_rgw_lua.cc)
 add_ceph_unittest(unittest_rgw_lua)
 target_include_directories(unittest_rgw_lua
@@ -295,4 +285,17 @@ target_link_libraries(radosgw-cr-test ${rgw_libs} librados
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   GTest::GTest)
 
-add_subdirectory(sfs)
+if(WITH_RADOSGW_SFS)
+  # unittest_rgw_status_page
+  add_executable(unittest_rgw_s3gw_telemetry test_rgw_s3gw_telemetry.cc)
+  add_ceph_unittest(unittest_rgw_s3gw_telemetry)
+  target_include_directories(unittest_rgw_s3gw_telemetry
+    SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
+    SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/store/rados")
+  target_link_libraries(unittest_rgw_s3gw_telemetry ${rgw_libs})
+  set_tests_properties(unittest_rgw_s3gw_telemetry
+    PROPERTIES LABELS "unittest;rgw;s3gw;telemetry")
+
+  # SFS tests
+  add_subdirectory(sfs)
+endif()


### PR DESCRIPTION
Note that this lumps the status page and telemetry in with SFS, which may not be strictly correct as I assume the status page could be a useful feature independently of SFS.  That said, this somewhat heavy handed approach does as least mean radosgw now successfully builds if you run `cmake -DWITH_RADOSGW_SFS=OFF`.