### PR TITLE
cmake: use `nproc` if _num_cores is zero

### DIFF
--- a/cmake/modules/LimitJobs.cmake
+++ b/cmake/modules/LimitJobs.cmake
@@ -5,7 +5,11 @@ cmake_host_system_information(RESULT _num_cores QUERY NUMBER_OF_LOGICAL_CORES)
 # This will never be zero on a real system, but it can be if you're doing
 # weird things like trying to cross-compile using qemu emulation.
 if(_num_cores EQUAL 0)
-  set(_num_cores 1)
+  execute_process(
+    COMMAND "nproc"
+    OUTPUT_VARIABLE _num_cores
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  message(WARNING "Unable to query NUMBER_OF_LOGICAL_CORES, defaulting to nproc (${_num_cores})")
 endif()
 cmake_host_system_information(RESULT _total_mem QUERY TOTAL_PHYSICAL_MEMORY)
 


### PR DESCRIPTION
The previous workaround set _num_cores to 1 if cmake thought NUMBER_OF_LOGICAL_CORES was zero.  That worked fine, but it'd be much better to take advantage of all possible cores.  This version runs `nproc` which seems to work just fine under qemu-aarch64 and gives us the actual number of CPUs.

Fixes: b6669263cacd56ff589529784066b9f637f79e87





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

