### PR TITLE
.github/workflows: add pr to s3gw project

### DIFF
--- a/.github/workflows/pr-add-to-project.yaml
+++ b/.github/workflows/pr-add-to-project.yaml
@@ -1,0 +1,19 @@
+---
+name: Add Pull Request to S3GW Project
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - s3gw
+
+jobs:
+  add-to-project:
+    name: Add Pull Request to S3GW Project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jecluis/custom-project-status@v1.1.0
+        with:
+          project-url: https://github.com/orgs/aquarist-labs/projects/5
+          gh-token: ${{ secrets.PAT_S3GW_PROJECT_ADD }}
+          default-pr-status: "In review"


### PR DESCRIPTION
Introduces a workflow action that will add opened PRs against this repository to the [s3gw project][s3gw-prj-url].

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>

[s3gw-prj-url]: https://github.com/orgs/aquarist-labs/projects/5
