### PR TITLE
rgw/sfs: fail gracefully if objref not created

### DIFF
--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include <filesystem>
 #include <fstream>
 
 #include "rgw/driver/sfs/fmt.h"
@@ -441,12 +442,14 @@ int SFSMultipartUploadV2::complete(
                bucketref->get_bucket_id(), mp->object_name, e.what()
            )
         << dendl;
+    std::filesystem::remove(objpath, ec);
     return -ERR_INTERNAL_ERROR;
   }
   if (!objref) {
     // We were unable to create a version, but this might very well have been
     // because we conflicted with another in-flight transaction. Lets return
     // back to the user, and they can complete it again if they so desire.
+    std::filesystem::remove(objpath, ec);
     return -ERR_INTERNAL_ERROR;
   }
   auto destpath = store->get_data_path() / objref->get_storage_path();
@@ -462,6 +465,7 @@ int SFSMultipartUploadV2::complete(
                destpath, ec.message()
            )
         << dendl;
+    std::filesystem::remove(objpath, ec);
     return -ERR_INTERNAL_ERROR;
   }
 
@@ -473,6 +477,7 @@ int SFSMultipartUploadV2::complete(
                          objpath, destpath, cpp_strerror(errno)
                      )
                   << dendl;
+    std::filesystem::remove(objpath, ec);
     return -ERR_INTERNAL_ERROR;
   }
 

--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -510,12 +510,19 @@ int SFSMultipartUploadV2::complete(
        .delete_at = ceph::real_time()}
   );
   try {
-    objref->metadata_finish(store, bucketref->get_info().versioning_enabled());
+    res = objref->metadata_finish(
+        store, bucketref->get_info().versioning_enabled()
+    );
   } catch (const std::system_error& e) {
     lsfs_err(dpp) << fmt::format(
                          "failed to update db object {}: {}", objref->name,
                          e.what()
                      )
+                  << dendl;
+    return -ERR_INTERNAL_ERROR;
+  }
+  if (!res) {
+    lsfs_err(dpp) << fmt::format("failed to update db object {}", objref->name)
                   << dendl;
     return -ERR_INTERNAL_ERROR;
   }

--- a/src/rgw/driver/sfs/multipart.cc
+++ b/src/rgw/driver/sfs/multipart.cc
@@ -443,6 +443,12 @@ int SFSMultipartUploadV2::complete(
         << dendl;
     return -ERR_INTERNAL_ERROR;
   }
+  if (!objref) {
+    // We were unable to create a version, but this might very well have been
+    // because we conflicted with another in-flight transaction. Lets return
+    // back to the user, and they can complete it again if they so desire.
+    return -ERR_INTERNAL_ERROR;
+  }
   auto destpath = store->get_data_path() / objref->get_storage_path();
   lsfs_debug(dpp
   ) << fmt::format("moving final object from {} to {}", objpath, destpath)


### PR DESCRIPTION
It may happen if we conflict in-flight with another thread. Ensure we
just fail gracefully to the client.

Additionally, remove dangling final multipart build files.

Fixes: aquarist-labs/s3gw#820

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>
