### PR TITLE
Fix default retention mode with multipart uploaded objects

### DIFF
--- a/src/rgw/driver/sfs/writer.cc
+++ b/src/rgw/driver/sfs/writer.cc
@@ -328,13 +328,11 @@ int SFSAtomicWriter::complete(
       bucketref->get_info().obj_lock.has_rule()) {
     auto iter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
     if (iter == attrs.end()) {
-      real_time lock_until_date =
+      ceph::real_time lock_until_date =
           bucketref->get_info().obj_lock.get_lock_until_date(now);
-      string mode = bucketref->get_info().obj_lock.get_mode();
+      std::string mode = bucketref->get_info().obj_lock.get_mode();
       RGWObjectRetention obj_retention(mode, lock_until_date);
-      bufferlist bl;
-      obj_retention.encode(bl);
-      attrs[RGW_ATTR_OBJECT_RETENTION] = bl;
+      encode(obj_retention, attrs[RGW_ATTR_OBJECT_RETENTION]);
     }
   }
 


### PR DESCRIPTION
When an object is uploaded with multipart, for object-lock enabled buckets,
the default rentention mode must be set in the object's attributes
(when a retention mode is not explicitely set by the user for the object).
Therefore, `RGW_ATTR_OBJECT_RETENTION` must be set in the attrs of each part
being uploaded in the `SFSMultipartUploadV2::complete()` function.
    
Fixes: https://github.com/aquarist-labs/s3gw/issues/761

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

