### PR TITLE
First Steps Towards Replacing sqlite_orm with sqlite_modern_cpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,3 +75,6 @@
 [submodule "src/rgw/driver/sfs/sqlite/sqlite_orm"]
 	path = src/rgw/driver/sfs/sqlite/sqlite_orm
 	url = https://github.com/aquarist-labs/sqlite_orm.git
+[submodule "src/rgw/driver/sfs/sqlite_modern_cpp"]
+	path = src/rgw/driver/sfs/sqlite/sqlite_modern_cpp
+	url = https://github.com/SqliteModernCpp/sqlite_modern_cpp.git

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -320,6 +320,7 @@ endif()
 
 if(WITH_RADOSGW_SFS)
   target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/sfs")
+  target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/sfs/sqlite/sqlite_modern_cpp/hdr")
   target_link_libraries(rgw_common PRIVATE global sfs)
 endif()
 

--- a/src/rgw/driver/sfs/CMakeLists.txt
+++ b/src/rgw/driver/sfs/CMakeLists.txt
@@ -25,6 +25,7 @@ set(sfs_srcs
   sqlite/dbconn.cc
   sqlite/errors.cc
   sqlite/sqlite_list.cc
+  sqlite/conversion_utils.cc
   bucket.cc
   multipart.cc
   object.cc

--- a/src/rgw/driver/sfs/sqlite/conversion_utils.cc
+++ b/src/rgw/driver/sfs/sqlite/conversion_utils.cc
@@ -1,0 +1,37 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ * SFS SAL implementation
+ *
+ * Copyright (C) 2023 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+
+#include <string>
+
+namespace rgw::sal::sfs::sqlite {
+
+std::string prefix_to_escaped_like(const std::string& prefix, char escape) {
+  std::string like_expr;
+  like_expr.reserve(prefix.length() + 10);
+  for (const char c : prefix) {
+    switch (c) {
+      case '%':
+        [[fallthrough]];
+      case '_':
+        like_expr.push_back(escape);
+        [[fallthrough]];
+      default:
+        like_expr.push_back(c);
+    }
+  }
+  like_expr.push_back('%');
+  return like_expr;
+}
+
+}  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/conversion_utils.h
+++ b/src/rgw/driver/sfs/sqlite/conversion_utils.h
@@ -128,22 +128,12 @@ void assign_db_value(const SOURCE& source, std::vector<char>& dest) {
   dest = blob_vector;
 }
 
+std::string prefix_to_escaped_like(const std::string& prefix, char escape);
+
 template <typename COL>
 sqlite_orm::internal::like_t<COL, std::basic_string<char>, const char*>
 prefix_to_like(COL col, const std::string& prefix) {
-  std::string like_expr;
-  like_expr.reserve(prefix.length() + 10);
-  for (const char c : prefix) {
-    switch (c) {
-      case '%':
-      case '_':
-        like_expr.push_back('\a');
-      default:
-        like_expr.push_back(c);
-    }
-  }
-  like_expr.push_back('%');
-  return sqlite_orm::like(col, like_expr, "\a");
+  return sqlite_orm::like(col, prefix_to_escaped_like(prefix, '\a'), "\a");
 }
 
 }  // namespace rgw::sal::sfs::sqlite

--- a/src/rgw/driver/sfs/sqlite/dbapi.h
+++ b/src/rgw/driver/sfs/sqlite/dbapi.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <sqlite3.h>
+
+namespace rgw::sal::sfs::dbapi {
+
+#include "sqlite_modern_cpp/hdr/sqlite_modern_cpp.h"
+
+}  // namespace rgw::sal::sfs::dbapi

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 if(WITH_RADOSGW_SFS)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rgw/driver/sfs/sqlite/sqlite_orm/include")
+  include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rgw/driver/sfs/sqlite/sqlite_modern_cpp/hdr")
 endif()
 
 if(WITH_JAEGER)


### PR DESCRIPTION
Add `sqlite_modern_cpp` alongside `sqlite_orm` as a submodule. Wrap
include in `dbapi.h` to work around it's namespace `sqlite` coliding
with ours. Convert `SQLiteList::versions` and add type mappers for
`ceph::real_time`, `ObjectState` and `VersionType`

Epic: https://github.com/aquarist-labs/s3gw/issues/742
Issue: https://github.com/aquarist-labs/s3gw/issues/788
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

