### PR TITLE
cmake: workaround _num_cores being 0 under qemu emulation

### DIFF
--- a/cmake/modules/LimitJobs.cmake
+++ b/cmake/modules/LimitJobs.cmake
@@ -2,6 +2,11 @@ set(MAX_COMPILE_MEM 3500 CACHE INTERNAL "maximum memory used by each compiling j
 set(MAX_LINK_MEM 4500 CACHE INTERNAL "maximum memory used by each linking job (in MiB)")
 
 cmake_host_system_information(RESULT _num_cores QUERY NUMBER_OF_LOGICAL_CORES)
+# This will never be zero on a real system, but it can be if you're doing
+# weird things like trying to cross-compile using qemu emulation.
+if(_num_cores EQUAL 0)
+  set(_num_cores 1)
+endif()
 cmake_host_system_information(RESULT _total_mem QUERY TOTAL_PHYSICAL_MEMORY)
 
 math(EXPR _avg_compile_jobs "${_total_mem} / ${MAX_COMPILE_MEM}")


### PR DESCRIPTION
If you're doing something weird like trying to cross compile bits of ceph using qemu emulation, cmake can think there are zero CPU cores.  This is because cmake counts "processor" lines in /proc/cpuinfo, which don't exist when running under qemu-aarch64:
```
  # cat /proc/cpuinfo
  Processor       : ARMv7 Processor rev 5 (v7l)
  BogoMIPS        : 799.53
  Features        : swp half thumb fastmult vfp edsp thumbee neon vfpv3
  CPU implementer : 0x41
  CPU architecture: 7
  CPU variant     : 0x2
  CPU part        : 0xc08
  CPU revision    : 5

  Hardware        : Genesi Efika MX (Smarttop)
  Revision        : 51030
  Serial          : 0000000000000000
```
This in turn causes heavy_compile_job_pool to not be set, which later makes the build fail, as that pool is referenced in src/tools/ceph-dencoder/CMakeLists.txt.  We can work around the problem by setting _num_cores to 1 in this case.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

