### PR TITLE
rgw/sfs: upgrade existing db for bucket mtime col (backport to v0.23)

### DIFF
--- a/src/rgw/driver/sfs/sqlite/dbconn.h
+++ b/src/rgw/driver/sfs/sqlite/dbconn.h
@@ -37,7 +37,7 @@
 namespace rgw::sal::sfs::sqlite {
 
 /// current db version.
-constexpr int SFS_METADATA_VERSION = 4;
+constexpr int SFS_METADATA_VERSION = 5;
 /// minimum required version to upgrade db.
 constexpr int SFS_METADATA_MIN_VERSION = 4;
 
@@ -139,7 +139,9 @@ inline auto _make_storage(const std::string& path) {
           sqlite_orm::make_column("deleted", &DBBucket::deleted),
           sqlite_orm::make_column("bucket_attrs", &DBBucket::bucket_attrs),
           sqlite_orm::make_column("object_lock", &DBBucket::object_lock),
-          sqlite_orm::make_column("mtime", &DBBucket::mtime),
+          sqlite_orm::make_column(
+              "mtime", &DBBucket::mtime, sqlite_orm::default_value(0)
+          ),
           sqlite_orm::foreign_key(&DBBucket::owner_id)
               .references(&DBUser::user_id)
       ),


### PR DESCRIPTION
Fixes: aquarist-labs/s3gw#811


(cherry picked from commit 003e2a8758b413519be8eed737ae46a2d017aa0f)

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>