### PR TITLE
rgw/sfs: honor retry_raced_bucket_write mechanism

### DIFF
--- a/src/rgw/driver/sfs/bucket.h
+++ b/src/rgw/driver/sfs/bucket.h
@@ -62,6 +62,25 @@ class SFSBucket : public StoreBucket {
   SFSBucket(SFStore* _store, sfs::BucketRef _bucket);
   SFSBucket& operator=(const SFSBucket&) = delete;
 
+  /**
+   * This method updates the in-memory views of this object fetching
+   * from this.bucket.
+   * This method should be called every time this.bucket is updated
+   * from the backing storage.
+   *
+   * Views updated:
+   *
+   *  - get_info()
+   *  - get_attrs()
+   *  - acls
+   */
+  void update_views();
+
+  int try_metadata_update(
+      const std::function<int(sfs::sqlite::DBOPBucketInfo& current_state)>&
+          apply_delta
+  );
+
   virtual std::unique_ptr<Bucket> clone() override {
     return std::unique_ptr<Bucket>(new SFSBucket{*this});
   }

--- a/src/rgw/driver/sfs/sqlite/buckets/bucket_definitions.h
+++ b/src/rgw/driver/sfs/sqlite/buckets/bucket_definitions.h
@@ -72,6 +72,16 @@ struct DBOPBucketInfo {
 
   DBOPBucketInfo(const DBOPBucketInfo& other) = default;
   DBOPBucketInfo& operator=(const DBOPBucketInfo& other) = default;
+
+  bool operator==(const DBOPBucketInfo& other) const {
+    if (this->deleted != other.deleted) return false;
+    if (this->battrs != other.battrs) return false;
+    ceph::bufferlist this_binfo_bl;
+    this->binfo.encode(this_binfo_bl);
+    ceph::bufferlist other_binfo_bl;
+    other.binfo.encode(other_binfo_bl);
+    return this_binfo_bl == other_binfo_bl;
+  }
 };
 
 using DBDeletedObjectItem =

--- a/src/rgw/driver/sfs/sqlite/sqlite_buckets.h
+++ b/src/rgw/driver/sfs/sqlite/sqlite_buckets.h
@@ -33,32 +33,62 @@ class SQLiteBuckets {
     uint64_t obj_count;
   };
 
-  std::optional<DBOPBucketInfo> get_bucket(const std::string& bucket_id) const;
-  std::vector<DBOPBucketInfo> get_bucket_by_name(const std::string& bucket_name
+  std::optional<DBOPBucketInfo> get_bucket(
+      const std::string& bucket_id,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
+
+  std::vector<DBOPBucketInfo> get_bucket_by_name(
+      const std::string& bucket_name,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
   ) const;
   /// get_onwer returns bucket ownership information as a pair of
   /// (user id, display name) or nullopt
   std::optional<std::pair<std::string, std::string>> get_owner(
-      const std::string& bucket_id
+      const std::string& bucket_id, rgw::sal::sfs::sqlite::StorageRef storage = nullptr
   ) const;
 
-  void store_bucket(const DBOPBucketInfo& bucket) const;
-  void remove_bucket(const std::string& bucket_id) const;
+  void store_bucket(
+      const DBOPBucketInfo& bucket,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
 
-  std::vector<std::string> get_bucket_ids() const;
-  std::vector<std::string> get_bucket_ids(const std::string& user_id) const;
+  void remove_bucket(
+      const std::string& bucket_id,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
 
-  std::vector<DBOPBucketInfo> get_buckets() const;
-  std::vector<DBOPBucketInfo> get_buckets(const std::string& user_id) const;
+  std::vector<std::string> get_bucket_ids(
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
+  std::vector<std::string> get_bucket_ids(
+      const std::string& user_id,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
 
-  std::vector<std::string> get_deleted_buckets_ids() const;
+  std::vector<DBOPBucketInfo> get_buckets(
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
+  std::vector<DBOPBucketInfo> get_buckets(
+      const std::string& user_id,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
 
-  bool bucket_empty(const std::string& bucket_id) const;
+  std::vector<std::string> get_deleted_buckets_ids(
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
+
+  bool bucket_empty(
+      const std::string& bucket_id,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
+  ) const;
   std::optional<DBDeletedObjectItems> delete_bucket_transact(
-      const std::string& bucket_id, uint max_objects, bool& bucket_deleted
+      const std::string& bucket_id, uint max_objects, bool& bucket_deleted,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
   ) const;
   const std::optional<SQLiteBuckets::Stats> get_stats(
-      const std::string& bucket_id
+      const std::string& bucket_id,
+      rgw::sal::sfs::sqlite::StorageRef storage = nullptr
   ) const;
 };
 


### PR DESCRIPTION
Updating bucket's metadata concurrently by two or more threads is allowed in radosgw.
There is a retry mechanism: retry_raced_bucket_write(), that expects the bucket references to fetch the latest data from the persistent store.
rgw/sfs driver didn't implement try_refresh_info() in its bucket class definition; this could cause two references to the same bucket to potentially lead to partial metadata updates.

Fixes: https://github.com/aquarist-labs/s3gw/issues/637

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

