### PR TITLE
Replace ceph_abort with ceph_abort_msg

### DIFF
--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -382,7 +382,7 @@ int SFSMultipartUploadV2::complete(
                  part.part_num, partfd, objpath, objfd, cpp_strerror(errno)
              )
           << dendl;
-      ceph_abort("Unexpected error aggregating multipart upload");
+      ceph_abort_msg("Unexpected error aggregating multipart upload");
     }
     accounted_bytes += partsize;
     ret = ::fsync(objfd);
@@ -392,7 +392,7 @@ int SFSMultipartUploadV2::complete(
                                 objfd, objpath, cpp_strerror(ret)
                             )
                          << dendl;
-      ceph_abort("Unexpected error fsync'ing obj path");
+      ceph_abort_msg("Unexpected error fsync'ing obj path");
     }
     ret = ::close(partfd);
     if (ret < 0) {
@@ -401,7 +401,7 @@ int SFSMultipartUploadV2::complete(
                                 partfd, path, cpp_strerror(ret)
                             )
                          << dendl;
-      ceph_abort("Unexpected error on closing part path");
+      ceph_abort_msg("Unexpected error on closing part path");
     }
   }
 
@@ -421,7 +421,7 @@ int SFSMultipartUploadV2::complete(
                               accounted_bytes, final_obj_size
                           )
                        << dendl;
-    ceph_abort("BUG: on final object for multipart upload!");
+    ceph_abort_msg("BUG: on final object for multipart upload!");
   }
 
   lsfs_dout(dpp, 10)


### PR DESCRIPTION
ceph_abort(msg) ignores msg using the generic "abort() called"
instead. Replace with ceph_abort_msg to get the messages in the crash
output.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
