### PR TITLE
rgw/sfs: mark all OPEN versions DELETED on startup

### DIFF
--- a/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_versioned_objects.h
@@ -80,6 +80,8 @@ class SQLiteVersionedObjects {
       uint max_objects
   ) const;
 
+  int set_all_open_versions_to_deleted() const;
+
  private:
   std::optional<DBVersionedObject>
   get_committed_versioned_object_specific_version(

--- a/src/rgw/rgw_sal_sfs.cc
+++ b/src/rgw/rgw_sal_sfs.cc
@@ -607,6 +607,10 @@ SFStore::SFStore(CephContext* c, const std::filesystem::path& data_path)
       ) {
   maybe_init_store();
   db_conn = std::make_shared<sfs::sqlite::DBConn>(cctx);
+  sfs::sqlite::SQLiteVersionedObjects objs_versions(db_conn);
+  int num_deleted = objs_versions.set_all_open_versions_to_deleted();
+  ldout(ctx(), 10) << "marked " << num_deleted << " open objects deleted"
+                   << dendl;
   gc = std::make_shared<sfs::SFSGC>(cctx, this);
 
   filesystem_stats_updater = make_named_thread(


### PR DESCRIPTION
All OPEN versions that exist on startup are due to aborted uploads. Setting them to DELETED allows us to free up space leveraging the GC.

Tested by running `s3cmd --limit-rate 1000 put obj.1mb.bin s3://foo/slow` and hitting CTRL-C after a few seconds to leave an open object lying around, then restarting s3gw and looking for "marked 1 open objects deleted" in the debug logs.

Fixes: https://github.com/aquarist-labs/s3gw/issues/624

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

