### PR TITLE
Retry Util sqlite_modern_cpp Support

### DIFF
--- a/src/test/rgw/sfs/test_rgw_sfs_retry.cc
+++ b/src/test/rgw/sfs/test_rgw_sfs_retry.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "common/ceph_context.h"
+#include "driver/sfs/sqlite/dbapi.h"
 #include "driver/sfs/sqlite/retry.h"
 #include "driver/sfs/sqlite/sqlite_orm.h"
 #include "gtest/gtest.h"
@@ -26,9 +27,13 @@ class TestSFSRetrySQLite : public ::testing::Test {
   void TearDown() override {}
 };
 
-class TestSFSRetrySQLiteDeathTest : public TestSFSRetrySQLite {};
+// TODO(https://github.com/aquarist-labs/s3gw/issues/788) Remove
+// TestSFSRetrySQLiteOrm tests
 
-TEST_F(TestSFSRetrySQLite, retry_non_crit_till_failure) {
+class TestSFSRetrySQLiteOrm : public TestSFSRetrySQLite {};
+class TestSFSRetrySQLiteOrmDeathTest : public TestSFSRetrySQLiteOrm {};
+
+TEST_F(TestSFSRetrySQLiteOrm, retry_non_crit_till_failure) {
   auto exception =
       std::system_error{SQLITE_BUSY, sqlite_orm::get_sqlite_error_category()};
   RetrySQLiteBusy<int> uut([&]() {
@@ -37,11 +42,11 @@ TEST_F(TestSFSRetrySQLite, retry_non_crit_till_failure) {
   });
   EXPECT_EQ(uut.run(), std::nullopt);
   EXPECT_FALSE(uut.successful());
-  EXPECT_EQ(uut.failed_error(), exception.code());
+  EXPECT_EQ(uut.failed_error(), exception.code().value());
   EXPECT_GT(uut.retries(), 0);
 }
 
-TEST_F(TestSFSRetrySQLiteDeathTest, crit_aborts) {
+TEST_F(TestSFSRetrySQLiteOrmDeathTest, crit_aborts) {
   GTEST_FLAG_SET(death_test_style, "threadsafe");
   auto exception = std::system_error{
       SQLITE_CORRUPT, sqlite_orm::get_sqlite_error_category()
@@ -53,14 +58,14 @@ TEST_F(TestSFSRetrySQLiteDeathTest, crit_aborts) {
   ASSERT_DEATH(uut.run(), "Critical SQLite error");
 }
 
-TEST_F(TestSFSRetrySQLite, simple_return_succeeds_immediately) {
+TEST_F(TestSFSRetrySQLiteOrm, simple_return_succeeds_immediately) {
   RetrySQLiteBusy<int> uut([&]() { return 42; });
   EXPECT_EQ(uut.run(), 42);
   EXPECT_TRUE(uut.successful());
   EXPECT_EQ(uut.retries(), 0);
 }
 
-TEST_F(TestSFSRetrySQLite, retry_second_time_success) {
+TEST_F(TestSFSRetrySQLiteOrm, retry_second_time_success) {
   auto exception =
       std::system_error{SQLITE_BUSY, sqlite_orm::get_sqlite_error_category()};
   bool first = true;
@@ -74,6 +79,72 @@ TEST_F(TestSFSRetrySQLite, retry_second_time_success) {
   });
   EXPECT_EQ(uut.run(), 23);
   EXPECT_TRUE(uut.successful());
-  EXPECT_NE(uut.failed_error(), exception.code());
+  EXPECT_NE(uut.failed_error(), exception.code().value());
+  EXPECT_EQ(uut.retries(), 1);
+}
+
+class TestSFSRetrySQLiteDeathTest : public TestSFSRetrySQLite {};
+
+TEST_F(TestSFSRetrySQLite, retry_non_crit_till_failure) {
+  auto exception = rgw::sal::sfs::dbapi::sqlite::errors::busy(SQLITE_BUSY, "");
+  RetrySQLiteBusy<int> uut([&]() {
+    throw exception;
+    return 0;
+  });
+  EXPECT_EQ(uut.run(), std::nullopt);
+  EXPECT_FALSE(uut.successful());
+  EXPECT_EQ(uut.failed_error(), exception.get_code());
+  EXPECT_GT(uut.retries(), 0);
+}
+
+TEST_F(TestSFSRetrySQLite, retry_non_crit_extended_till_failure) {
+  auto exception = rgw::sal::sfs::dbapi::sqlite::errors::busy_snapshot(
+      SQLITE_BUSY_SNAPSHOT, ""
+  );
+  RetrySQLiteBusy<int> uut([&]() {
+    throw exception;
+    return 0;
+  });
+  EXPECT_EQ(uut.run(), std::nullopt);
+  EXPECT_FALSE(uut.successful());
+  EXPECT_EQ(uut.failed_error(), exception.get_code());
+  EXPECT_GT(uut.retries(), 0);
+}
+
+TEST_F(TestSFSRetrySQLiteDeathTest, crit_aborts) {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
+  auto exception = std::system_error{
+      SQLITE_CORRUPT, sqlite_orm::get_sqlite_error_category()
+  };
+  RetrySQLiteBusy<int> uut([&]() {
+    rgw::sal::sfs::dbapi::sqlite::errors::throw_sqlite_error(SQLITE_CORRUPT);
+    return 0;
+  });
+  ASSERT_DEATH(uut.run(), "Critical SQLite error");
+}
+
+TEST_F(TestSFSRetrySQLite, simple_return_succeeds_immediately) {
+  RetrySQLiteBusy<int> uut([&]() { return 42; });
+  EXPECT_EQ(uut.run(), 42);
+  EXPECT_TRUE(uut.successful());
+  EXPECT_EQ(uut.retries(), 0);
+}
+
+TEST_F(TestSFSRetrySQLite, retry_second_time_success) {
+  auto exception = rgw::sal::sfs::dbapi::sqlite::sqlite_exception(
+      SQLITE_BUSY, "", "non critical error"
+  );
+  bool first = true;
+  RetrySQLiteBusy<int> uut([&]() {
+    if (first) {
+      first = false;
+      throw exception;
+    } else {
+      return 23;
+    }
+  });
+  EXPECT_EQ(uut.run(), 23);
+  EXPECT_TRUE(uut.successful());
+  EXPECT_NE(uut.failed_error(), exception.get_code());
   EXPECT_EQ(uut.retries(), 1);
 }


### PR DESCRIPTION
Support sqlite_modern_cpp custom exceptions as well as sqlite_orm
system error exceptions. Mark legacy code paths with TODOs for later
removal.

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>

Issue: https://github.com/aquarist-labs/s3gw/issues/788

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
