### PR TITLE
rgw/sfs: don't care about location constraints

### DIFF
--- a/src/rgw/driver/sfs/zone.cc
+++ b/src/rgw/driver/sfs/zone.cc
@@ -42,7 +42,7 @@ bool SFSZone::get_redirect_endpoint(std::string* /*endpoint*/) {
 }
 
 bool SFSZone::has_zonegroup_api(const std::string& /*api*/) const {
-  return false;
+  return true;
 }
 
 const std::string& SFSZone::get_current_period_id() {

--- a/src/rgw/driver/sfs/zone.h
+++ b/src/rgw/driver/sfs/zone.h
@@ -43,7 +43,8 @@ class SFSZoneGroup : public StoreZoneGroup {
     return !!group->placement_targets.count(target);
   }
   virtual bool is_master_zonegroup() const override {
-    return group->is_master_zonegroup();
+    // we are a master zonegroup, because we are just the one running.
+    return true;
   }
   virtual const std::string& get_api_name() const override {
     return group->api_name;


### PR DESCRIPTION
We don't deal with zones, all zones are welcome zones. So, when someone wants to store something on a given location, welcome them by allowing all zones.

Fixes: aquarist-labs/s3gw#848

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>